### PR TITLE
update workflow for V2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Build Source
       run: npm run build
 
-    - uses: zowe-actions/octorelease@v1
+    - uses: zowe-actions/octorelease@temp-lerna-fix
       env:
         GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
         GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}


### PR DESCRIPTION
This one will publish the SDK, and may fail to publish the CLI

Then we should be able to rerun the workflow  (with current) to publish the CLI)