### PR TITLE
Fix CLI tgz bundle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
 
     - name: Update Dependencies
       id: npm-update
-      uses: zowe-actions/octorelease/script@reg-config
+      uses: zowe-actions/octorelease/script@v1
       with:
         config-dir: .github
         script: npmUpdate
@@ -79,6 +79,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         env_vars: OS,NODE
+        token: ${{ secrets.CODECOV_TOKEN }}
 
     # - name: Bundle all packages
     #   if: matrix.os == 'ubuntu-latest' && matrix.node-version == '18.x'
@@ -113,7 +114,7 @@ jobs:
       run: npm ci
 
     - name: Update Dependencies
-      uses: zowe-actions/octorelease/script@reg-config
+      uses: zowe-actions/octorelease/script@v1
       env:
         GIT_COMMITTER_NAME: zowe_robot
         GIT_COMMITTER_EMAIL: zowe.robot@gmail.com
@@ -125,7 +126,7 @@ jobs:
     - name: Build Source
       run: npm run build
 
-    - uses: zowe-actions/octorelease@reg-config
+    - uses: zowe-actions/octorelease@v1
       env:
         GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
         GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@zowe/cics_monorepo",
     "private": true,
-    "version": "4.0.8",
+    "version": "4.0.9",
     "publishConfig": {
         "registry": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/"
     },

--- a/scripts/bundleTgz.js
+++ b/scripts/bundleTgz.js
@@ -50,8 +50,12 @@ fsE.copyFileSync(pkgJsonFile, pkgJsonFile + ".bak");
 try {
     // Install node_modules directly inside packages/cli
     execCmd("npm run preshrinkwrap");
-    const sdkTgzPath = path.relative(__dirname, "../dist/zowe-cics-for-zowe-sdk-" + tempPkgJson.version + ".tgz");
-    execCmd(`${npmInstallCmd} ${sdkTgzPath}`);
+    try {
+        execCmd(`npm view @zowe/cics-for-zowe-sdk`);
+    } catch (err) {
+        const sdkTgzPath = path.relative(__dirname, "../dist/zowe-cics-for-zowe-sdk-" + tempPkgJson.version + ".tgz");
+        execCmd(`${npmInstallCmd} ${sdkTgzPath}`);
+    }
     execCmd(npmInstallCmd);
     for (const zowePkgDir of fsE.readdirSync(path.join(cliPkgDir, "node_modules", "@zowe"))) {
         const srcDir = path.join("node_modules", "@zowe", zowePkgDir);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Fix offline bundling of the CLI `.tgz` file

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
Run `npm run package` and check the `cics-cli.tgz#package.json#dependencies` and the sdk should have a dependency number instead of a `file:../dist/path.tgz`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
Related to:
- https://github.com/zowe/zowe-cli-standalone-package/pull/252