### PR TITLE
Fix CICS connections breaking other ZE sessions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ root = true
 
 [*]
 indent_style = space
-indent_size = 4
+indent_size = 2
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/package-lock.json
+++ b/package-lock.json
@@ -3907,17 +3907,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
-      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -4669,6 +4660,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -4995,6 +4987,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6411,25 +6404,6 @@
       "deprecated": "flatten is deprecated in favor of utility frameworks such as lodash.",
       "dev": true
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/foreground-child": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.2.1.tgz",
@@ -6449,6 +6423,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -8777,6 +8752,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8785,6 +8761,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -10581,11 +10558,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -12873,7 +12845,6 @@
         "@zowe/cics-for-zowe-sdk": "6.2.4",
         "@zowe/core-for-zowe-sdk": "^8.0.0",
         "@zowe/zowe-explorer-api": "^3.0.3",
-        "axios": "^1.6.7",
         "xml-js": "~1.6.11"
       },
       "devDependencies": {

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 
 - BugFix: Updated commands to use Utils.getResourceURI. [#178](https://github.com/zowe/cics-for-zowe-client/issues/178)
 - BugFix: Regions icon updates when plex tree is expanded. [#194](https://github.com/zowe/cics-for-zowe-client/issues/194)
+- BugFix: Opening CICS connections prevents other Zowe sessions connecting. [#159](https://github.com/zowe/cics-for-zowe-client/issues/159)
 
 ## `3.2.3`
 

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -895,7 +895,6 @@
     "@zowe/cics-for-zowe-sdk": "6.2.4",
     "@zowe/core-for-zowe-sdk": "^8.0.0",
     "@zowe/zowe-explorer-api": "^3.0.3",
-    "axios": "^1.6.7",
     "xml-js": "~1.6.11"
   }
 }

--- a/packages/vsce/src/commands/ICommandParams.ts
+++ b/packages/vsce/src/commands/ICommandParams.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+/**
+ * Parameters passed to a command
+ */
+export interface ICommandParams {
+  /**
+   * Name of resource to find in filter
+   */
+  name: string;
+  /**
+   * Region Applid to perform action
+   */
+  regionName: string;
+  /**
+   * CICS Plex to perform action
+   */
+  cicsPlex: string;
+}

--- a/packages/vsce/src/commands/closeLocalFileCommand.ts
+++ b/packages/vsce/src/commands/closeLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -52,8 +51,6 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
-            https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
             try {
               await closeLocalFile(
                 currentNode.parentRegion.parentSession.session,
@@ -64,20 +61,17 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
                 },
                 busyDecision
               );
-              https.globalAgent.options.rejectUnauthorized = undefined;
               if (!parentRegions.includes(currentNode.parentRegion)) {
                 parentRegions.push(currentNode.parentRegion);
               }
             } catch (error) {
-              https.globalAgent.options.rejectUnauthorized = undefined;
               // @ts-ignore
               if (error.mMessage) {
                 // @ts-ignore
                 const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
 
                 window.showErrorMessage(
-                  `Perform CLOSE on local file "${
-                    allSelectedNodes[parseInt(index)].localFile.file
+                  `Perform CLOSE on local file "${allSelectedNodes[parseInt(index)].localFile.file
                   }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
                 );
               } else {
@@ -124,7 +118,7 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
 
 async function closeLocalFile(
   session: imperative.AbstractSession,
-  parms: { name: string; regionName: string; cicsPlex: string },
+  parms: { name: string; regionName: string; cicsPlex: string; },
   busyDecision: string
 ): Promise<ICMCIApiResponse> {
   const requestBody: any = {

--- a/packages/vsce/src/commands/closeLocalFileCommand.ts
+++ b/packages/vsce/src/commands/closeLocalFileCommand.ts
@@ -18,6 +18,7 @@ import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
 import { CICSCombinedLocalFileTree } from "../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
+import { ICommandParams } from "./ICommandParams";
 
 export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.closeLocalFile", async (clickedNode) => {
@@ -118,7 +119,7 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
 
 async function closeLocalFile(
   session: imperative.AbstractSession,
-  parms: { name: string; regionName: string; cicsPlex: string; },
+  parms: ICommandParams,
   busyDecision: string
 ): Promise<ICMCIApiResponse> {
   const requestBody: any = {

--- a/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
@@ -52,8 +52,6 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<an
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
-            https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
             try {
               await disableLocalFile(
                 currentNode.parentRegion.parentSession.session,
@@ -64,12 +62,10 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<an
                 },
                 busyDecision
               );
-              https.globalAgent.options.rejectUnauthorized = undefined;
               if (!parentRegions.includes(currentNode.parentRegion)) {
                 parentRegions.push(currentNode.parentRegion);
               }
             } catch (error) {
-              https.globalAgent.options.rejectUnauthorized = undefined;
               window.showErrorMessage(
                 `Something went wrong when performing a DISABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                   /(\\n\t|\\n|\\t)/gm,

--- a/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSLocalFileTreeItem } from "../../trees/treeItems/CICSLocalFileTreeItem";

--- a/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
@@ -18,6 +18,7 @@ import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSLocalFileTreeItem } from "../../trees/treeItems/CICSLocalFileTreeItem";
 import { CICSCombinedLocalFileTree } from "../../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
+import { ICommandParams } from "../ICommandParams";
 
 export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.disableLocalFile", async (clickedNode) => {
@@ -107,7 +108,7 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<an
 
 async function disableLocalFile(
   session: imperative.AbstractSession,
-  parms: { name: string; regionName: string; cicsPlex: string },
+  parms: ICommandParams,
   busyDecision: string
 ): Promise<ICMCIApiResponse> {
   const requestBody: any = {

--- a/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSProgramTreeItem } from "../../trees/treeItems/CICSProgramTreeItem";

--- a/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
@@ -18,6 +18,7 @@ import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSProgramTreeItem } from "../../trees/treeItems/CICSProgramTreeItem";
 import { CICSCombinedProgramTree } from "../../trees/CICSCombinedTrees/CICSCombinedProgramTree";
+import { ICommandParams } from "../ICommandParams";
 
 /**
  * Performs disable on selected CICSProgram nodes.
@@ -101,7 +102,7 @@ export function getDisableProgramCommand(tree: CICSTree, treeview: TreeView<any>
   });
 }
 
-function disableProgram(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string }): Promise<ICMCIApiResponse> {
+function disableProgram(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
@@ -50,7 +50,6 @@ export function getDisableProgramCommand(tree: CICSTree, treeview: TreeView<any>
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
           try {
             await disableProgram(currentNode.parentRegion.parentSession.session, {
@@ -58,12 +57,10 @@ export function getDisableProgramCommand(tree: CICSTree, treeview: TreeView<any>
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             window.showErrorMessage(
               `Something went wrong when performing a disable - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes, splitCmciErrorMessage } from "../../utils/commandUtils";
 import { CICSTransactionTreeItem } from "../../trees/treeItems/CICSTransactionTreeItem";

--- a/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
@@ -45,7 +45,6 @@ export function getDisableTransactionCommand(tree: CICSTree, treeview: TreeView<
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
           try {
             await disableTransaction(currentNode.parentRegion.parentSession.session, {
@@ -53,12 +52,10 @@ export function getDisableTransactionCommand(tree: CICSTree, treeview: TreeView<
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore

--- a/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
@@ -18,6 +18,7 @@ import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes, splitCmciErrorMessage } from "../../utils/commandUtils";
 import { CICSTransactionTreeItem } from "../../trees/treeItems/CICSTransactionTreeItem";
 import { CICSCombinedTransactionsTree } from "../../trees/CICSCombinedTrees/CICSCombinedTransactionTree";
+import { ICommandParams } from "../ICommandParams";
 
 export function getDisableTransactionCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.disableTransaction", async (clickedNode) => {
@@ -108,7 +109,7 @@ export function getDisableTransactionCommand(tree: CICSTree, treeview: TreeView<
 
 async function disableTransaction(
   session: imperative.AbstractSession,
-  parms: { name: string; regionName: string; cicsPlex: string }
+  parms: ICommandParams
 ): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {

--- a/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
@@ -18,6 +18,7 @@ import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSCombinedLocalFileTree } from "../../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
+import { ICommandParams } from "../ICommandParams";
 
 export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.enableLocalFile", async (clickedNode) => {
@@ -95,7 +96,7 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any
   });
 }
 
-async function enableLocalFile(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string }): Promise<ICMCIApiResponse> {
+async function enableLocalFile(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
@@ -45,7 +45,6 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
           try {
             await enableLocalFile(currentNode.parentRegion.parentSession.session, {
@@ -53,12 +52,10 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             window.showErrorMessage(
               `Something went wrong when performing an ENABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                 /(\\n\t|\\n|\\t)/gm,

--- a/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes } from "../../utils/commandUtils";

--- a/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
@@ -18,6 +18,7 @@ import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSCombinedProgramTree } from "../../trees/CICSCombinedTrees/CICSCombinedProgramTree";
+import { ICommandParams } from "../ICommandParams";
 
 /**
  * Performs enable on selected CICSProgram nodes.
@@ -99,7 +100,7 @@ export function getEnableProgramCommand(tree: CICSTree, treeview: TreeView<any>)
   });
 }
 
-async function enableProgram(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string; }): Promise<ICMCIApiResponse> {
+async function enableProgram(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes } from "../../utils/commandUtils";
@@ -50,20 +49,16 @@ export function getEnableProgramCommand(tree: CICSTree, treeview: TreeView<any>)
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await enableProgram(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             window.showErrorMessage(
               `Something went wrong when performing an ENABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                 /(\\n\t|\\n|\\t)/gm,
@@ -104,7 +99,7 @@ export function getEnableProgramCommand(tree: CICSTree, treeview: TreeView<any>)
   });
 }
 
-async function enableProgram(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string }): Promise<ICMCIApiResponse> {
+async function enableProgram(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string; }): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSTransactionTreeItem } from "../../trees/treeItems/CICSTransactionTreeItem";
@@ -46,7 +45,6 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
           try {
             await enableTransaction(currentNode.parentRegion.parentSession.session, {
@@ -54,12 +52,10 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             window.showErrorMessage(
               `Something went wrong when performing an ENABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                 /(\\n\t|\\n|\\t)/gm,
@@ -99,7 +95,7 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
   });
 }
 
-async function enableTransaction(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string }): Promise<ICMCIApiResponse> {
+async function enableTransaction(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string; }): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
@@ -18,6 +18,7 @@ import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSTransactionTreeItem } from "../../trees/treeItems/CICSTransactionTreeItem";
 import { CICSCombinedTransactionsTree } from "../../trees/CICSCombinedTrees/CICSCombinedTransactionTree";
+import { ICommandParams } from "../ICommandParams";
 
 export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.enableTransaction", async (clickedNode) => {
@@ -95,7 +96,7 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
   });
 }
 
-async function enableTransaction(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string; }): Promise<ICMCIApiResponse> {
+async function enableTransaction(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/newCopyCommand.ts
+++ b/packages/vsce/src/commands/newCopyCommand.ts
@@ -13,7 +13,6 @@ import { programNewcopy } from "@zowe/cics-for-zowe-sdk";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -49,28 +48,23 @@ export function getNewCopyCommand(tree: CICSTree, treeview: TreeView<any>) {
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await programNewcopy(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
             // CMCI new copy error
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore
               const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
               window.showErrorMessage(
-                `Perform NEWCOPY on Program "${
-                  allSelectedNodes[parseInt(index)].program.program
+                `Perform NEWCOPY on Program "${allSelectedNodes[parseInt(index)].program.program
                 }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
               );
             } else {

--- a/packages/vsce/src/commands/openLocalFileCommand.ts
+++ b/packages/vsce/src/commands/openLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -45,27 +44,22 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await openLocalFile(currentNode.parentRegion.parentSession.session, {
               name: currentNode.localFile.file,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore
               const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
               window.showErrorMessage(
-                `Perform OPEN on local file "${
-                  allSelectedNodes[parseInt(index)].localFile.file
+                `Perform OPEN on local file "${allSelectedNodes[parseInt(index)].localFile.file
                 }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
               );
             } else {
@@ -109,7 +103,7 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
   });
 }
 
-async function openLocalFile(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string }): Promise<ICMCIApiResponse> {
+async function openLocalFile(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string; }): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/openLocalFileCommand.ts
+++ b/packages/vsce/src/commands/openLocalFileCommand.ts
@@ -18,6 +18,7 @@ import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
 import { CICSCombinedLocalFileTree } from "../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
+import { ICommandParams } from "./ICommandParams";
 
 export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.openLocalFile", async (clickedNode) => {
@@ -103,7 +104,7 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
   });
 }
 
-async function openLocalFile(session: imperative.AbstractSession, parms: { name: string; regionName: string; cicsPlex: string; }): Promise<ICMCIApiResponse> {
+async function openLocalFile(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/phaseInCommand.ts
+++ b/packages/vsce/src/commands/phaseInCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -50,28 +49,23 @@ export function getPhaseInCommand(tree: CICSTree, treeview: TreeView<any>) {
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await performPhaseIn(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
 
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore
               const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
               window.showErrorMessage(
-                `Perform PHASEIN on Program "${
-                  allSelectedNodes[parseInt(index)].program.program
+                `Perform PHASEIN on Program "${allSelectedNodes[parseInt(index)].program.program
                 }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
               );
             } else {
@@ -116,7 +110,7 @@ export function getPhaseInCommand(tree: CICSTree, treeview: TreeView<any>) {
   });
 }
 
-async function performPhaseIn(session: imperative.AbstractSession, parms: { cicsPlex: string | null; regionName: string; name: string }) {
+async function performPhaseIn(session: imperative.AbstractSession, parms: { cicsPlex: string | null; regionName: string; name: string; }) {
   const requestBody: any = {
     request: {
       action: {

--- a/packages/vsce/src/commands/purgeTaskCommand.ts
+++ b/packages/vsce/src/commands/purgeTaskCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
 import { CICSTaskTreeItem } from "../trees/treeItems/CICSTaskTreeItem";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
@@ -55,8 +54,6 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
-            https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
             try {
               await purgeTask(
                 currentNode.parentRegion.parentSession.session,
@@ -67,19 +64,16 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
                 },
                 purgeType
               );
-              https.globalAgent.options.rejectUnauthorized = undefined;
               if (!parentRegions.includes(currentNode.parentRegion)) {
                 parentRegions.push(currentNode.parentRegion);
               }
             } catch (error) {
-              https.globalAgent.options.rejectUnauthorized = undefined;
               // @ts-ignore
               if (error.mMessage) {
                 // @ts-ignore
                 const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
                 window.showErrorMessage(
-                  `Perform ${purgeType?.toUpperCase()} on CICSTask "${
-                    allSelectedNodes[parseInt(index)].task.task
+                  `Perform ${purgeType?.toUpperCase()} on CICSTask "${allSelectedNodes[parseInt(index)].task.task
                   }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
                 );
               } else {
@@ -136,7 +130,7 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
  */
 async function purgeTask(
   session: imperative.AbstractSession,
-  parms: { name: string; regionName: string; cicsPlex: string },
+  parms: { name: string; regionName: string; cicsPlex: string; },
   purgeType: string
 ): Promise<ICMCIApiResponse> {
   const requestBody: any = {

--- a/packages/vsce/src/commands/purgeTaskCommand.ts
+++ b/packages/vsce/src/commands/purgeTaskCommand.ts
@@ -18,6 +18,7 @@ import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils"
 import { CICSTaskTreeItem } from "../trees/treeItems/CICSTaskTreeItem";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSCombinedTaskTree } from "../trees/CICSCombinedTrees/CICSCombinedTaskTree";
+import { ICommandParams } from "./ICommandParams";
 
 /**
  * Purge a CICS Task and reload the CICS Task tree contents and the combined Task tree contents
@@ -130,7 +131,7 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
  */
 async function purgeTask(
   session: imperative.AbstractSession,
-  parms: { name: string; regionName: string; cicsPlex: string; },
+  parms: ICommandParams,
   purgeType: string
 ): Promise<ICMCIApiResponse> {
   const requestBody: any = {

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLibraryTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLibraryTree.ts
@@ -66,7 +66,7 @@ export class CICSCombinedLibraryTree extends TreeItem {
           );
           if (cacheTokenInfo) {
             const recordsCount = cacheTokenInfo.recordCount;
-            if (parseInt(recordsCount, 10)) {
+            if (recordsCount) {
               let allLibraries;
               if (recordsCount <= this.incrementCount) {
                 allLibraries = await ProfileManagement.getCachedResources(
@@ -74,7 +74,7 @@ export class CICSCombinedLibraryTree extends TreeItem {
                   cacheTokenInfo.cacheToken,
                   this.constant,
                   1,
-                  parseInt(recordsCount, 10)
+                  recordsCount
                 );
               } else {
                 allLibraries = await ProfileManagement.getCachedResources(
@@ -84,7 +84,7 @@ export class CICSCombinedLibraryTree extends TreeItem {
                   1,
                   this.incrementCount
                 );
-                count = parseInt(recordsCount);
+                count = recordsCount;
               }
               this.addLibrariesUtil([], allLibraries, count);
               this.iconPath = getIconOpen(true);
@@ -153,7 +153,7 @@ export class CICSCombinedLibraryTree extends TreeItem {
         if (cacheTokenInfo) {
           // record count may have updated
           const recordsCount = cacheTokenInfo.recordCount;
-          const count = parseInt(recordsCount);
+          const count = recordsCount;
           const allLibraries = await ProfileManagement.getCachedResources(
             this.parentPlex.getProfile(),
             cacheTokenInfo.cacheToken,

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLocalFileTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLocalFileTree.ts
@@ -66,7 +66,7 @@ export class CICSCombinedLocalFileTree extends TreeItem {
           );
           if (cacheTokenInfo) {
             const recordsCount = cacheTokenInfo.recordCount;
-            if (parseInt(recordsCount, 10)) {
+            if (recordsCount) {
               let allLocalFiles;
               if (recordsCount <= this.incrementCount) {
                 allLocalFiles = await ProfileManagement.getCachedResources(
@@ -74,7 +74,7 @@ export class CICSCombinedLocalFileTree extends TreeItem {
                   cacheTokenInfo.cacheToken,
                   this.constant,
                   1,
-                  parseInt(recordsCount, 10)
+                  recordsCount
                 );
               } else {
                 allLocalFiles = await ProfileManagement.getCachedResources(
@@ -84,7 +84,7 @@ export class CICSCombinedLocalFileTree extends TreeItem {
                   1,
                   this.incrementCount
                 );
-                count = parseInt(recordsCount);
+                count = recordsCount;
               }
               this.addLocalFilesUtil([], allLocalFiles, count);
               this.iconPath = getIconOpen(true);
@@ -148,7 +148,7 @@ export class CICSCombinedLocalFileTree extends TreeItem {
         if (cacheTokenInfo) {
           // record count may have updated
           const recordsCount = cacheTokenInfo.recordCount;
-          const count = parseInt(recordsCount);
+          const count = recordsCount;
           const allLocalFiles = await ProfileManagement.getCachedResources(
             this.parentPlex.getProfile(),
             cacheTokenInfo.cacheToken,

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedPipelineTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedPipelineTree.ts
@@ -66,7 +66,7 @@ export class CICSCombinedPipelineTree extends TreeItem {
           );
           if (cacheTokenInfo) {
             const recordsCount = cacheTokenInfo.recordCount;
-            if (parseInt(recordsCount, 10)) {
+            if (recordsCount) {
               let allPipelines;
               if (recordsCount <= this.incrementCount) {
                 allPipelines = await ProfileManagement.getCachedResources(
@@ -74,7 +74,7 @@ export class CICSCombinedPipelineTree extends TreeItem {
                   cacheTokenInfo.cacheToken,
                   this.constant,
                   1,
-                  parseInt(recordsCount, 10)
+                  recordsCount
                 );
               } else {
                 allPipelines = await ProfileManagement.getCachedResources(
@@ -84,7 +84,7 @@ export class CICSCombinedPipelineTree extends TreeItem {
                   1,
                   this.incrementCount
                 );
-                count = parseInt(recordsCount);
+                count = recordsCount;
               }
               this.addPipelinesUtil([], allPipelines, count);
               this.iconPath = getIconOpen(true);
@@ -153,7 +153,7 @@ export class CICSCombinedPipelineTree extends TreeItem {
         if (cacheTokenInfo) {
           // record count may have updated
           const recordsCount = cacheTokenInfo.recordCount;
-          const count = parseInt(recordsCount);
+          const count = recordsCount;
           const allPipelines = await ProfileManagement.getCachedResources(
             this.parentPlex.getProfile(),
             cacheTokenInfo.cacheToken,

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedProgramTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedProgramTree.ts
@@ -20,7 +20,7 @@ import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconOpen } from "../../utils/profileUtils";
+import { getIconOpen, getIconPathInResources } from "../../utils/profileUtils";
 import { imperative } from "@zowe/zowe-explorer-api";
 
 export class CICSCombinedProgramTree extends TreeItem {

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedProgramTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedProgramTree.ts
@@ -21,6 +21,7 @@ import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen } from "../../utils/profileUtils";
+import { imperative } from "@zowe/zowe-explorer-api";
 
 export class CICSCombinedProgramTree extends TreeItem {
   children: (CICSProgramTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -49,9 +50,8 @@ export class CICSCombinedProgramTree extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the load");
-        });
+        token.onCancellationRequested(() => { });
+        let recordsCount: number;
         try {
           let criteria;
           if (this.activeFilter) {
@@ -66,8 +66,8 @@ export class CICSCombinedProgramTree extends TreeItem {
             this.getParent().getGroupName()
           );
           if (cacheTokenInfo) {
-            const recordsCount = cacheTokenInfo.recordCount;
-            if (parseInt(recordsCount, 10)) {
+            recordsCount = cacheTokenInfo.recordCount;
+            if (recordsCount) {
               let allPrograms;
               if (recordsCount <= this.incrementCount) {
                 allPrograms = await ProfileManagement.getCachedResources(
@@ -75,7 +75,7 @@ export class CICSCombinedProgramTree extends TreeItem {
                   cacheTokenInfo.cacheToken,
                   this.constant,
                   1,
-                  parseInt(recordsCount, 10)
+                  recordsCount
                 );
               } else {
                 allPrograms = await ProfileManagement.getCachedResources(
@@ -85,7 +85,7 @@ export class CICSCombinedProgramTree extends TreeItem {
                   1,
                   this.incrementCount
                 );
-                count = parseInt(recordsCount);
+                count = recordsCount;
               }
               this.addProgramsUtil([], allPrograms, count);
               this.iconPath = getIconOpen(true);
@@ -99,12 +99,20 @@ export class CICSCombinedProgramTree extends TreeItem {
             }
           }
         } catch (error) {
-          window.showErrorMessage(
-            `Something went wrong when fetching programs - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
-              /(\\n\t|\\n|\\t)/gm,
-              " "
-            )}`
-          );
+          if (error instanceof imperative.ImperativeError && error.mDetails.msg.includes("NOTAVAILABLE")) {
+            this.children = [];
+            this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+            tree._onDidChangeTreeData.fire(undefined);
+            window.showInformationMessage(`No programs found`);
+            this.label = `All Programs${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;
+          } else {
+            window.showErrorMessage(
+              `Something went wrong when fetching programs - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
+                /(\\n\t|\\n|\\t)/gm,
+                " "
+              )}`
+            );
+          }
         }
       }
     );
@@ -155,7 +163,7 @@ export class CICSCombinedProgramTree extends TreeItem {
         if (cacheTokenInfo) {
           // record count may have updated
           const recordsCount = cacheTokenInfo.recordCount;
-          const count = parseInt(recordsCount);
+          const count = recordsCount;
           const allPrograms = await ProfileManagement.getCachedResources(
             this.parentPlex.getProfile(),
             cacheTokenInfo.cacheToken,

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTCPIPServiceTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTCPIPServiceTree.ts
@@ -48,9 +48,7 @@ export class CICSCombinedTCPIPServiceTree extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the load");
-        });
+        token.onCancellationRequested(() => { });
         try {
           let criteria;
           if (this.activeFilter) {
@@ -66,7 +64,7 @@ export class CICSCombinedTCPIPServiceTree extends TreeItem {
           );
           if (cacheTokenInfo) {
             const recordsCount = cacheTokenInfo.recordCount;
-            if (parseInt(recordsCount, 10)) {
+            if (recordsCount) {
               let allTCPIPS;
               if (recordsCount <= this.incrementCount) {
                 allTCPIPS = await ProfileManagement.getCachedResources(
@@ -74,7 +72,7 @@ export class CICSCombinedTCPIPServiceTree extends TreeItem {
                   cacheTokenInfo.cacheToken,
                   this.constant,
                   1,
-                  parseInt(recordsCount, 10)
+                  recordsCount
                 );
               } else {
                 allTCPIPS = await ProfileManagement.getCachedResources(
@@ -84,7 +82,7 @@ export class CICSCombinedTCPIPServiceTree extends TreeItem {
                   1,
                   this.incrementCount
                 );
-                count = parseInt(recordsCount);
+                count = recordsCount;
               }
               this.addTCPIPSUtil([], allTCPIPS, count);
               this.iconPath = getIconOpen(true);
@@ -156,7 +154,7 @@ export class CICSCombinedTCPIPServiceTree extends TreeItem {
         if (cacheTokenInfo) {
           // record count may have updated
           const recordsCount = cacheTokenInfo.recordCount;
-          const count = parseInt(recordsCount);
+          const count = recordsCount;
           const allTCPIPS = await ProfileManagement.getCachedResources(
             this.parentPlex.getProfile(),
             cacheTokenInfo.cacheToken,

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTaskTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTaskTree.ts
@@ -48,9 +48,7 @@ export class CICSCombinedTaskTree extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the load");
-        });
+        token.onCancellationRequested(() => { });
         try {
           let criteria;
           if (this.activeFilter) {
@@ -66,7 +64,7 @@ export class CICSCombinedTaskTree extends TreeItem {
           );
           if (cacheTokenInfo) {
             const recordsCount = cacheTokenInfo.recordCount;
-            if (parseInt(recordsCount, 10)) {
+            if (recordsCount) {
               let allTasks;
               if (recordsCount <= this.incrementCount) {
                 allTasks = await ProfileManagement.getCachedResources(
@@ -74,7 +72,7 @@ export class CICSCombinedTaskTree extends TreeItem {
                   cacheTokenInfo.cacheToken,
                   this.constant,
                   1,
-                  parseInt(recordsCount, 10)
+                  recordsCount
                 );
               } else {
                 allTasks = await ProfileManagement.getCachedResources(
@@ -84,7 +82,7 @@ export class CICSCombinedTaskTree extends TreeItem {
                   1,
                   this.incrementCount
                 );
-                count = parseInt(recordsCount);
+                count = recordsCount;
               }
               this.addTasksUtil([], allTasks, count);
               this.iconPath = getIconOpen(true);
@@ -153,7 +151,7 @@ export class CICSCombinedTaskTree extends TreeItem {
         if (cacheTokenInfo) {
           // record count may have updated
           const recordsCount = cacheTokenInfo.recordCount;
-          const count = parseInt(recordsCount);
+          const count = recordsCount;
           const allTasks = await ProfileManagement.getCachedResources(
             this.parentPlex.getProfile(),
             cacheTokenInfo.cacheToken,

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTransactionTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTransactionTree.ts
@@ -67,7 +67,7 @@ export class CICSCombinedTransactionsTree extends TreeItem {
           );
           if (cacheTokenInfo) {
             const recordsCount = cacheTokenInfo.recordCount;
-            if (parseInt(recordsCount, 10)) {
+            if (recordsCount) {
               let allLocalTransactions;
               if (recordsCount <= this.incrementCount) {
                 allLocalTransactions = await ProfileManagement.getCachedResources(
@@ -75,7 +75,7 @@ export class CICSCombinedTransactionsTree extends TreeItem {
                   cacheTokenInfo.cacheToken,
                   this.constant,
                   1,
-                  parseInt(recordsCount, 10)
+                  recordsCount
                 );
               } else {
                 allLocalTransactions = await ProfileManagement.getCachedResources(
@@ -85,7 +85,7 @@ export class CICSCombinedTransactionsTree extends TreeItem {
                   1,
                   this.incrementCount
                 );
-                count = parseInt(recordsCount);
+                count = recordsCount;
               }
               this.addLocalTransactionsUtil([], allLocalTransactions, count);
               this.iconPath = getIconOpen(true);
@@ -149,7 +149,7 @@ export class CICSCombinedTransactionsTree extends TreeItem {
         if (cacheTokenInfo) {
           // record count may have updated
           const recordsCount = cacheTokenInfo.recordCount;
-          const count = parseInt(recordsCount);
+          const count = recordsCount;
           const allLocalTransactions = await ProfileManagement.getCachedResources(
             this.parentPlex.getProfile(),
             cacheTokenInfo.cacheToken,

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedURIMapTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedURIMapTree.ts
@@ -48,9 +48,7 @@ export class CICSCombinedURIMapTree extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the load");
-        });
+        token.onCancellationRequested(() => { });
         try {
           let criteria;
           if (this.activeFilter) {
@@ -66,7 +64,7 @@ export class CICSCombinedURIMapTree extends TreeItem {
           );
           if (cacheTokenInfo) {
             const recordsCount = cacheTokenInfo.recordCount;
-            if (parseInt(recordsCount, 10)) {
+            if (recordsCount) {
               let allURIMaps;
               if (recordsCount <= this.incrementCount) {
                 allURIMaps = await ProfileManagement.getCachedResources(
@@ -74,7 +72,7 @@ export class CICSCombinedURIMapTree extends TreeItem {
                   cacheTokenInfo.cacheToken,
                   this.constant,
                   1,
-                  parseInt(recordsCount, 10)
+                  recordsCount
                 );
               } else {
                 allURIMaps = await ProfileManagement.getCachedResources(
@@ -84,7 +82,7 @@ export class CICSCombinedURIMapTree extends TreeItem {
                   1,
                   this.incrementCount
                 );
-                count = parseInt(recordsCount);
+                count = recordsCount;
               }
               this.addURIMapsUtil([], allURIMaps, count);
               this.iconPath = getIconOpen(true);
@@ -158,7 +156,7 @@ export class CICSCombinedURIMapTree extends TreeItem {
         if (cacheTokenInfo) {
           // record count may have updated
           const recordsCount = cacheTokenInfo.recordCount;
-          const count = parseInt(recordsCount);
+          const count = recordsCount;
           const allURIMaps = await ProfileManagement.getCachedResources(
             this.parentPlex.getProfile(),
             cacheTokenInfo.cacheToken,

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedWebServiceTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedWebServiceTree.ts
@@ -48,9 +48,7 @@ export class CICSCombinedWebServiceTree extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the load");
-        });
+        token.onCancellationRequested(() => { });
         try {
           let criteria;
           if (this.activeFilter) {
@@ -66,7 +64,7 @@ export class CICSCombinedWebServiceTree extends TreeItem {
           );
           if (cacheTokenInfo) {
             const recordsCount = cacheTokenInfo.recordCount;
-            if (parseInt(recordsCount, 10)) {
+            if (recordsCount) {
               let allWebServices;
               if (recordsCount <= this.incrementCount) {
                 allWebServices = await ProfileManagement.getCachedResources(
@@ -74,7 +72,7 @@ export class CICSCombinedWebServiceTree extends TreeItem {
                   cacheTokenInfo.cacheToken,
                   this.constant,
                   1,
-                  parseInt(recordsCount, 10)
+                  recordsCount
                 );
               } else {
                 allWebServices = await ProfileManagement.getCachedResources(
@@ -84,7 +82,7 @@ export class CICSCombinedWebServiceTree extends TreeItem {
                   1,
                   this.incrementCount
                 );
-                count = parseInt(recordsCount);
+                count = recordsCount;
               }
               this.addWebServicesUtil([], allWebServices, count);
               this.iconPath = getIconOpen(true);
@@ -154,7 +152,7 @@ export class CICSCombinedWebServiceTree extends TreeItem {
         if (cacheTokenInfo) {
           // record count may have updated
           const recordsCount = cacheTokenInfo.recordCount;
-          const count = parseInt(recordsCount);
+          const count = recordsCount;
           const allWebServices = await ProfileManagement.getCachedResources(
             this.parentPlex.getProfile(),
             cacheTokenInfo.cacheToken,

--- a/packages/vsce/src/trees/CICSPlexTree.ts
+++ b/packages/vsce/src/trees/CICSPlexTree.ts
@@ -71,14 +71,12 @@ export class CICSPlexTree extends TreeItem {
    */
   public async loadOnlyRegion() {
     const plexProfile = this.getProfile();
-    https.globalAgent.options.rejectUnauthorized = plexProfile.profile.rejectUnauthorized;
     const session = this.getParent().getSession();
     const regionsObtained = await getResource(session, {
       name: "CICSRegion",
       cicsPlex: plexProfile.profile.cicsPlex,
       regionName: plexProfile.profile.regionName,
     });
-    https.globalAgent.options.rejectUnauthorized = undefined;
     const newRegionTree = new CICSRegionTree(
       plexProfile.profile.regionName,
       regionsObtained.response.records.cicsregion,

--- a/packages/vsce/src/trees/CICSPlexTree.ts
+++ b/packages/vsce/src/trees/CICSPlexTree.ts
@@ -14,7 +14,6 @@ import { CICSRegionTree } from "./CICSRegionTree";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { CICSSessionTree } from "./CICSSessionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { CICSCombinedProgramTree } from "./CICSCombinedTrees/CICSCombinedProgramTree";
 import { CICSCombinedTransactionsTree } from "./CICSCombinedTrees/CICSCombinedTransactionTree";
 import { CICSCombinedLocalFileTree } from "./CICSCombinedTrees/CICSCombinedLocalFileTree";

--- a/packages/vsce/src/trees/CICSRegionsContainer.ts
+++ b/packages/vsce/src/trees/CICSRegionsContainer.ts
@@ -89,11 +89,12 @@ export class CICSRegionsContainer extends TreeItem {
    * Count the number of total and active regions
    * @param regionsArray
    */
-  private addRegionsUtility(regionsArray: [any]) {
+  private addRegionsUtility(regionsArray: any[]) {
     let activeCount = 0;
     let totalCount = 0;
     const parentPlex = this.getParent();
-    const regionFilterRegex = this.activeFilter ? new RegExp(this.patternIntoRegex(this.activeFilter)) : ""; //parentPlex.getActiveFilter() ? RegExp(parentPlex.getActiveFilter()!) : undefined;
+    //parentPlex.getActiveFilter() ? RegExp(parentPlex.getActiveFilter()!) : undefined;
+    const regionFilterRegex = this.activeFilter ? new RegExp(this.patternIntoRegex(this.activeFilter)) : "";
     for (const region of regionsArray) {
       // If region filter exists then match it
       if (!regionFilterRegex || region.cicsname.match(regionFilterRegex)) {

--- a/packages/vsce/src/trees/CICSRegionsContainer.ts
+++ b/packages/vsce/src/trees/CICSRegionsContainer.ts
@@ -16,7 +16,7 @@ import { CICSTree } from "./CICSTree";
 import { ProfileManagement } from "../utils/profileManagement";
 import { getIconOpen } from "../utils/profileUtils";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
+import { toArray } from "../utils/commandUtils";
 
 export class CICSRegionsContainer extends TreeItem {
   children: CICSRegionTree[];
@@ -61,18 +61,14 @@ export class CICSRegionsContainer extends TreeItem {
   public async loadRegionsInCICSGroup(tree: CICSTree) {
     const parentPlex = this.getParent();
     const plexProfile = parentPlex.getProfile();
-    https.globalAgent.options.rejectUnauthorized = plexProfile.profile.rejectUnauthorized;
     const session = parentPlex.getParent().getSession();
     const regionsObtained = await getResource(session, {
       name: "CICSManagedRegion",
       cicsPlex: plexProfile.profile.cicsPlex,
       regionName: plexProfile.profile.regionName,
     });
-    https.globalAgent.options.rejectUnauthorized = undefined;
     this.clearChildren();
-    const regionsArray = Array.isArray(regionsObtained.response.records.cicsmanagedregion)
-      ? regionsObtained.response.records.cicsmanagedregion
-      : [regionsObtained.response.records.cicsmanagedregion];
+    const regionsArray = toArray(regionsObtained.response.records.cicsmanagedregion);
     this.addRegionsUtility(regionsArray);
     // Keep container open after label change
     this.collapsibleState = TreeItemCollapsibleState.Expanded;

--- a/packages/vsce/src/trees/CICSTree.ts
+++ b/packages/vsce/src/trees/CICSTree.ts
@@ -27,7 +27,6 @@ import { isTheia, openConfigFile } from "../utils/workspaceUtils";
 import { CICSPlexTree } from "./CICSPlexTree";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { CICSSessionTree } from "./CICSSessionTree";
-import * as https from "https";
 import { getIconPathInResources, missingSessionParameters, promptCredentials } from "../utils/profileUtils";
 import { Gui, imperative } from "@zowe/zowe-explorer-api";
 
@@ -215,15 +214,12 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
                 protocol: profile.profile.protocol,
               });
               try {
-                https.globalAgent.options.rejectUnauthorized = profile.profile.rejectUnauthorized;
-
                 const regionsObtained = await getResource(session, {
                   name: "CICSRegion",
                   regionName: item.regions[0].applid,
                 });
                 // 200 OK received
                 newSessionTree.setAuthorized();
-                https.globalAgent.options.rejectUnauthorized = undefined;
                 const newRegionTree = new CICSRegionTree(
                   item.regions[0].applid,
                   regionsObtained.response.records.cicsregion,
@@ -233,7 +229,6 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
                 );
                 newSessionTree.addRegion(newRegionTree);
               } catch (error) {
-                https.globalAgent.options.rejectUnauthorized = undefined;
                 console.log(error);
               }
             } else {
@@ -260,7 +255,6 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
           }
           this._onDidChangeTreeData.fire(undefined);
         } catch (error) {
-          https.globalAgent.options.rejectUnauthorized = undefined;
           // Change session tree icon to disconnected upon error
           newSessionTree = new CICSSessionTree(profile, getIconPathInResources("profile-disconnected-dark.svg", "profile-disconnected-light.svg"));
           // If method was called when expanding profile

--- a/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
+++ b/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
@@ -66,8 +66,7 @@ export class CICSLibraryTreeItem extends TreeItem {
         criteria: criteria,
       });
       const datasetArray = toArray(libraryResponse.response.records.cicslibrarydatasetname);
-      this.label = `${this.library.name}${this.parentRegion.parentPlex ? ` (${this.library.eyu_cicsname})` : ""}${this.activeFilter ? ` (${this.activeFilter}) ` : " "
-        }[${datasetArray.length}]`;
+      this.label = this.buildLabel(datasetArray);
       for (const dataset of datasetArray) {
         const newDatasetItem = new CICSLibraryDatasets(dataset, this.parentRegion, this); //this=CICSLibraryTreeItem
         this.addDataset(newDatasetItem);
@@ -78,9 +77,7 @@ export class CICSLibraryTreeItem extends TreeItem {
         window.showErrorMessage(`Resource Limit Exceeded - Set a datasets filter to narrow search`);
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No datasets found`);
-        this.label = `${this.library.name}${this.parentRegion.parentPlex ? ` (${this.library.eyu_cicsname})` : ""}${
-          this.activeFilter ? ` (${this.activeFilter}) ` : " "
-        }[0]`;
+        this.label = this.buildLabel([]);
         this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
@@ -91,6 +88,16 @@ export class CICSLibraryTreeItem extends TreeItem {
         );
       }
     }
+  }
+
+  private buildLabel(arr?: any[]) {
+    let labelContent = this.library.name;
+    labelContent += this.parentRegion.parentPlex ? ` (${this.library.eyu_cicsname})` : "";
+    labelContent += this.activeFilter ? ` (${this.activeFilter}) ` : " ";
+    if (arr) {
+      labelContent += `[${arr.length}]`;
+    }
+    return labelContent;
   }
 
   public clearFilter() {

--- a/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
@@ -15,6 +15,7 @@ import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconOpen } from "../../../utils/profileUtils";
+import { toArray } from "../../../utils/commandUtils";
 
 export class CICSPipelineTree extends TreeItem {
   children: CICSPipelineTreeItem[] = [];

--- a/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSPipelineTreeItem } from "./treeItems/CICSPipelineTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconOpen } from "../../../utils/profileUtils";
 
@@ -42,7 +41,6 @@ export class CICSPipelineTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const pipelineResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSPipeline",
@@ -50,10 +48,7 @@ export class CICSPipelineTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const pipelinesArray = Array.isArray(pipelineResponse.response.records.cicspipeline)
-        ? pipelineResponse.response.records.cicspipeline
-        : [pipelineResponse.response.records.cicspipeline];
+      const pipelinesArray = toArray(pipelineResponse.response.records.cicspipeline);
       this.label = `Pipelines${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${pipelinesArray.length}]`;
       for (const pipeline of pipelinesArray) {
         const newPipelineItem = new CICSPipelineTreeItem(pipeline, this.parentRegion, this);
@@ -62,7 +57,6 @@ export class CICSPipelineTree extends TreeItem {
       }
       this.iconPath = getIconOpen(true);
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a Pipeline filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
@@ -15,6 +15,7 @@ import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconOpen } from "../../../utils/profileUtils";
+import { toArray } from "../../../utils/commandUtils";
 
 export class CICSTCPIPServiceTree extends TreeItem {
   children: CICSTCPIPServiceTreeItem[] = [];

--- a/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSTCPIPServiceTreeItem } from "./treeItems/CICSTCPIPServiceTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconOpen } from "../../../utils/profileUtils";
 
@@ -42,7 +41,6 @@ export class CICSTCPIPServiceTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const tcpipsResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSTCPIPService",
@@ -50,10 +48,7 @@ export class CICSTCPIPServiceTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const tcpipservicesArray = Array.isArray(tcpipsResponse.response.records.cicstcpipservice)
-        ? tcpipsResponse.response.records.cicstcpipservice
-        : [tcpipsResponse.response.records.cicstcpipservice];
+      const tcpipservicesArray = toArray(tcpipsResponse.response.records.cicstcpipservice);
       this.label = `TCPIP Services${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${tcpipservicesArray.length}]`;
       for (const tcpips of tcpipservicesArray) {
         const newTCPIPServiceItem = new CICSTCPIPServiceTreeItem(tcpips, this.parentRegion, this);
@@ -64,7 +59,6 @@ export class CICSTCPIPServiceTree extends TreeItem {
       }
       this.iconPath = getIconOpen(true);
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a TCPIPService filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
@@ -15,6 +15,7 @@ import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconOpen } from "../../../utils/profileUtils";
+import { toArray } from "../../../utils/commandUtils";
 
 export class CICSURIMapTree extends TreeItem {
   children: CICSURIMapTreeItem[] = [];

--- a/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSURIMapTreeItem } from "./treeItems/CICSURIMapTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconOpen } from "../../../utils/profileUtils";
 
@@ -42,7 +41,6 @@ export class CICSURIMapTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const urimapResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSURIMap",
@@ -50,10 +48,7 @@ export class CICSURIMapTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const urimapArray = Array.isArray(urimapResponse.response.records.cicsurimap)
-        ? urimapResponse.response.records.cicsurimap
-        : [urimapResponse.response.records.cicsurimap];
+      const urimapArray = toArray(urimapResponse.response.records.cicsurimap);
       this.label = `URI Maps${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${urimapArray.length}]`;
       for (const urimap of urimapArray) {
         const newURIMapItem = new CICSURIMapTreeItem(urimap, this.parentRegion, this);
@@ -64,7 +59,6 @@ export class CICSURIMapTree extends TreeItem {
       }
       this.iconPath = getIconOpen(true);
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a URIMap filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
@@ -15,6 +15,7 @@ import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconOpen } from "../../../utils/profileUtils";
+import { toArray } from "../../../utils/commandUtils";
 
 export class CICSWebServiceTree extends TreeItem {
   children: CICSWebServiceTreeItem[] = [];

--- a/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSWebServiceTreeItem } from "./treeItems/CICSWebServiceTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconOpen } from "../../../utils/profileUtils";
 
@@ -42,7 +41,6 @@ export class CICSWebServiceTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
 
       const webserviceResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSWebService",
@@ -50,10 +48,7 @@ export class CICSWebServiceTree extends TreeItem {
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-      const webservicesArray = Array.isArray(webserviceResponse.response.records.cicswebservice)
-        ? webserviceResponse.response.records.cicswebservice
-        : [webserviceResponse.response.records.cicswebservice];
+      const webservicesArray = toArray(webserviceResponse.response.records.cicswebservice);
       this.label = `Web Services${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${webservicesArray.length}]`;
       for (const webservice of webservicesArray) {
         const newWebServiceItem = new CICSWebServiceTreeItem(webservice, this.parentRegion, this);
@@ -62,7 +57,6 @@ export class CICSWebServiceTree extends TreeItem {
       }
       this.iconPath = getIconOpen(true);
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a Web Services filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/utils/commandUtils.ts
+++ b/packages/vsce/src/utils/commandUtils.ts
@@ -62,3 +62,7 @@ export function splitCmciErrorMessage(message: any) {
   }
   return [resp, resp2, respAlt, eibfnAlt];
 }
+
+export function toArray<T>(input: T | [T]): [T] {
+  return Array.isArray(input) ? input : [input];
+}

--- a/packages/vsce/src/utils/profileManagement.ts
+++ b/packages/vsce/src/utils/profileManagement.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { getCache, getResource, ICMCIApiResponse } from "@zowe/cics-for-zowe-sdk";
+import { getCache, getResource } from "@zowe/cics-for-zowe-sdk";
 import { Session } from "@zowe/imperative";
 import { imperative, Types, ZoweVsCodeExtension } from "@zowe/zowe-explorer-api";
 import { window } from "vscode";
@@ -71,14 +71,17 @@ export class ProfileManagement {
 
   public static async regionIsGroup(session: Session, profile: imperative.IProfile): Promise<boolean> {
 
-    let checkIfSystemGroup: ICMCIApiResponse;
+    let isGroup = false;
     try {
-      checkIfSystemGroup = await getResource(session, {
+      const checkIfSystemGroup = await getResource(session, {
         name: "CICSRegionGroup",
         cicsPlex: profile.cicsPlex,
         regionName: profile.regionName,
         criteria: `GROUP=${profile.regionName}`,
       });
+      if (checkIfSystemGroup && checkIfSystemGroup.response.resultsummary.recordcount !== "0") {
+        isGroup = true;
+      }
     } catch (error) {
       if (error instanceof imperative.ImperativeError) {
         if (!error.mDetails.msg.toUpperCase().includes("NODATA")) {
@@ -87,7 +90,7 @@ export class ProfileManagement {
       }
     }
 
-    return checkIfSystemGroup?.response.resultsummary.recordcount !== "0";
+    return isGroup;
   }
 
   public static async isPlex(session: Session): Promise<string | null> {


### PR DESCRIPTION
**What It Does**
- Changes method of pulling data from CMCI from Axios HTTP requests to the CICS SDK's getResource and getCache methods
  - Removes makeRequest method - refactored response handling
  - Refactored getPlexInfo method into smaller methods depending on what's provided in the profile
- Removes the global rejectUnauthorized overrides which broke the other ZE sessions
- Created toArray utility to replace all cases where we had to do a Array.isArray check

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
Resolves #159
Resolves #124