### PR TITLE
chore: update workflows in preparation for Zowe v3 GA

### DIFF
--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -1,22 +1,19 @@
 module.exports = {
     branches: [
         {
-            // This will be moved down once Zowe V3 is announced
-            // Remember to also update aliasTags below
+            name: "main",
+            level: "minor",
+            devDependencies: {
+                "@zowe/imperative": "zowe-v3-lts",
+                "@zowe/zowe-explorer-api": ["next", "@zowe:registry=https://registry.npmjs.org/"],
+            }
+        },
+        {
             name: "zowe-v2-lts",
             level: "patch",
             devDependencies: {
                 "@zowe/imperative": "zowe-v2-lts",
                 "@zowe/zowe-explorer-api": ["zowe-v2-lts", "@zowe:registry=https://registry.npmjs.org/"],
-            }
-        },
-        {
-            name: "main",
-            channel: "zowe-v3-lts",
-            level: "none",
-            devDependencies: {
-                "@zowe/imperative": "zowe-v3-lts",
-                "@zowe/zowe-explorer-api": ["next", "@zowe:registry=https://registry.npmjs.org/"],
             }
         }
     ],
@@ -48,7 +45,7 @@ module.exports = {
             {
                 $cwd: "packages/sdk",
                 aliasTags: {
-                    "latest": ["zowe-v2-lts"]
+                    "latest": ["zowe-v3-lts"]
                 },
                 npmPublish: true,
                 tarballDir: "dist",
@@ -56,7 +53,7 @@ module.exports = {
             {
                 $cwd: "packages/cli",
                 aliasTags: {
-                    "latest": ["zowe-v2-lts"]
+                    "latest": ["zowe-v3-lts"]
                 },
                 npmPublish: true,
                 tarballDir: "dist",
@@ -66,15 +63,15 @@ module.exports = {
             "@octorelease/vsce",
             {
                 $cwd: "packages/vsce",
-                ovsxPublish: false,
-                vscePublish: false,
+                ovsxPublish: true,
+                vscePublish: true,
                 vsixDir: "dist",
             },
         ],
         [
             "@octorelease/github",
             {
-                assets: ["dist/*.tgz"],//, "dist/*.vsix"],
+                assets: ["dist/*.tgz", "dist/*.vsix"],
                 checkPrLabels: true,
                 publishRelease: true
             },

--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -5,7 +5,7 @@ module.exports = {
             level: "minor",
             devDependencies: {
                 "@zowe/imperative": "zowe-v3-lts",
-                "@zowe/zowe-explorer-api": ["next", "@zowe:registry=https://registry.npmjs.org/"],
+                "@zowe/zowe-explorer-api": ["zowe-v3-lts", "@zowe:registry=https://registry.npmjs.org/"],
             }
         },
         {


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

This PR will update the latest tag to match the same version as `zowe-v3-lts` going forward.

This PR should be merged only after the Zowe v3.0 announcement 😋 

**Note:** This PR shall be merged with the `release-current` label.

Also, this is dependent on the `@zowe/zowe-explorer-api@zowe-v3-lts`
