### PR TITLE
Update npmrc to have correct Zowe registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 registry=https://registry.npmjs.org/
-@zowe:registry=https://zowe.jfrog.io/zowe/api/npm/npm-local-release/
+@zowe:registry=https://zowe.jfrog.io/zowe/api/npm/npm-release/


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Updates the npmrc file to use the `npm-release` registry on V1, which should fix publishing and have V1 use the same registry as V2 and V3

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
