### PR TITLE
Updated getResource so that the region name is now optional

### DIFF
--- a/packages/sdk/__tests__/__unit__/add-to-list/AddToList.csdGroup.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/add-to-list/AddToList.csdGroup.unit.test.ts
@@ -166,7 +166,7 @@ describe("CMCI - Add csdGroup to list", () => {
     it("should be able to add a csdGroup to list without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP + "/" + addToListParms.regionName +
-            "?CRITERIA=NAME=='" + addToListParms.name + "'";
+            "?CRITERIA=(NAME%3D%3D'" + addToListParms.name + "')";
 
       response = await addCSDGroupToList(dummySession, addToListParms);
 
@@ -179,7 +179,7 @@ describe("CMCI - Add csdGroup to list", () => {
       addToListParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP + "/" + addToListParms.cicsPlex + "/" + addToListParms.regionName +
-            "?CRITERIA=NAME=='" + addToListParms.name + "'";
+            "?CRITERIA=(NAME%3D%3D'" + addToListParms.name + "')";
 
       response = await addCSDGroupToList(dummySession, addToListParms);
 
@@ -192,7 +192,7 @@ describe("CMCI - Add csdGroup to list", () => {
       addToListParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP + "/" + addToListParms.cicsPlex + "/" + addToListParms.regionName +
-            "?CRITERIA=NAME=='" + addToListParms.name + "'";
+            "?CRITERIA=(NAME%3D%3D'" + addToListParms.name + "')";
 
       response = await addCSDGroupToList(dummySession, addToListParms);
 

--- a/packages/sdk/__tests__/__unit__/common/Common.getResourceUri.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/common/Common.getResourceUri.unit.test.ts
@@ -1,0 +1,178 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { getResourceUri } from "../../../src/methods/common";
+
+describe("getResourceUri", () => {
+
+  let error: any;
+  let response: any;
+  let endPoint: string;
+
+  describe("validation", () => {
+    beforeEach(() => {
+      response = undefined;
+      error = undefined;
+    });
+
+    it("should throw error if resourceName is empty", async () => {
+      try {
+        response = getResourceUri("", "", "");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toEqual("Expect Error: Required parameter 'CICS Resource name' must not be blank");
+    });
+
+    it("should throw error if resourceName is undefined", async () => {
+      try {
+        response = getResourceUri("", "", undefined);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toEqual("Expect Error: CICS resource name is required");
+    });
+
+    it("should throw error if resourceName is null", async () => {
+      try {
+        response = getResourceUri("", "", null);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toEqual("Expect Error: CICS resource name is required");
+    });
+  });
+
+  describe("success scenarios", () => {
+
+    beforeEach(() => {
+      response = undefined;
+      error = undefined;
+    });
+
+    it("should be able to get a resource uri with only the resource name specified", async () => {
+      try {
+        response = getResourceUri("", "", "resource1");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1//");
+    });
+
+    it("should be able to get a resource uri with the cicsplex and resource name specified", async () => {
+      try {
+        response = getResourceUri("cicsplex1", "", "resource1");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/");
+    });
+
+    it("should be able to get a resource uri with the region and resource names specified", async () => {
+      try {
+        response = getResourceUri("", "region1", "resource1");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1//region1");
+    });
+
+    it("should be able to get a resource uri with the plex, region and resource names specified", async () => {
+      try {
+        response = getResourceUri("cicsplex1", "region1", "resource1");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1");
+    });
+
+    it("should be able to get a resource uri with the criteria is unspecified", async () => {
+      try {
+        response = getResourceUri("cicsplex1", "region1", "resource1", "");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1");
+    });
+
+    it("should be able to get a resource uri with the criteria is specified", async () => {
+      try {
+        response = getResourceUri("cicsplex1", "region1", "resource1", "NAME=test");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?CRITERIA=(NAME%3Dtest)");
+    });
+
+    it("should be able to get a resource uri with the parameter is unspecified", async () => {
+      try {
+        response = getResourceUri("cicsplex1", "region1", "resource1", "", "");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1");
+    });
+
+    it("should be able to get a resource uri with the parameter is specified", async () => {
+      try {
+        response = getResourceUri("cicsplex1", "region1", "resource1", "", "PARAM=test");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?PARAMETER=PARAM%3Dtest");
+    });
+
+    it("should be able to get a resource uri when both criteria and parameter are specified", async () => {
+      try {
+        response = getResourceUri("cicsplex1", "region1", "resource1", "NAME=test1", "PARAM=test2");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?CRITERIA=(NAME%3Dtest1)&PARAMETER=PARAM%3Dtest2");
+    });
+  });
+});

--- a/packages/sdk/__tests__/__unit__/delete/Delete.program.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/delete/Delete.program.unit.test.ts
@@ -173,7 +173,7 @@ describe("CMCI - Delete program", () => {
     it("should be able to delete a program without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteProgram(dummySession, deleteParms);
 
@@ -186,7 +186,7 @@ describe("CMCI - Delete program", () => {
       deleteParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "//" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteProgram(dummySession, deleteParms);
 
@@ -199,7 +199,7 @@ describe("CMCI - Delete program", () => {
       deleteParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex + "/" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteProgram(dummySession, deleteParms);
 

--- a/packages/sdk/__tests__/__unit__/delete/Delete.transaction.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/delete/Delete.transaction.unit.test.ts
@@ -179,7 +179,7 @@ describe("CMCI - Discard transaction", () => {
     it("should be able to delete a transaction without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteTransaction(dummySession, deleteParms);
 
@@ -192,7 +192,7 @@ describe("CMCI - Discard transaction", () => {
       deleteParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "//" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteTransaction(dummySession, deleteParms);
 
@@ -205,7 +205,7 @@ describe("CMCI - Discard transaction", () => {
       deleteParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex + "/" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteTransaction(dummySession, deleteParms);
 

--- a/packages/sdk/__tests__/__unit__/delete/Delete.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/delete/Delete.urimap.unit.test.ts
@@ -104,7 +104,7 @@ describe("CMCI - Delete urimap", () => {
     it("should be able to delete a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+            `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteUrimap(dummySession, deleteParms);
       expect(response).toContain(content);

--- a/packages/sdk/__tests__/__unit__/delete/Delete.webservice.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/delete/Delete.webservice.unit.test.ts
@@ -104,7 +104,7 @@ describe("CMCI - Delete web service", () => {
     it("should be able to delete a web service", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + region +
-            `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+            `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteWebservice(dummySession, deleteParms);
       expect(response).toContain(content);

--- a/packages/sdk/__tests__/__unit__/disable/Disable.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/disable/Disable.urimap.unit.test.ts
@@ -89,7 +89,7 @@ describe("CMCI - Disable urimap", () => {
     it("should be able to disable a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${disableParms.name})`;
+            `?CRITERIA=(NAME%3D${disableParms.name})`;
       requestBody = {
         request: {
           update: {

--- a/packages/sdk/__tests__/__unit__/discard/Discard.program.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/discard/Discard.program.unit.test.ts
@@ -129,7 +129,7 @@ describe("CMCI - Discard program", () => {
     it("should be able to discard a program without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + region +
-                "?CRITERIA=(PROGRAM=" + discardParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + discardParms.name + ")";
 
       response = await discardProgram(dummySession, discardParms);
 
@@ -142,7 +142,7 @@ describe("CMCI - Discard program", () => {
       discardParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "//" + region +
-                "?CRITERIA=(PROGRAM=" + discardParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + discardParms.name + ")";
 
       response = await discardProgram(dummySession, discardParms);
 
@@ -155,7 +155,7 @@ describe("CMCI - Discard program", () => {
       discardParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(PROGRAM=" + discardParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + discardParms.name + ")";
 
       response = await discardProgram(dummySession, discardParms);
 

--- a/packages/sdk/__tests__/__unit__/discard/Discard.transaction.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/discard/Discard.transaction.unit.test.ts
@@ -147,7 +147,7 @@ describe("CMCI - Discard transaction", () => {
     it("should be able to discard a transaction without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_LOCAL_TRANSACTION + "/" + region +
-                "?CRITERIA=(TRANID=" + discardParms.name + ")";
+                "?CRITERIA=(TRANID%3D" + discardParms.name + ")";
 
       response = await discardTransaction(dummySession, discardParms);
 
@@ -160,7 +160,7 @@ describe("CMCI - Discard transaction", () => {
       discardParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_LOCAL_TRANSACTION + "//" + region +
-                "?CRITERIA=(TRANID=" + discardParms.name + ")";
+                "?CRITERIA=(TRANID%3D" + discardParms.name + ")";
 
       response = await discardTransaction(dummySession, discardParms);
 
@@ -173,7 +173,7 @@ describe("CMCI - Discard transaction", () => {
       discardParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_LOCAL_TRANSACTION + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(TRANID=" + discardParms.name + ")";
+                "?CRITERIA=(TRANID%3D" + discardParms.name + ")";
 
       response = await discardTransaction(dummySession, discardParms);
 

--- a/packages/sdk/__tests__/__unit__/discard/Discard.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/discard/Discard.urimap.unit.test.ts
@@ -88,7 +88,7 @@ describe("CMCI - Discard urimap", () => {
     it("should be able to discard a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_URIMAP + "/" + region +
-            `?CRITERIA=(NAME='${discardParms.name}')`;
+            `?CRITERIA=(NAME%3D${discardParms.name})`;
 
       response = await discardUrimap(dummySession, discardParms);
       expect(response).toContain(content);

--- a/packages/sdk/__tests__/__unit__/enable/Enable.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/enable/Enable.urimap.unit.test.ts
@@ -89,7 +89,7 @@ describe("CMCI - enable urimap", () => {
     it("should be able to enable a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${enableParms.name})`;
+            `?CRITERIA=(NAME%3D${enableParms.name})`;
       requestBody = {
         request: {
           update: {

--- a/packages/sdk/__tests__/__unit__/install/Install.program.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/install/Install.program.unit.test.ts
@@ -177,7 +177,7 @@ describe("CMCI - Install program", () => {
     it("should be able to install a program without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installProgram(dummySession, installParms);
 
@@ -190,7 +190,7 @@ describe("CMCI - Install program", () => {
       installParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "//" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installProgram(dummySession, installParms);
 
@@ -203,7 +203,7 @@ describe("CMCI - Install program", () => {
       installParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installProgram(dummySession, installParms);
 

--- a/packages/sdk/__tests__/__unit__/install/Install.transaction.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/install/Install.transaction.unit.test.ts
@@ -180,7 +180,7 @@ describe("CMCI - Install transaction", () => {
     it("should be able to install a transaction without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installTransaction(dummySession, installParms);
 
@@ -193,7 +193,7 @@ describe("CMCI - Install transaction", () => {
       installParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "//" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installTransaction(dummySession, installParms);
 
@@ -206,7 +206,7 @@ describe("CMCI - Install transaction", () => {
       installParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installTransaction(dummySession, installParms);
 

--- a/packages/sdk/__tests__/__unit__/install/Install.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/install/Install.urimap.unit.test.ts
@@ -105,7 +105,7 @@ describe("CMCI - Install urimap", () => {
     it("should be able to install a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${installParms.name})&PARAMETER=CSDGROUP(${installParms.csdGroup})`;
+            `?CRITERIA=(NAME%3D${installParms.name})&PARAMETER=CSDGROUP(${installParms.csdGroup})`;
       requestBody = {
         request: {
           action: {

--- a/packages/sdk/__tests__/__unit__/refresh/Refresh.program.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/refresh/Refresh.program.unit.test.ts
@@ -139,7 +139,7 @@ describe("CMCI - Refresh program", () => {
     it("should be able to refresh a program without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + region +
-                "?CRITERIA=(PROGRAM=" + refreshParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + refreshParms.name + ")";
 
       response = await programNewcopy(dummySession, refreshParms);
 
@@ -152,7 +152,7 @@ describe("CMCI - Refresh program", () => {
       refreshParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "//" + region +
-                "?CRITERIA=(PROGRAM=" + refreshParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + refreshParms.name + ")";
 
       response = await programNewcopy(dummySession, refreshParms);
 
@@ -165,7 +165,7 @@ describe("CMCI - Refresh program", () => {
       refreshParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(PROGRAM=" + refreshParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + refreshParms.name + ")";
 
       response = await programNewcopy(dummySession, refreshParms);
 

--- a/packages/sdk/__tests__/__unit__/remove-from-list/RemoveFromList.csdGroup.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/remove-from-list/RemoveFromList.csdGroup.unit.test.ts
@@ -150,7 +150,7 @@ describe("CMCI - Remove csdGroup from list", () => {
     it("should be able to remove a csdGroup from list without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP_IN_LIST + "/" + removeFromListParms.regionName +
-            "?CRITERIA=(CSDLIST=='" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP=='" + removeFromListParms.name + "')";
+            "?CRITERIA=(CSDLIST%3D%3D'" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP%3D%3D'" + removeFromListParms.name + "')";
 
       response = await removeCSDGroupFromList(dummySession, removeFromListParms);
 
@@ -163,7 +163,7 @@ describe("CMCI - Remove csdGroup from list", () => {
       removeFromListParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP_IN_LIST + "/" + removeFromListParms.cicsPlex + "/" + removeFromListParms.regionName +
-            "?CRITERIA=(CSDLIST=='" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP=='" + removeFromListParms.name + "')";
+            "?CRITERIA=(CSDLIST%3D%3D'" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP%3D%3D'" + removeFromListParms.name + "')";
 
       response = await removeCSDGroupFromList(dummySession, removeFromListParms);
 
@@ -176,7 +176,7 @@ describe("CMCI - Remove csdGroup from list", () => {
       removeFromListParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP_IN_LIST + "/" + removeFromListParms.cicsPlex + "/" + removeFromListParms.regionName +
-            "?CRITERIA=(CSDLIST=='" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP=='" + removeFromListParms.name + "')";
+            "?CRITERIA=(CSDLIST%3D%3D'" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP%3D%3D'" + removeFromListParms.name + "')";
 
       response = await removeCSDGroupFromList(dummySession, removeFromListParms);
 

--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -94,4 +94,9 @@ export const CicsCmciConstants: { [key: string]: any } = {
      */
   CICS_CMCI_EXTERNAL_RESOURCES: ["CICSLocalTransaction", "CICSRemoteTransaction", "CICSDefinitionTransaction", "CICSLocalFile"],
 
+  /**
+     * SEPERATOR token
+     */
+  SEPERATOR: "/",
+
 };

--- a/packages/sdk/src/doc/IResourceParms.ts
+++ b/packages/sdk/src/doc/IResourceParms.ts
@@ -37,7 +37,7 @@ export interface IResourceParms {
   /**
      * The name of the CICS region of the program
      */
-  regionName: string;
+  regionName?: string;
 
   /**
      * CICS Plex of the program

--- a/packages/sdk/src/methods/add-to-list/AddToList.ts
+++ b/packages/sdk/src/methods/add-to-list/AddToList.ts
@@ -12,6 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
+import { getResourceUri } from "../common";
 import { ICMCIApiResponse, ICSDGroupParms } from "../../doc";
 
 /**
@@ -31,10 +32,8 @@ export function addCSDGroupToList(session: AbstractSession, parms: ICSDGroupParm
 
   Logger.getAppLogger().debug("Attempting to add a CSD Group to a CSD List with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_CSDGROUP + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=NAME=='" + parms.name + "'";
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+        CicsCmciConstants.CICS_CSDGROUP, "NAME=='" + parms.name + "'");
 
   const requestBody: any = {
     request: {

--- a/packages/sdk/src/methods/common/Common.ts
+++ b/packages/sdk/src/methods/common/Common.ts
@@ -1,0 +1,49 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { ImperativeExpect } from "@zowe/imperative";
+import { CicsCmciConstants } from "../../constants";
+
+/**
+ * Get uri for requesting a resources in CICS through CMCI REST API
+ * @param {string} cicsPlexName - CICSplex name
+ * @param {string} regionName - CICS region name
+ * @param {string} resourceName - CMCI resource name
+ * @param {string} criteria - criteria string
+ * @param {string} parameter - parameter string
+ * @returns {string} return a string containing the resource uri
+ */
+export function getResourceUri(cicsPlexName: string, regionName: string, resourceName: string, criteria?: string, parameter?: string) {
+  ImperativeExpect.toBeDefinedAndNonBlank(resourceName, "CICS Resource name", "CICS resource name is required");
+
+  let delimiter = "?"; // initial delimiter
+
+  const cicsPlex = cicsPlexName == null ? "" : cicsPlexName + CicsCmciConstants.SEPERATOR;
+  const region = regionName == null ? "" : regionName;
+
+  let cmciResource = CicsCmciConstants.SEPERATOR + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
+                     CicsCmciConstants.SEPERATOR + resourceName + CicsCmciConstants.SEPERATOR +
+                     cicsPlex + region;
+
+  if (criteria != null && criteria.length > 0) {
+    let addParentheses = criteria.charAt(0) !== '(';
+
+    cmciResource = cmciResource + delimiter + "CRITERIA=" + (addParentheses ? "(": "") + encodeURIComponent(criteria) + (addParentheses ? ")": "") ;
+    delimiter = "&";
+  }
+
+  if (parameter != null && parameter.length > 0) {
+    cmciResource = cmciResource + delimiter + "PARAMETER=" + encodeURIComponent(parameter);
+  }
+
+  return cmciResource;
+}
+

--- a/packages/sdk/src/methods/common/index.ts
+++ b/packages/sdk/src/methods/common/index.ts
@@ -1,0 +1,12 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export * from "./Common";

--- a/packages/sdk/src/methods/define/Define.ts
+++ b/packages/sdk/src/methods/define/Define.ts
@@ -13,6 +13,7 @@ import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
 import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms } from "../../doc";
+import { getResourceUri } from "../common";
 
 /**
  * Define a new program resource to CICS through CMCI REST API
@@ -49,9 +50,8 @@ export function defineProgram(session: AbstractSession, parms: IProgramParms): P
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex + parms.regionName;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+     CicsCmciConstants.CICS_DEFINITION_PROGRAM);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -93,10 +93,8 @@ export function defineTransaction(session: AbstractSession, parms: ITransactionP
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex +
-        parms.regionName;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+        CicsCmciConstants.CICS_DEFINITION_TRANSACTION);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
     [], requestBody) as any;
 }
@@ -124,9 +122,8 @@ export function defineUrimapServer(session: AbstractSession, parms: IURIMapParms
   const requestBody: any = buildUrimapRequestBody(parms, "server");
   requestBody.request.create.attributes.$.program = parms.programName;
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+        CicsCmciConstants.CICS_DEFINITION_URIMAP);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -150,9 +147,8 @@ export function defineUrimapClient(session: AbstractSession, parms: IURIMapParms
   Logger.getAppLogger().debug("Attempting to define a client URIMap with the following parameters:\n%s", JSON.stringify(parms));
   const requestBody: any = buildUrimapRequestBody(parms, "client");
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+        CicsCmciConstants.CICS_DEFINITION_URIMAP);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -179,9 +175,8 @@ export function defineUrimapPipeline(session: AbstractSession, parms: IURIMapPar
   const requestBody: any = buildUrimapRequestBody(parms, "pipeline");
   requestBody.request.create.attributes.$.pipeline = parms.pipelineName;
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+        CicsCmciConstants.CICS_DEFINITION_URIMAP);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -305,10 +300,8 @@ export function defineWebservice(session: AbstractSession, parms: IWebServicePar
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + cicsPlex +
-        parms.regionName;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+          CicsCmciConstants.CICS_DEFINITION_WEBSERVICE);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
     [], requestBody) as any;
 }

--- a/packages/sdk/src/methods/delete/Delete.ts
+++ b/packages/sdk/src/methods/delete/Delete.ts
@@ -12,6 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
+import { getResourceUri } from "../common";
 import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms } from "../../doc";
 
 /**
@@ -31,10 +32,11 @@ export async function deleteProgram(session: AbstractSession, parms: IProgramPar
 
   Logger.getAppLogger().debug("Attempting to delete a program with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_DEFINITION_PROGRAM,
+                                      `NAME=${parms.name}`,
+                                      `CSDGROUP(${parms.csdGroup})`);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -55,10 +57,11 @@ export async function deleteTransaction(session: AbstractSession, parms: ITransa
 
   Logger.getAppLogger().debug("Attempting to delete a transaction with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_DEFINITION_TRANSACTION,
+                                      `NAME=${parms.name}`,
+                                      `CSDGROUP(${parms.csdGroup})`);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -80,10 +83,11 @@ export async function deleteUrimap(session: AbstractSession, parms: IURIMapParms
 
   Logger.getAppLogger().debug("Attempting to delete a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_DEFINITION_URIMAP,
+                                      `NAME=${parms.name}`,
+                                      `CSDGROUP(${parms.csdGroup})`);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -105,9 +109,10 @@ export async function deleteWebservice(session: AbstractSession, parms: IWebServ
 
   Logger.getAppLogger().debug("Attempting to delete a web service with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_DEFINITION_WEBSERVICE,
+                                      `NAME=${parms.name}`,
+                                      `CSDGROUP(${parms.csdGroup})`);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }

--- a/packages/sdk/src/methods/disable/Disable.ts
+++ b/packages/sdk/src/methods/disable/Disable.ts
@@ -12,6 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
+import { getResourceUri } from "../common";
 import { ICMCIApiResponse, IURIMapParms } from "../../doc";
 
 /**
@@ -32,10 +33,10 @@ export async function disableUrimap(session: AbstractSession, parms: IURIMapParm
 
   Logger.getAppLogger().debug("Attempting to disable a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})`;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_URIMAP,
+                                      `NAME=${parms.name}`);
+
   const requestBody: any = {
     request: {
       update: {

--- a/packages/sdk/src/methods/discard/Discard.ts
+++ b/packages/sdk/src/methods/discard/Discard.ts
@@ -12,6 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
+import { getResourceUri } from "../common";
 import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms } from "../../doc";
 
 /**
@@ -30,10 +31,10 @@ export async function discardProgram(session: AbstractSession, parms: IProgramPa
 
   Logger.getAppLogger().debug("Attempting to discard a program with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(PROGRAM=" + parms.name + ")";
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_PROGRAM_RESOURCE,
+                                      `PROGRAM=${parms.name}`);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -53,10 +54,10 @@ export async function discardTransaction(session: AbstractSession, parms: ITrans
 
   Logger.getAppLogger().debug("Attempting to discard a transaction with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_LOCAL_TRANSACTION + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(TRANID=" + parms.name + ")";
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_LOCAL_TRANSACTION,
+                                      `(TRANID=${parms.name})`);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -66,9 +67,9 @@ export async function discardUrimap(session: AbstractSession, parms: IURIMapParm
 
   Logger.getAppLogger().debug("Attempting to discard a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME='${parms.name}')`;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_URIMAP,
+                                      `(NAME=${parms.name})`);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }

--- a/packages/sdk/src/methods/enable/Enable.ts
+++ b/packages/sdk/src/methods/enable/Enable.ts
@@ -12,6 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
+import { getResourceUri } from "../common";
 import { ICMCIApiResponse, IURIMapParms } from "../../doc";
 
 /**
@@ -32,10 +33,10 @@ export async function enableUrimap(session: AbstractSession, parms: IURIMapParms
 
   Logger.getAppLogger().debug("Attempting to enable a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})`;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_URIMAP,
+                                      `NAME=${parms.name}`);
+
   const requestBody: any = {
     request: {
       update: {

--- a/packages/sdk/src/methods/get/Get.ts
+++ b/packages/sdk/src/methods/get/Get.ts
@@ -11,8 +11,8 @@
 
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
-import { CicsCmciConstants } from "../../constants";
 import { ICMCIApiResponse, IResourceParms } from "../../doc";
+import { getResourceUri } from "../common";
 
 /**
  * Get resources on in CICS through CMCI REST API
@@ -26,23 +26,10 @@ import { ICMCIApiResponse, IResourceParms } from "../../doc";
  */
 export async function getResource(session: AbstractSession, parms: IResourceParms): Promise<ICMCIApiResponse> {
   ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Resource name", "CICS resource name is required");
-  ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
-
-  let delimiter = "?"; // initial delimiter
 
   Logger.getAppLogger().debug("Attempting to get resource(s) with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  let cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        parms.name + "/" + cicsPlex + parms.regionName;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName, parms.name, parms.criteria, parms.parameter);
 
-  if (parms.criteria != null) {
-    cmciResource = cmciResource + delimiter + "CRITERIA=(" + encodeURIComponent(parms.criteria) + ")";
-    delimiter = "&";
-  }
-
-  if (parms.parameter != null) {
-    cmciResource = cmciResource + delimiter + "PARAMETER=" + encodeURIComponent(parms.parameter);
-  }
   return CicsCmciRestClient.getExpectParsedXml(session, cmciResource, []);
 }

--- a/packages/sdk/src/methods/install/Install.ts
+++ b/packages/sdk/src/methods/install/Install.ts
@@ -12,6 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
+import { getResourceUri } from "../common";
 import { ICMCIApiResponse, IProgramParms, IURIMapParms } from "../../doc";
 
 /**
@@ -41,10 +42,11 @@ export function installProgram(session: AbstractSession, parms: IProgramParms): 
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(NAME=" + parms.name + ")&PARAMETER=CSDGROUP(" + parms.csdGroup + ")";
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_DEFINITION_PROGRAM,
+                                      `NAME=${parms.name}`,
+                                      `CSDGROUP(${parms.csdGroup})`);
+
   return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -75,10 +77,11 @@ export function installTransaction(session: AbstractSession, parms: IProgramParm
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(NAME=" + parms.name + ")&PARAMETER=CSDGROUP(" + parms.csdGroup + ")";
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                      CicsCmciConstants.CICS_DEFINITION_TRANSACTION,
+                      `NAME=${parms.name}`,
+                      `CSDGROUP(${parms.csdGroup})`);
+
   return CicsCmciRestClient.putExpectParsedXml(session, cmciResource,
     [], requestBody) as any;
 }
@@ -102,10 +105,11 @@ export function installUrimap(session: AbstractSession, parms: IURIMapParms): Pr
 
   Logger.getAppLogger().debug("Attempting to install a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_DEFINITION_URIMAP,
+                                      `NAME=${parms.name}`,
+                                      `CSDGROUP(${parms.csdGroup})`);
+
   const requestBody: any = {
     request: {
       action: {
@@ -115,5 +119,6 @@ export function installUrimap(session: AbstractSession, parms: IURIMapParms): Pr
       }
     }
   };
+
   return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/packages/sdk/src/methods/remove-from-list/RemoveFromList.ts
+++ b/packages/sdk/src/methods/remove-from-list/RemoveFromList.ts
@@ -12,6 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
+import { getResourceUri } from "../common";
 import { ICMCIApiResponse, ICSDGroupParms } from "../../doc";
 
 /**
@@ -31,9 +32,9 @@ export function removeCSDGroupFromList(session: AbstractSession, parms: ICSDGrou
 
   Logger.getAppLogger().debug("Attempting to remove a CSD Group from a CSD List with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_CSDGROUP_IN_LIST + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(CSDLIST=='" + parms.csdList + "')%20AND%20(CSDGROUP=='" + parms.name + "')";
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_CSDGROUP_IN_LIST,
+                                      `(CSDLIST=='${parms.csdList}') AND (CSDGROUP=='${parms.name}')`);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []) as any;
 }

--- a/packages/sdk/src/methods/set/Set.ts
+++ b/packages/sdk/src/methods/set/Set.ts
@@ -12,6 +12,7 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
+import { getResourceUri } from "../common";
 import { ICMCIApiResponse, IProgramParms } from "../../doc";
 
 /**
@@ -39,9 +40,9 @@ export function programNewcopy(session: AbstractSession, parms: IProgramParms): 
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(PROGRAM=" + parms.name + ")";
+  const cmciResource = getResourceUri(parms.cicsPlex, parms.regionName,
+                                      CicsCmciConstants.CICS_PROGRAM_RESOURCE,
+                                      `PROGRAM=${parms.name}`);
+
   return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }


### PR DESCRIPTION
**What It Does**
Have made the Region optional and in doing so extracted the logic that creates the resource uri into a separate method. 

**How to Test**
Have added additional unit tests.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
