### PR TITLE
Fully specify urls for repo files in VSCE README

### DIFF
--- a/packages/vsce/README.md
+++ b/packages/vsce/README.md
@@ -42,7 +42,7 @@ Ensure that you meet the following prerequisites before you use the extension:
 
 - Install Zowe Explorer v2
 
-**Tip**: See [Troubleshooting guide](./docs/Troubleshooting.md) for solutions to common problems.
+**Tip**: See [Troubleshooting guide](/packages/vsce/docs/Troubleshooting.md) for solutions to common problems.
 
 ## Features
 
@@ -57,7 +57,7 @@ Ensure that you meet the following prerequisites before you use the extension:
 - Apply multiple filters to regions, programs, local transactions local files and/or tasks.
 - View and interact with all resources under a plex.
 
-To Install CICS Extension for Zowe Explorer see [Installation](./docs/installation-guide.md).
+To Install CICS Extension for Zowe Explorer see [Installation](/packages/vsce/docs/installation-guide.md).
 
 ## Getting Started
 
@@ -80,7 +80,7 @@ If you don't have an existing Zowe CICS CLI profile, follow these steps to creat
 5. Select the **+** button in the CICS tree and click the newly created profile to load it into view.
 
 <p align="center">
-<img src="./docs/images/create-config-profile.gif" alt="Zowe CICS Explorer config profiles" width="700px"/>
+<img src="/packages/vsce/docs/images/create-config-profile.gif" alt="Zowe CICS Explorer config profiles" width="700px"/>
 </p>
 
 Here's an example of a CICS profile entry in the config file:
@@ -116,7 +116,7 @@ Here's an example of a CICS profile entry in the config file:
 Configuring a CICS region to have a connection is a system programmer task and more details can be found in [Setting up CMCI with CICSPlex SM](https://www.ibm.com/docs/en/cics-ts/5.3?topic=explorer-setting-up-cmci-cicsplex-sm) or [Setting up CMCI in a stand-alone CICS region](https://www.ibm.com/docs/en/cics-ts/5.3?topic=suace-setting-up-cmci-in-stand-alone-cics-region). If your CMCI connection is configured to use a self-signed certificate that your PC's trust store doesn't recognize, see [Untrusted TLS certificates](#untrusted-tls-certificates).
 
 <p align="center">
-<img src="./docs/images/create-profile.gif" alt="Zowe CICS Explorer profiles" width="700px"/>
+<img src="/packages/vsce/docs/images/create-profile.gif" alt="Zowe CICS Explorer profiles" width="700px"/>
 </p>
 
 To show more than one CICS profiles in the tree, select the **+** button and choose from the list of profiles. Only profiles that not already included in the CICS tree will be shown.
@@ -149,7 +149,7 @@ To show more than one CICS profile in the tree, select the + button and choose f
 4. Refresh the IBM CICS for Zowe Explorer extension by either clicking the button at the top level of the CICS view, or the `IBM CICS for Zowe Explorer: Refresh` command palette option.
 
 <p align="center">
-<img src="./docs/images/update-config-profile.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
+<img src="/packages/vsce/docs/images/update-config-profile.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
 </p>
 
 #### Using Zowe v1 profiles
@@ -163,7 +163,7 @@ To show more than one CICS profile in the tree, select the + button and choose f
 3. Once the details are updated, click the **Update Profile** button to apply the changes to the profile.
 
 <p align="center">
-<img src="./docs/images/update-profile.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
+<img src="/packages/vsce/docs/images/update-profile.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
 </p>
 
 ### Hiding Profiles
@@ -171,7 +171,7 @@ To show more than one CICS profile in the tree, select the + button and choose f
 Open the menu actions for a profile by right-clicking a profile and select `Hide Profile` to hide it from the CICS view. To add the profile back, click the + button and select the profile from the quick pick list.
 
 <p align="center">
-<img src="./docs/images/hide-profile.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
+<img src="/packages/vsce/docs/images/hide-profile.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
 </p>
 
 ### Deleting Profiles
@@ -187,7 +187,7 @@ Open the menu actions for a profile by right-clicking a profile and select `Hide
 4. Refresh the IBM CICS for Zowe Explorer extension by either clicking the button at the top level of the CICS view, or the `IBM CICS for Zowe Explorer: Refresh` command palette option.
 
 <p align="center">
-<img src="./docs/images/delete-config-profile.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
+<img src="/packages/vsce/docs/images/delete-config-profile.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
 </p>
 
 #### Using Zowe v1 profiles
@@ -197,7 +197,7 @@ Open the menu actions for a profile by right-clicking a profile and select `Hide
 2. Select **Delete Profile** and click the **Yes** button when prompted to confirm the action of permanently deleting the profile. The functionality deletes the CICS profile from the persistent storage directory `~/.zowe/profiles/cics`.
 
 <p align="center">
-<img src="./docs/images/delete-profile.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
+<img src="/packages/vsce/docs/images/delete-profile.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
 </p>
 
 ## CICS Resources
@@ -208,24 +208,24 @@ Expand a CICS profile to see the region name, and expand the region to view its 
 
 Expand a CICS region to show folders for the resource types `Programs`, `Transactions`, `Local Files` and `Tasks`. Expand each type to show the resources. The number of resources in a resource tree will appear in square brackets next to the tree name.
 
-The list of resources are pre-filtered to exclude many of the IBM supplied ones to narrow the contents to just include user programs. Use the search icon <img src="./docs/images/resource-filter.png" width="16px"/> against a resource type to apply a filter. This can be an exact resource name or else you can use wildcards. The search history is saved so you can recall previous searches.
+The list of resources are pre-filtered to exclude many of the IBM supplied ones to narrow the contents to just include user programs. Use the search icon <img src="/packages/vsce/docs/images/resource-filter.png" width="16px"/> against a resource type to apply a filter. This can be an exact resource name or else you can use wildcards. The search history is saved so you can recall previous searches.
 
-To reset the filter to its initial criteria use the clear filter icon <img src="./docs/images/resource-filter-clear.png" width="16px"/> against the resource type. If you wish to see all resources in a region (including IBM supplied ones) you can use "\*" as a filter.
+To reset the filter to its initial criteria use the clear filter icon <img src="/packages/vsce/docs/images/resource-filter-clear.png" width="16px"/> against the resource type. If you wish to see all resources in a region (including IBM supplied ones) you can use "\*" as a filter.
 
 <p align="center">
-<img src="./docs/images/region-filter.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
+<img src="/packages/vsce/docs/images/region-filter.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
 </p>
 
 **Tip:** To apply multiple filters, separate entries with a comma. You can append any filter with an \*, which indicates wildcard searching.
 
 ### Show and Filter Resources in a Plex
 
-Similar to filtering resources in a region, it is also possible to apply a filter on a all region resources in a plex. Use the search icon <img src="./docs/images/resource-filter.png" width="16px"/> inline with the `Regions` tree and then select either `Regions`, `Programs`, `Local Transactions` or `Local Files` from the drop-down menu to specify which resource type the filter should be applied to for all regions in the plex.
+Similar to filtering resources in a region, it is also possible to apply a filter on a all region resources in a plex. Use the search icon <img src="/packages/vsce/docs/images/resource-filter.png" width="16px"/> inline with the `Regions` tree and then select either `Regions`, `Programs`, `Local Transactions` or `Local Files` from the drop-down menu to specify which resource type the filter should be applied to for all regions in the plex.
 
-To reset the filter to its initial criteria use the clear filter icon <img src="./docs/images/resource-filter-clear.png" width="16px"/> against the `Regions` tree. This will open a drop-down menu which gives the option to clear the filter for all the `Regions`, `Programs`, `Local Transactions` or `Local Files` in the plex, and an option to otherwise clear `All` filters within the plex.
+To reset the filter to its initial criteria use the clear filter icon <img src="/packages/vsce/docs/images/resource-filter-clear.png" width="16px"/> against the `Regions` tree. This will open a drop-down menu which gives the option to clear the filter for all the `Regions`, `Programs`, `Local Transactions` or `Local Files` in the plex, and an option to otherwise clear `All` filters within the plex.
 
 <p align="center">
-<img src="./docs/images/plex-filter.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
+<img src="/packages/vsce/docs/images/plex-filter.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
 </p>
 
 **Tip:** To apply multiple filters, separate entries with a comma. You can append any filter with an \*, which indicates wildcard searching.
@@ -234,10 +234,10 @@ To reset the filter to its initial criteria use the clear filter icon <img src="
 
 Plexes contain an `All Programs`, `All Local Transactions`, `All Local Files` and `All Tasks` trees which contain all the corresponding resources from all regions in the plex.
 
-To view resources under these trees, use the search icon <img src="./docs/images/resource-filter.png" width="16px"/> inline with the tree and apply a filter.
+To view resources under these trees, use the search icon <img src="/packages/vsce/docs/images/resource-filter.png" width="16px"/> inline with the tree and apply a filter.
 
 <p align="center">
-<img src="./docs/images/all-resources.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
+<img src="/packages/vsce/docs/images/all-resources.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
 </p>
 
 If the applied filter results in over 500 records, either change the filter to narrow down the search, or click the `view X more ...` item to retrieve 'X' more resources.
@@ -245,7 +245,7 @@ If the applied filter results in over 500 records, either change the filter to n
 **Tip:** The default 500 count can be modified via the `Record Count Increment` property in Settings (UI).
 
 <p align="center">
-<img src="./docs/images/record-count-increment.png" alt="Zowe CICS Explorer Record Count Increment in Setting UI" width="700px"/>
+<img src="/packages/vsce/docs/images/record-count-increment.png" alt="Zowe CICS Explorer Record Count Increment in Setting UI" width="700px"/>
 </p>
 
 ### Show Attributes
@@ -253,7 +253,7 @@ If the applied filter results in over 500 records, either change the filter to n
 Right-click and use the pop-up menu against a program to list the available actions that can be performed. For every resource, including a CICS region, `Show Attributes` opens a viewer listing all attributes and their values. The attributes page has a filter box at the top that lets you search for attributes matching the criteria.
 
 <p align="center">
-<img src="./docs/images/show-attributes.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
+<img src="/packages/vsce/docs/images/show-attributes.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
 </p>
 
 ### Enable and Disable
@@ -261,17 +261,17 @@ Right-click and use the pop-up menu against a program to list the available acti
 Right-click against a program, local transaction or local file to open up the pop-up menu and click `Disable [CICS resource]` to disable the resource. When a resource is already disabled the first option becomes `Enable [CICS resource]` to allow its enablement state to be toggled. A disabled resource is identified by a `(Disabled)` text next to its name.
 
 <p align="center">
-<img src="./docs/images/disable-enable.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
+<img src="/packages/vsce/docs/images/disable-enable.gif" alt="Zowe CICS Explorer Filter" width="700px"/>
 </p>
 
 ### New Copy and Phase In
 
-Use `New Copy` <img src="./docs/images/program-newcopy-action.png" width="16px"/> and `Phase In` <img src="./docs/images/program-phasein-action.png" width="16px"/> actions against a CICS program to get the CICS region to load a fresh of the selected program into memory. This could be after you've edited a COBOL program source and successfully compiled it into a load library and now want to test your change.
+Use `New Copy` <img src="/packages/vsce/docs/images/program-newcopy-action.png" width="16px"/> and `Phase In` <img src="/packages/vsce/docs/images/program-phasein-action.png" width="16px"/> actions against a CICS program to get the CICS region to load a fresh of the selected program into memory. This could be after you've edited a COBOL program source and successfully compiled it into a load library and now want to test your change.
 
 The `newcopycnt` for a program which is greater than zero is shown next to the program item in the CICS resource tree.
 
 <p align="center">
-<img src="./docs/images/new-copy.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
+<img src="/packages/vsce/docs/images/new-copy.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
 </p>
 
 ### Open and Close Local Files
@@ -281,7 +281,7 @@ Right-click against a closed local file and perform the `Open Local File` menu a
 To close a local file, right-click against an open local file and perform the `Close Local File` menu action. This will bring up a prompt on the bottom right corner requesting to choose one of `Wait`, `No Wait` or `Force` for the file busy condition. Once an option has been selected, the local file name will be appended with a `(Closed)` label upon success.
 
 <p align="center">
-<img src="./docs/images/open-close.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
+<img src="/packages/vsce/docs/images/open-close.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
 </p>
 
 ### Purge Task
@@ -291,7 +291,7 @@ Right-click against a task and click the `Purge Task` command. This will open a 
 Select the appropriate condition to perform the purge.
 
 <p align="center">
-<img src="./docs/images/purge-task.gif" alt="Zowe CICS Explorer Purge Task" width="600px"/>
+<img src="/packages/vsce/docs/images/purge-task.gif" alt="Zowe CICS Explorer Purge Task" width="600px"/>
 </p>
 
 ### Inquire Functionality
@@ -301,7 +301,7 @@ Right-click against a Task and perform the `Inquire Transaction` command. This w
 The same can be done on a Local Transaction to find the associated Program by executing the `Inquire Program` right-click menu action against a Local Transaction.
 
 <p align="center">
-<img src="./docs/images/inquire.gif" alt="Zowe CICS Explorer Inquire functionality" width="600px"/>
+<img src="/packages/vsce/docs/images/inquire.gif" alt="Zowe CICS Explorer Inquire functionality" width="600px"/>
 </p>
 
 ### View Datasets under Libraries
@@ -309,7 +309,7 @@ The same can be done on a Local Transaction to find the associated Program by ex
 Expand libraries of a region to view specific datasets belonging to a library. Right-click on libraries to `Show Attributes` to view library attributes. Similarly, right-click on datasets to `Show Attributes` to view dataset attributes.
 
 <p align="center">
-<img src="./docs/images/datasets.gif" alt="Zowe CICS Explorer View Datasets functionality" width="600px"/>
+<img src="/packages/vsce/docs/images/datasets.gif" alt="Zowe CICS Explorer View Datasets functionality" width="600px"/>
 </p>
 
 ### View four CICS Web Resources under the Web Folder
@@ -317,7 +317,7 @@ Expand libraries of a region to view specific datasets belonging to a library. R
 Expand the Web folder to view TCPIP Services, URI Maps, Pipelines and Web Services. Each of these resources can be expanded and allows for right-click functionality on the specific resource to execute the `Show Attributes` command. Use the search icon to filter down specific resources by applying a filter.
 
 <p align="center">
-<img src="./docs/images/webResources.gif" alt="Zowe CICS Explorer Web resources under the Web folder" width="600px"/>
+<img src="/packages/vsce/docs/images/webResources.gif" alt="Zowe CICS Explorer Web resources under the Web folder" width="600px"/>
 </p>
 
 ## Untrusted TLS Certificates
@@ -327,7 +327,7 @@ If the CMCI connection is using a TLS certificate that your PC doesn't have in i
 If you define a profile as only accepting trusted TLS certificates when the Zowe Explorer first connects it will detect the mismatch and allow you to override the setting and proceed. This is done through a pop-up message with a `Yes` button to accept the untrusted certificate authority, which changes the profile's setting.
 
 <p align="center">
-<img src="./docs/images/untrusted-cert.gif" alt="Zowe CICS Explorer accepted untrusted certificate" width="600px"/>
+<img src="/packages/vsce/docs/images/untrusted-cert.gif" alt="Zowe CICS Explorer accepted untrusted certificate" width="600px"/>
 </p>
 
 ## Usage tips
@@ -336,7 +336,7 @@ If you define a profile as only accepting trusted TLS certificates when the Zowe
 
   - To multi-select, either hold `Ctrl`/`Cmd` key while clicking resources, or select the first item in a list of nodes then hold `Shift` and click both the last item to select a consecutive list of nodes.
 
-- Click the refresh icon <img src="./docs/images/refresh-icon.png" width="16px"/> at the top of the CICS view to reload the resources in every region.
+- Click the refresh icon <img src="/packages/vsce/docs/images/refresh-icon.png" width="16px"/> at the top of the CICS view to reload the resources in every region.
 
 ## Providing feedback or help contributing
 
@@ -345,13 +345,13 @@ If you define a profile as only accepting trusted TLS certificates when the Zowe
 Before filing an issue, check if an error is arising from the IBM CICS for Zowe Explorer extension and not the Zowe Explorer extension by expanding the error message and checking if the `Source` is `IBM CICS for Zowe Explorer (Extension)`.
 
 <p align="center">
-<img src="./docs/images/expand-error-cics.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
+<img src="/packages/vsce/docs/images/expand-error-cics.gif" alt="Zowe CICS Explorer NewCopy Program" width="600px"/>
 </p>
 
 Error messages arising from the Zowe Explorer extension will have the `Source` as `Zowe Explorer(Extension)`.
 
 ### Filing an issue
 
-Before filing an issue, check the [Troubleshooting guide](./docs/Troubleshooting.md) first to ensure that the issue hasn't already been addressed.
+Before filing an issue, check the [Troubleshooting guide](/packages/vsce/docs/Troubleshooting.md) first to ensure that the issue hasn't already been addressed.
 
 To file issues, use the [IBM CICS for Zowe Explorer issue list](https://github.com/zowe/vscode-extension-for-cics/issues), or chat with use on [Slack](https://openmainframeproject.slack.com/archives/CUVE37Z5F) by indicating the message is for the IBM CICS for Zowe Explorer extension.


### PR DESCRIPTION
**What It Does**
Addresses https://github.com/zowe/cics-for-zowe-client/issues/155

URLs to resources from this repository have been updated to include the full file path.

**How to Test**
Build and package the extension, and confirm that the URLs to screenshots and other resources work properly.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
