### PR TITLE
Have made the region name optional on the getResource SDK method

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Have made the region name optional on the getResource SDK method. [#164](https://github.com/zowe/cics-for-zowe-client/pull/164)
+
 ## `6.0.0`
 
 - MAJOR: v6.0.0 release

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented 
 
 ## Recent Changes
 
-- Enhancement: Have made the region name optional on the getResource SDK method. [#164](https://github.com/zowe/cics-for-zowe-client/pull/164)
+- Enhancement: Made the region name optional on the getResource SDK method. [#162](https://github.com/zowe/cics-for-zowe-client/issues/162)
 
 ## `6.0.0`
 

--- a/packages/sdk/__tests__/__unit__/add-to-list/AddToList.csdGroup.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/add-to-list/AddToList.csdGroup.unit.test.ts
@@ -166,7 +166,7 @@ describe("CMCI - Add csdGroup to list", () => {
     it("should be able to add a csdGroup to list without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP + "/" + addToListParms.regionName +
-            "?CRITERIA=NAME=='" + addToListParms.name + "'";
+            "?CRITERIA=(NAME%3D%3D'" + addToListParms.name + "')";
 
       response = await addCSDGroupToList(dummySession, addToListParms);
 
@@ -179,7 +179,7 @@ describe("CMCI - Add csdGroup to list", () => {
       addToListParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP + "/" + addToListParms.cicsPlex + "/" + addToListParms.regionName +
-            "?CRITERIA=NAME=='" + addToListParms.name + "'";
+            "?CRITERIA=(NAME%3D%3D'" + addToListParms.name + "')";
 
       response = await addCSDGroupToList(dummySession, addToListParms);
 
@@ -192,7 +192,7 @@ describe("CMCI - Add csdGroup to list", () => {
       addToListParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP + "/" + addToListParms.cicsPlex + "/" + addToListParms.regionName +
-            "?CRITERIA=NAME=='" + addToListParms.name + "'";
+            "?CRITERIA=(NAME%3D%3D'" + addToListParms.name + "')";
 
       response = await addCSDGroupToList(dummySession, addToListParms);
 

--- a/packages/sdk/__tests__/__unit__/delete/Delete.program.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/delete/Delete.program.unit.test.ts
@@ -173,7 +173,7 @@ describe("CMCI - Delete program", () => {
     it("should be able to delete a program without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteProgram(dummySession, deleteParms);
 
@@ -186,7 +186,7 @@ describe("CMCI - Delete program", () => {
       deleteParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "//" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteProgram(dummySession, deleteParms);
 
@@ -199,7 +199,7 @@ describe("CMCI - Delete program", () => {
       deleteParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex + "/" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteProgram(dummySession, deleteParms);
 

--- a/packages/sdk/__tests__/__unit__/delete/Delete.transaction.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/delete/Delete.transaction.unit.test.ts
@@ -179,7 +179,7 @@ describe("CMCI - Discard transaction", () => {
     it("should be able to delete a transaction without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteTransaction(dummySession, deleteParms);
 
@@ -192,7 +192,7 @@ describe("CMCI - Discard transaction", () => {
       deleteParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "//" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteTransaction(dummySession, deleteParms);
 
@@ -205,7 +205,7 @@ describe("CMCI - Discard transaction", () => {
       deleteParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex + "/" + region +
-                `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+                `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteTransaction(dummySession, deleteParms);
 

--- a/packages/sdk/__tests__/__unit__/delete/Delete.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/delete/Delete.urimap.unit.test.ts
@@ -104,7 +104,7 @@ describe("CMCI - Delete urimap", () => {
     it("should be able to delete a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+            `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteUrimap(dummySession, deleteParms);
       expect(response).toContain(content);

--- a/packages/sdk/__tests__/__unit__/delete/Delete.webservice.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/delete/Delete.webservice.unit.test.ts
@@ -104,7 +104,7 @@ describe("CMCI - Delete web service", () => {
     it("should be able to delete a web service", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + region +
-            `?CRITERIA=(NAME=${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
+            `?CRITERIA=(NAME%3D${deleteParms.name})&PARAMETER=CSDGROUP(${deleteParms.csdGroup})`;
 
       response = await deleteWebservice(dummySession, deleteParms);
       expect(response).toContain(content);

--- a/packages/sdk/__tests__/__unit__/disable/Disable.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/disable/Disable.urimap.unit.test.ts
@@ -89,7 +89,7 @@ describe("CMCI - Disable urimap", () => {
     it("should be able to disable a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${disableParms.name})`;
+            `?CRITERIA=(NAME%3D${disableParms.name})`;
       requestBody = {
         request: {
           update: {

--- a/packages/sdk/__tests__/__unit__/discard/Discard.program.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/discard/Discard.program.unit.test.ts
@@ -129,7 +129,7 @@ describe("CMCI - Discard program", () => {
     it("should be able to discard a program without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + region +
-                "?CRITERIA=(PROGRAM=" + discardParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + discardParms.name + ")";
 
       response = await discardProgram(dummySession, discardParms);
 
@@ -142,7 +142,7 @@ describe("CMCI - Discard program", () => {
       discardParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "//" + region +
-                "?CRITERIA=(PROGRAM=" + discardParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + discardParms.name + ")";
 
       response = await discardProgram(dummySession, discardParms);
 
@@ -155,7 +155,7 @@ describe("CMCI - Discard program", () => {
       discardParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(PROGRAM=" + discardParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + discardParms.name + ")";
 
       response = await discardProgram(dummySession, discardParms);
 

--- a/packages/sdk/__tests__/__unit__/discard/Discard.transaction.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/discard/Discard.transaction.unit.test.ts
@@ -147,7 +147,7 @@ describe("CMCI - Discard transaction", () => {
     it("should be able to discard a transaction without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_LOCAL_TRANSACTION + "/" + region +
-                "?CRITERIA=(TRANID=" + discardParms.name + ")";
+                "?CRITERIA=(TRANID%3D" + discardParms.name + ")";
 
       response = await discardTransaction(dummySession, discardParms);
 
@@ -160,7 +160,7 @@ describe("CMCI - Discard transaction", () => {
       discardParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_LOCAL_TRANSACTION + "//" + region +
-                "?CRITERIA=(TRANID=" + discardParms.name + ")";
+                "?CRITERIA=(TRANID%3D" + discardParms.name + ")";
 
       response = await discardTransaction(dummySession, discardParms);
 
@@ -173,7 +173,7 @@ describe("CMCI - Discard transaction", () => {
       discardParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_LOCAL_TRANSACTION + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(TRANID=" + discardParms.name + ")";
+                "?CRITERIA=(TRANID%3D" + discardParms.name + ")";
 
       response = await discardTransaction(dummySession, discardParms);
 

--- a/packages/sdk/__tests__/__unit__/discard/Discard.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/discard/Discard.urimap.unit.test.ts
@@ -88,7 +88,7 @@ describe("CMCI - Discard urimap", () => {
     it("should be able to discard a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_URIMAP + "/" + region +
-            `?CRITERIA=(NAME='${discardParms.name}')`;
+            `?CRITERIA=(NAME%3D${discardParms.name})`;
 
       response = await discardUrimap(dummySession, discardParms);
       expect(response).toContain(content);

--- a/packages/sdk/__tests__/__unit__/enable/Enable.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/enable/Enable.urimap.unit.test.ts
@@ -89,7 +89,7 @@ describe("CMCI - enable urimap", () => {
     it("should be able to enable a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${enableParms.name})`;
+            `?CRITERIA=(NAME%3D${enableParms.name})`;
       requestBody = {
         request: {
           update: {

--- a/packages/sdk/__tests__/__unit__/install/Install.program.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/install/Install.program.unit.test.ts
@@ -177,7 +177,7 @@ describe("CMCI - Install program", () => {
     it("should be able to install a program without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installProgram(dummySession, installParms);
 
@@ -190,7 +190,7 @@ describe("CMCI - Install program", () => {
       installParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "//" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installProgram(dummySession, installParms);
 
@@ -203,7 +203,7 @@ describe("CMCI - Install program", () => {
       installParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installProgram(dummySession, installParms);
 

--- a/packages/sdk/__tests__/__unit__/install/Install.transaction.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/install/Install.transaction.unit.test.ts
@@ -180,7 +180,7 @@ describe("CMCI - Install transaction", () => {
     it("should be able to install a transaction without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installTransaction(dummySession, installParms);
 
@@ -193,7 +193,7 @@ describe("CMCI - Install transaction", () => {
       installParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "//" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installTransaction(dummySession, installParms);
 
@@ -206,7 +206,7 @@ describe("CMCI - Install transaction", () => {
       installParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(NAME=" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
+                "?CRITERIA=(NAME%3D" + installParms.name + ")&PARAMETER=CSDGROUP(" + installParms.csdGroup + ")";
 
       response = await installTransaction(dummySession, installParms);
 

--- a/packages/sdk/__tests__/__unit__/install/Install.urimap.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/install/Install.urimap.unit.test.ts
@@ -105,7 +105,7 @@ describe("CMCI - Install urimap", () => {
     it("should be able to install a urimap", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + region +
-            `?CRITERIA=(NAME=${installParms.name})&PARAMETER=CSDGROUP(${installParms.csdGroup})`;
+            `?CRITERIA=(NAME%3D${installParms.name})&PARAMETER=CSDGROUP(${installParms.csdGroup})`;
       requestBody = {
         request: {
           action: {

--- a/packages/sdk/__tests__/__unit__/refresh/Refresh.program.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/refresh/Refresh.program.unit.test.ts
@@ -139,7 +139,7 @@ describe("CMCI - Refresh program", () => {
     it("should be able to refresh a program without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + region +
-                "?CRITERIA=(PROGRAM=" + refreshParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + refreshParms.name + ")";
 
       response = await programNewcopy(dummySession, refreshParms);
 
@@ -152,7 +152,7 @@ describe("CMCI - Refresh program", () => {
       refreshParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "//" + region +
-                "?CRITERIA=(PROGRAM=" + refreshParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + refreshParms.name + ")";
 
       response = await programNewcopy(dummySession, refreshParms);
 
@@ -165,7 +165,7 @@ describe("CMCI - Refresh program", () => {
       refreshParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
                 CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + cicsPlex + "/" + region +
-                "?CRITERIA=(PROGRAM=" + refreshParms.name + ")";
+                "?CRITERIA=(PROGRAM%3D" + refreshParms.name + ")";
 
       response = await programNewcopy(dummySession, refreshParms);
 

--- a/packages/sdk/__tests__/__unit__/remove-from-list/RemoveFromList.csdGroup.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/remove-from-list/RemoveFromList.csdGroup.unit.test.ts
@@ -150,7 +150,7 @@ describe("CMCI - Remove csdGroup from list", () => {
     it("should be able to remove a csdGroup from list without cicsPlex specified", async () => {
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP_IN_LIST + "/" + removeFromListParms.regionName +
-            "?CRITERIA=(CSDLIST=='" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP=='" + removeFromListParms.name + "')";
+            "?CRITERIA=(CSDLIST%3D%3D'" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP%3D%3D'" + removeFromListParms.name + "')";
 
       response = await removeCSDGroupFromList(dummySession, removeFromListParms);
 
@@ -163,7 +163,7 @@ describe("CMCI - Remove csdGroup from list", () => {
       removeFromListParms.cicsPlex = "";
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP_IN_LIST + "/" + removeFromListParms.cicsPlex + "/" + removeFromListParms.regionName +
-            "?CRITERIA=(CSDLIST=='" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP=='" + removeFromListParms.name + "')";
+            "?CRITERIA=(CSDLIST%3D%3D'" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP%3D%3D'" + removeFromListParms.name + "')";
 
       response = await removeCSDGroupFromList(dummySession, removeFromListParms);
 
@@ -176,7 +176,7 @@ describe("CMCI - Remove csdGroup from list", () => {
       removeFromListParms.cicsPlex = cicsPlex;
       endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
             CicsCmciConstants.CICS_CSDGROUP_IN_LIST + "/" + removeFromListParms.cicsPlex + "/" + removeFromListParms.regionName +
-            "?CRITERIA=(CSDLIST=='" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP=='" + removeFromListParms.name + "')";
+            "?CRITERIA=(CSDLIST%3D%3D'" + removeFromListParms.csdList + "')%20AND%20(CSDGROUP%3D%3D'" + removeFromListParms.name + "')";
 
       response = await removeCSDGroupFromList(dummySession, removeFromListParms);
 

--- a/packages/sdk/__tests__/__unit__/utils/Utils.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/utils/Utils.unit.test.ts
@@ -1,0 +1,227 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Utils } from "../../../src/utils";
+import { IGetResourceUriOptions } from "../../../src";
+
+describe("Utils - getResourceUri", () => {
+
+  let error: any;
+  let response: any;
+
+  describe("validation", () => {
+    beforeEach(() => {
+      response = undefined;
+      error = undefined;
+    });
+
+    it("should throw error if resourceName is empty", async () => {
+      try {
+        response = Utils.getResourceUri("");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toEqual("Expect Error: Required parameter 'CICS Resource name' must not be blank");
+    });
+
+    it("should throw error if resourceName is undefined", async () => {
+      try {
+        response = Utils.getResourceUri(undefined);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toEqual("Expect Error: CICS resource name is required");
+    });
+
+    it("should throw error if resourceName is null", async () => {
+      try {
+        response = Utils.getResourceUri(null);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toEqual("Expect Error: CICS resource name is required");
+    });
+  });
+
+  describe("success scenarios", () => {
+
+    beforeEach(() => {
+      response = undefined;
+      error = undefined;
+    });
+
+    it("should be able to get a resource uri with only the resource name specified", async () => {
+      try {
+        response = Utils.getResourceUri("resource1");
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/");
+    });
+
+    it("should be able to get a resource uri with the cicsplex and resource name specified", async () => {
+      try {
+
+        const options: IGetResourceUriOptions = {
+          "cicsPlex": "cicsplex1",
+          "regionName": ""
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/");
+    });
+
+    it("should be able to get a resource uri with the region and resource names specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          "cicsPlex": "",
+          "regionName": "region1"
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1//region1");
+    });
+
+    it("should be able to get a resource uri with the plex, region and resource names specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          "cicsPlex": "cicsplex1",
+          "regionName": "region1"
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1");
+    });
+
+    it("should be able to get a resource uri with the criteria is unspecified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          "cicsPlex": "cicsplex1",
+          "regionName": "region1",
+          "criteria": ""
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1");
+    });
+
+    it("should be able to get a resource uri with the criteria is specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          "cicsPlex": "cicsplex1",
+          "regionName": "region1",
+          "criteria": "NAME=test"
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?CRITERIA=(NAME%3Dtest)");
+    });
+
+    it("should be able to get a resource uri with the parameter is unspecified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          "cicsPlex": "cicsplex1",
+          "regionName": "region1",
+          "criteria": "",
+          "parameter": ""
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1");
+    });
+
+    it("should be able to get a resource uri with the parameter is specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          "cicsPlex": "cicsplex1",
+          "regionName": "region1",
+          "criteria": "",
+          "parameter": "PARAM=test"
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?PARAMETER=PARAM%3Dtest");
+    });
+
+    it("should be able to get a resource uri when both criteria and parameter are specified", async () => {
+      try {
+        const options: IGetResourceUriOptions = {
+          "cicsPlex": "cicsplex1",
+          "regionName": "region1",
+          "criteria": "NAME=test1",
+          "parameter": "PARAM=test2"
+        };
+
+        response = Utils.getResourceUri("resource1", options);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeDefined();
+      expect(error).toBeUndefined();
+      expect(response).toEqual("/CICSSystemManagement/resource1/cicsplex1/region1?CRITERIA=(NAME%3Dtest1)&PARAMETER=PARAM%3Dtest2");
+    });
+  });
+});

--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -94,9 +94,4 @@ export const CicsCmciConstants: { [key: string]: any } = {
      */
   CICS_CMCI_EXTERNAL_RESOURCES: ["CICSLocalTransaction", "CICSRemoteTransaction", "CICSDefinitionTransaction", "CICSLocalFile"],
 
-  /**
-     * SEPERATOR token
-     */
-  SEPERATOR: "/",
-
 };

--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -94,4 +94,9 @@ export const CicsCmciConstants: { [key: string]: any } = {
      */
   CICS_CMCI_EXTERNAL_RESOURCES: ["CICSLocalTransaction", "CICSRemoteTransaction", "CICSDefinitionTransaction", "CICSLocalFile"],
 
+  /**
+     * SEPERATOR token
+     */
+  SEPERATOR: "/",
+
 };

--- a/packages/sdk/src/doc/IGetResourceUriOptions.ts
+++ b/packages/sdk/src/doc/IGetResourceUriOptions.ts
@@ -1,0 +1,42 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export interface IGetResourceUriOptions {
+
+  /**
+    * CICS Plex of the program
+    */
+  cicsPlex?: string;
+
+  /**
+    * The name of the CICS region of the program
+    */
+  regionName?: string;
+
+  /**
+    * Criteria by which to filter the records
+    *
+    * Examples:
+    *    "TRANID=TRAN"
+    *    "PROGRAM=PRG*"
+    *    "NAME=C* AND PROGRAM=D*"
+    */
+  criteria?: string;
+
+  /**
+    * Parameter by which to refine the records
+    *
+    * Example:
+    *    "CSDGROUP(GRP1)"
+    *    "CSDGROUP(D*)"
+    */
+  parameter?: string;
+}

--- a/packages/sdk/src/doc/IResourceParms.ts
+++ b/packages/sdk/src/doc/IResourceParms.ts
@@ -37,7 +37,7 @@ export interface IResourceParms {
   /**
      * The name of the CICS region of the program
      */
-  regionName: string;
+  regionName?: string;
 
   /**
      * CICS Plex of the program

--- a/packages/sdk/src/doc/index.ts
+++ b/packages/sdk/src/doc/index.ts
@@ -17,3 +17,4 @@ export * from "./IResourceParms";
 export * from "./ITransactionParms";
 export * from "./IURIMapParms";
 export * from "./IWebServiceParms";
+export * from "./IGetResourceUriOptions";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -13,3 +13,4 @@ export * from "./constants";
 export * from "./methods";
 export * from "./doc";
 export * from "./rest";
+export * from "./utils";

--- a/packages/sdk/src/methods/add-to-list/AddToList.ts
+++ b/packages/sdk/src/methods/add-to-list/AddToList.ts
@@ -12,7 +12,8 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, ICSDGroupParms } from "../../doc";
+import { Utils } from "../../utils";
+import { ICMCIApiResponse, ICSDGroupParms, IGetResourceUriOptions } from "../../doc";
 
 /**
  * Add a new CSD Group resource to a CSD List in CICS through CMCI REST API
@@ -31,10 +32,13 @@ export function addCSDGroupToList(session: AbstractSession, parms: ICSDGroupParm
 
   Logger.getAppLogger().debug("Attempting to add a CSD Group to a CSD List with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_CSDGROUP + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=NAME=='" + parms.name + "'";
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `NAME=='${parms.name}'`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_CSDGROUP, options);
 
   const requestBody: any = {
     request: {

--- a/packages/sdk/src/methods/define/Define.ts
+++ b/packages/sdk/src/methods/define/Define.ts
@@ -12,7 +12,8 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms } from "../../doc";
+import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms, IGetResourceUriOptions } from "../../doc";
+import { Utils } from "../../utils";
 
 /**
  * Define a new program resource to CICS through CMCI REST API
@@ -49,9 +50,12 @@ export function defineProgram(session: AbstractSession, parms: IProgramParms): P
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex + parms.regionName;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_PROGRAM, options);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -93,10 +97,12 @@ export function defineTransaction(session: AbstractSession, parms: ITransactionP
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex +
-        parms.regionName;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_TRANSACTION, options);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
     [], requestBody) as any;
 }
@@ -124,9 +130,12 @@ export function defineUrimapServer(session: AbstractSession, parms: IURIMapParms
   const requestBody: any = buildUrimapRequestBody(parms, "server");
   requestBody.request.create.attributes.$.program = parms.programName;
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_URIMAP, options);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -150,9 +159,12 @@ export function defineUrimapClient(session: AbstractSession, parms: IURIMapParms
   Logger.getAppLogger().debug("Attempting to define a client URIMap with the following parameters:\n%s", JSON.stringify(parms));
   const requestBody: any = buildUrimapRequestBody(parms, "client");
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_URIMAP, options);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -179,9 +191,12 @@ export function defineUrimapPipeline(session: AbstractSession, parms: IURIMapPar
   const requestBody: any = buildUrimapRequestBody(parms, "pipeline");
   requestBody.request.create.attributes.$.pipeline = parms.pipelineName;
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex + parms.regionName;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_URIMAP, options);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -305,10 +320,12 @@ export function defineWebservice(session: AbstractSession, parms: IWebServicePar
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + cicsPlex +
-        parms.regionName;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_WEBSERVICE, options);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource,
     [], requestBody) as any;
 }

--- a/packages/sdk/src/methods/delete/Delete.ts
+++ b/packages/sdk/src/methods/delete/Delete.ts
@@ -12,7 +12,8 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms } from "../../doc";
+import { Utils } from "../../utils";
+import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms, IGetResourceUriOptions } from "../../doc";
 
 /**
  * Delete a program installed in CICS through CMCI REST API
@@ -31,10 +32,15 @@ export async function deleteProgram(session: AbstractSession, parms: IProgramPar
 
   Logger.getAppLogger().debug("Attempting to delete a program with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `NAME=${parms.name}`,
+    "parameter": `CSDGROUP(${parms.csdGroup})`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_PROGRAM, options);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -55,10 +61,15 @@ export async function deleteTransaction(session: AbstractSession, parms: ITransa
 
   Logger.getAppLogger().debug("Attempting to delete a transaction with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `NAME=${parms.name}`,
+    "parameter": `CSDGROUP(${parms.csdGroup})`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_TRANSACTION, options);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -80,10 +91,15 @@ export async function deleteUrimap(session: AbstractSession, parms: IURIMapParms
 
   Logger.getAppLogger().debug("Attempting to delete a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `NAME=${parms.name}`,
+    "parameter": `CSDGROUP(${parms.csdGroup})`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_URIMAP, options);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -105,9 +121,14 @@ export async function deleteWebservice(session: AbstractSession, parms: IWebServ
 
   Logger.getAppLogger().debug("Attempting to delete a web service with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_WEBSERVICE + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `NAME=${parms.name}`,
+    "parameter": `CSDGROUP(${parms.csdGroup})`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_WEBSERVICE, options);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }

--- a/packages/sdk/src/methods/disable/Disable.ts
+++ b/packages/sdk/src/methods/disable/Disable.ts
@@ -12,7 +12,8 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IURIMapParms } from "../../doc";
+import { Utils } from "../../utils";
+import { ICMCIApiResponse, IURIMapParms, IGetResourceUriOptions } from "../../doc";
 
 /**
  * Disable a URIMap installed in CICS through CMCI REST API
@@ -32,10 +33,14 @@ export async function disableUrimap(session: AbstractSession, parms: IURIMapParm
 
   Logger.getAppLogger().debug("Attempting to disable a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})`;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `NAME=${parms.name}`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_URIMAP, options);
+
   const requestBody: any = {
     request: {
       update: {

--- a/packages/sdk/src/methods/discard/Discard.ts
+++ b/packages/sdk/src/methods/discard/Discard.ts
@@ -12,7 +12,8 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms } from "../../doc";
+import { Utils } from "../../utils";
+import { ICMCIApiResponse, IProgramParms, ITransactionParms, IURIMapParms, IGetResourceUriOptions } from "../../doc";
 
 /**
  * Discard a program installed in CICS through CMCI REST API
@@ -30,10 +31,14 @@ export async function discardProgram(session: AbstractSession, parms: IProgramPa
 
   Logger.getAppLogger().debug("Attempting to discard a program with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(PROGRAM=" + parms.name + ")";
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `PROGRAM=${parms.name}`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_PROGRAM_RESOURCE, options);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -53,10 +58,14 @@ export async function discardTransaction(session: AbstractSession, parms: ITrans
 
   Logger.getAppLogger().debug("Attempting to discard a transaction with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_LOCAL_TRANSACTION + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(TRANID=" + parms.name + ")";
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `(TRANID=${parms.name})`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_LOCAL_TRANSACTION, options);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }
 
@@ -66,9 +75,13 @@ export async function discardUrimap(session: AbstractSession, parms: IURIMapParm
 
   Logger.getAppLogger().debug("Attempting to discard a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME='${parms.name}')`;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `(NAME=${parms.name})`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_URIMAP, options);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []);
 }

--- a/packages/sdk/src/methods/enable/Enable.ts
+++ b/packages/sdk/src/methods/enable/Enable.ts
@@ -12,7 +12,8 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IURIMapParms } from "../../doc";
+import { Utils } from "../../utils";
+import { ICMCIApiResponse, IURIMapParms, IGetResourceUriOptions } from "../../doc";
 
 /**
  * Enable a URIMap installed in CICS through CMCI REST API
@@ -32,10 +33,14 @@ export async function enableUrimap(session: AbstractSession, parms: IURIMapParms
 
   Logger.getAppLogger().debug("Attempting to enable a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})`;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `NAME=${parms.name}`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_URIMAP, options);
+
   const requestBody: any = {
     request: {
       update: {

--- a/packages/sdk/src/methods/install/Install.ts
+++ b/packages/sdk/src/methods/install/Install.ts
@@ -12,7 +12,8 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms, IURIMapParms } from "../../doc";
+import { Utils } from "../../utils";
+import { ICMCIApiResponse, IProgramParms, IURIMapParms, IGetResourceUriOptions } from "../../doc";
 
 /**
  * Install a program definition to CICS through CMCI REST API
@@ -41,10 +42,15 @@ export function installProgram(session: AbstractSession, parms: IProgramParms): 
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_PROGRAM + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(NAME=" + parms.name + ")&PARAMETER=CSDGROUP(" + parms.csdGroup + ")";
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria":  `NAME=${parms.name}`,
+    "parameter": `CSDGROUP(${parms.csdGroup})`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_PROGRAM, options);
+
   return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }
 
@@ -75,10 +81,15 @@ export function installTransaction(session: AbstractSession, parms: IProgramParm
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_TRANSACTION + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(NAME=" + parms.name + ")&PARAMETER=CSDGROUP(" + parms.csdGroup + ")";
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria":  `NAME=${parms.name}`,
+    "parameter": `CSDGROUP(${parms.csdGroup})`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_TRANSACTION, options);
+
   return CicsCmciRestClient.putExpectParsedXml(session, cmciResource,
     [], requestBody) as any;
 }
@@ -102,10 +113,15 @@ export function installUrimap(session: AbstractSession, parms: IURIMapParms): Pr
 
   Logger.getAppLogger().debug("Attempting to install a URIMap with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_DEFINITION_URIMAP + "/" + cicsPlex +
-        `${parms.regionName}?CRITERIA=(NAME=${parms.name})&PARAMETER=CSDGROUP(${parms.csdGroup})`;
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria":  `NAME=${parms.name}`,
+    "parameter": `CSDGROUP(${parms.csdGroup})`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_URIMAP, options);
+
   const requestBody: any = {
     request: {
       action: {
@@ -115,5 +131,6 @@ export function installUrimap(session: AbstractSession, parms: IURIMapParms): Pr
       }
     }
   };
+
   return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/packages/sdk/src/methods/remove-from-list/RemoveFromList.ts
+++ b/packages/sdk/src/methods/remove-from-list/RemoveFromList.ts
@@ -12,7 +12,8 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, ICSDGroupParms } from "../../doc";
+import { Utils } from "../../utils";
+import { ICMCIApiResponse, ICSDGroupParms, IGetResourceUriOptions } from "../../doc";
 
 /**
  * Remove a CSD Group resource from a CSD List in CICS through CMCI REST API
@@ -31,9 +32,13 @@ export function removeCSDGroupFromList(session: AbstractSession, parms: ICSDGrou
 
   Logger.getAppLogger().debug("Attempting to remove a CSD Group from a CSD List with the following parameters:\n%s", JSON.stringify(parms));
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_CSDGROUP_IN_LIST + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(CSDLIST=='" + parms.csdList + "')%20AND%20(CSDGROUP=='" + parms.name + "')";
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `(CSDLIST=='${parms.csdList}') AND (CSDGROUP=='${parms.name}')`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_CSDGROUP_IN_LIST, options);
+
   return CicsCmciRestClient.deleteExpectParsedXml(session, cmciResource, []) as any;
 }

--- a/packages/sdk/src/methods/set/Set.ts
+++ b/packages/sdk/src/methods/set/Set.ts
@@ -12,7 +12,8 @@
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../rest";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IProgramParms } from "../../doc";
+import { Utils } from "../../utils";
+import { ICMCIApiResponse, IProgramParms, IGetResourceUriOptions } from "../../doc";
 
 /**
  * Refresh a program definition on CICS through CMCI REST API
@@ -39,9 +40,13 @@ export function programNewcopy(session: AbstractSession, parms: IProgramParms): 
     }
   };
 
-  const cicsPlex = parms.cicsPlex == null ? "" : parms.cicsPlex + "/";
-  const cmciResource = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" +
-        CicsCmciConstants.CICS_PROGRAM_RESOURCE + "/" + cicsPlex + parms.regionName +
-        "?CRITERIA=(PROGRAM=" + parms.name + ")";
+  const options: IGetResourceUriOptions = {
+    "cicsPlex": parms.cicsPlex,
+    "regionName": parms.regionName,
+    "criteria": `PROGRAM=${parms.name}`
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_PROGRAM_RESOURCE, options);
+
   return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }

--- a/packages/sdk/src/utils/Utils.ts
+++ b/packages/sdk/src/utils/Utils.ts
@@ -30,12 +30,10 @@ export class Utils {
 
     let delimiter = "?"; // initial delimiter
 
-    const cicsPlex = (options && options.cicsPlex) == null ? "" : options.cicsPlex + CicsCmciConstants.SEPERATOR;
+    const cicsPlex = (options && options.cicsPlex) == null ? "" : `${options.cicsPlex}/`;
     const region = (options && options.regionName) == null ? "" : options.regionName;
 
-    let cmciResource = CicsCmciConstants.SEPERATOR + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
-                      CicsCmciConstants.SEPERATOR + resourceName + CicsCmciConstants.SEPERATOR +
-                      cicsPlex + region;
+    let cmciResource = `/${CicsCmciConstants.CICS_SYSTEM_MANAGEMENT}/${resourceName}/${cicsPlex}${region}`;
 
     if (options != null) {
       if (options.criteria != null && options.criteria.length > 0) {

--- a/packages/sdk/src/utils/Utils.ts
+++ b/packages/sdk/src/utils/Utils.ts
@@ -1,0 +1,56 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { ImperativeExpect } from "@zowe/imperative";
+import { CicsCmciConstants } from "../constants";
+import { IGetResourceUriOptions } from "../doc";
+
+/**
+ * Class for providing static utility methods
+ * @export
+ * @class Utils
+ */
+export class Utils {
+
+  /**
+   * Get uri for requesting a resources in CICS through CMCI REST API
+   * @param {string} resourceName - CMCI resource name
+   * @param {IGetResourceUriOptions} options - CMCI resource options
+   */
+  public static getResourceUri(resourceName: string, options?: IGetResourceUriOptions) : string {
+    ImperativeExpect.toBeDefinedAndNonBlank(resourceName, "CICS Resource name", "CICS resource name is required");
+
+    let delimiter = "?"; // initial delimiter
+
+    const cicsPlex = (options && options.cicsPlex) == null ? "" : options.cicsPlex + CicsCmciConstants.SEPERATOR;
+    const region = (options && options.regionName) == null ? "" : options.regionName;
+
+    let cmciResource = CicsCmciConstants.SEPERATOR + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
+                      CicsCmciConstants.SEPERATOR + resourceName + CicsCmciConstants.SEPERATOR +
+                      cicsPlex + region;
+
+    if (options != null) {
+      if (options.criteria != null && options.criteria.length > 0) {
+        const addParentheses = options.criteria.charAt(0) !== '(';
+
+        cmciResource = cmciResource + delimiter + "CRITERIA=" + (addParentheses ? "(": "") +
+        encodeURIComponent(options.criteria) + (addParentheses ? ")": "") ;
+        delimiter = "&";
+      }
+
+      if (options.parameter != null && options.parameter.length > 0) {
+        cmciResource = cmciResource + delimiter + "PARAMETER=" + encodeURIComponent(options.parameter);
+      }
+    }
+
+    return cmciResource;
+  }
+}

--- a/packages/sdk/src/utils/index.ts
+++ b/packages/sdk/src/utils/index.ts
@@ -1,0 +1,12 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export * from "./Utils";


### PR DESCRIPTION
**What It Does**
Changed the getResource SDK method making the region name optional so we can now use this method to fetch any CICS resource, including regions and plexes.

This will allow us to migrate the remaining http requests in the VSCE to use the SDK, fixing the bug with rejectUnauthorized not being passed to all requests.

**How to Test**
Connect to a cicsplex and expand regions, have also added unit tests.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
Resolves #162
