### PR TITLE
Log during activation instead of showing popup

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 ## `2.3.6`
 
 - BugFix: Fixed several identified problems with possible null values in the tree and web views. [#121](https://github.com/zowe/cics-for-zowe-client/issues/121)
+- Moved the popup from activation `Zowe Explorer was modified for the CICS Extension.` to the logger instead.
 
 ## `2.3.5`
 

--- a/packages/vsce/src/extension.ts
+++ b/packages/vsce/src/extension.ts
@@ -77,6 +77,7 @@ import { getZoweExplorerVersion } from "./utils/workspaceUtils";
 import { getInquireTransactionCommand } from "./commands/inquireTransaction";
 import { getPurgeTaskCommand } from "./commands/purgeTaskCommand";
 import { getInquireProgramCommand } from "./commands/inquireProgram";
+import { Logger } from "@zowe/imperative";
 
 /**
  * Initialises extension
@@ -85,6 +86,7 @@ import { getInquireProgramCommand } from "./commands/inquireProgram";
  */
 export async function activate(context: ExtensionContext) {
   const zeVersion = getZoweExplorerVersion();
+  const logger = Logger.getAppLogger();
   let treeDataProv: CICSTree = null;
   if (!zeVersion) {
     window.showErrorMessage("Zowe Explorer was not found: Please ensure Zowe Explorer v2.0.0 or higher is installed");
@@ -105,10 +107,10 @@ export async function activate(context: ExtensionContext) {
           await treeDataProv.refreshLoadedProfiles();
         });
       }
-      window.showInformationMessage("Zowe Explorer was modified for the CICS Extension.");
+      logger.debug("Zowe Explorer was modified for the CICS Extension.");
     } catch (error) {
       console.log(error);
-      window.showErrorMessage("Zowe Explorer for IBM CICS was not initiliaized correctly");
+      logger.error("Zowe Explorer for IBM CICS was not initiliaized correctly");
       return;
     }
   } else {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Displays the old `Zowe Explorer was modified for the CICS Extension.` in the log instead of in a popup.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

Package and install extension, and when opening ZE should not show popup anymore.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
