### PR TITLE
Correcting condition to read team configuration file.

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 - Renamed the VSCE to `IBM CICS for Zowe Explorer`. [#129](https://github.com/zowe/cics-for-zowe-client/issues/129)
 - Update: See `2.3.6` for details.
 - BugFix: Fixed several identified problems with possible null values in the tree and web views. [#122](https://github.com/zowe/cics-for-zowe-client/issues/122)
+- BugFix: Correcting condition to read team configuration file. [#160](https://github.com/zowe/cics-for-zowe-client/pull/160)
 
 ## `3.0.0-next.202403011419`
 

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 
 - MAJOR: v3.0.0 release
 
+## Recent Changes
+
+- BugFix: Correcting condition to read team configuration file. [#160](https://github.com/zowe/cics-for-zowe-client/pull/160)
+
 ## `3.0.0-next.202409201904`
 
 - Update: Final prerelease
@@ -14,7 +18,6 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 - Renamed the VSCE to `IBM CICS for Zowe Explorer`. [#129](https://github.com/zowe/cics-for-zowe-client/issues/129)
 - Update: See `2.3.6` for details.
 - BugFix: Fixed several identified problems with possible null values in the tree and web views. [#122](https://github.com/zowe/cics-for-zowe-client/issues/122)
-- BugFix: Correcting condition to read team configuration file. [#160](https://github.com/zowe/cics-for-zowe-client/pull/160)
 
 ## `3.0.0-next.202403011419`
 

--- a/packages/vsce/src/trees/CICSTree.ts
+++ b/packages/vsce/src/trees/CICSTree.ts
@@ -86,7 +86,7 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
       const allCICSProfiles = (await ProfileManagement.getProfilesCache().getProfileInfo()).getAllProfiles("cics");
       // const allCICSProfiles = await ProfileManagement.getProfilesCache().getProfiles('cics');
       if (!allCICSProfiles) {
-        if (!configInstance.usingTeamConfig) {
+        if (!configInstance.getTeamConfig().exists) {
           window.showErrorMessage(`Could not find any CICS profiles`);
           return;
         }
@@ -94,7 +94,7 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
       }
       const allCICSProfileNames: string[] = allCICSProfiles ? (allCICSProfiles.map((profile) => profile.profName) as unknown as [string]) : [];
       // No cics profiles needed beforhand for team config method
-      if (configInstance.usingTeamConfig || allCICSProfileNames.length > 0) {
+      if (configInstance.getTeamConfig().exists || allCICSProfileNames.length > 0) {
         const profileNameToLoad = await window.showQuickPick(
           [{ label: "\uFF0B Create New CICS Profile..." }].concat(
             allCICSProfileNames
@@ -118,7 +118,7 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
         if (profileNameToLoad) {
           // If Create New CICS Profile option chosen
           if (profileNameToLoad.label.includes("\uFF0B")) {
-            if (configInstance.usingTeamConfig) {
+            if (configInstance.getTeamConfig().exists) {
               // get all profiles of all types including zosmf
               const profiles = configInstance.getAllProfiles();
               if (!profiles.length) {
@@ -133,7 +133,7 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
           } else {
             let profileToLoad;
             // TODO: Just use loadNamedProfile once the method is configured to v2 profiles
-            if (configInstance.usingTeamConfig) {
+            if (configInstance.getTeamConfig().exists) {
               profileToLoad = await ProfileManagement.getProfilesCache().getLoadedProfConfig(profileNameToLoad.label); //ProfileManagement.getProfilesCache().loadNamedProfile(profileNameToLoad.label, 'cics');
             } else {
               await ProfileManagement.profilesCacheRefresh();
@@ -184,7 +184,7 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
         });
         try {
           const configInstance = await ProfileManagement.getConfigInstance();
-          if (configInstance.usingTeamConfig) {
+          if (configInstance.getTeamConfig().exists) {
             let missingParamters = missingSessionParameters(profile.profile);
             if (missingParamters.length) {
               const userPass = ["user", "password"];
@@ -318,7 +318,7 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
                       if (decision === "Yes") {
                         const configInstance = await ProfileManagement.getConfigInstance();
                         let updatedProfile;
-                        if (configInstance.usingTeamConfig) {
+                        if (configInstance.getTeamConfig().exists) {
                           const upd = { profileName: profile.name, profileType: "cics" };
                           //   const configInstance = await ProfileManagement.getConfigInstance();
                           // flip rejectUnauthorized to false


### PR DESCRIPTION
**What It Does**
It does a correct condition checking on whether or not Team Configuration File exists.

**How to Test**

- click on + icon 
- Click on "Create a New CICS Profile"
- zowe.config.json file opens up

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**

- Currently, these changes only take care of the condition when a Team Configuration file is available globally.
- Still investigating the case when Team Configuration file is missing, 
