### PR TITLE
chore: update release config to get cli/sdk with a non prerelease

### DIFF
--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -12,9 +12,8 @@ module.exports = {
         },
         {
             name: "main",
-            channel: "next",
+            channel: "zowe-v3-lts",
             level: "none",
-            prerelease: true,
             devDependencies: {
                 "@zowe/imperative": "zowe-v3-lts",
                 "@zowe/zowe-explorer-api": ["next", "@zowe:registry=https://registry.npmjs.org/"],
@@ -49,8 +48,7 @@ module.exports = {
             {
                 $cwd: "packages/sdk",
                 aliasTags: {
-                    "latest": ["zowe-v2-lts"],
-                    "next": ["zowe-v3-lts"],
+                    "latest": ["zowe-v2-lts"]
                 },
                 npmPublish: true,
                 tarballDir: "dist",
@@ -58,8 +56,7 @@ module.exports = {
             {
                 $cwd: "packages/cli",
                 aliasTags: {
-                    "latest": ["zowe-v2-lts"],
-                    "next": ["zowe-v3-lts"],
+                    "latest": ["zowe-v2-lts"]
                 },
                 npmPublish: true,
                 tarballDir: "dist",
@@ -69,8 +66,8 @@ module.exports = {
             "@octorelease/vsce",
             {
                 $cwd: "packages/vsce",
-                ovsxPublish: true,
-                vscePublish: true,
+                ovsxPublish: false,
+                vscePublish: false,
                 vsixDir: "dist",
             },
         ],
@@ -79,6 +76,7 @@ module.exports = {
             {
                 assets: ["dist/*.tgz", "dist/*.vsix"],
                 checkPrLabels: true,
+                publishRelease: true
             },
         ],
         "@octorelease/git",

--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -74,7 +74,7 @@ module.exports = {
         [
             "@octorelease/github",
             {
-                assets: ["dist/*.tgz", "dist/*.vsix"],
+                assets: ["dist/*.tgz"],//, "dist/*.vsix"],
                 checkPrLabels: true,
                 publishRelease: true
             },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented 
 
 ## Recent Changes
 
-- MAJOR: v3.0.0 release
+- MAJOR: v6.0.0 release
 
 ## `6.0.0-next.202409201904`
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v3.0.0 release
+
 ## `6.0.0-next.202409201904`
 
 - Update: Final prerelease

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented 
 
 ## Recent Changes
 
-- MAJOR: v3.0.0 release
+- MAJOR: v6.0.0 release
 
 ## `6.0.0-next.202409201904`
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v3.0.0 release
+
 ## `6.0.0-next.202409201904`
 
 - Update: Final prerelease

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
+## Recent Changes
+
+- MAJOR: v3.0.0 release
+
 ## `3.0.0-next.202409201904`
 
 - Update: Final prerelease


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

Only release plugin CLI and SDK as 6.0.0 to public zowe.jfrog