### PR TITLE
Fixing issue in 3.1.0 due to SSH2 external dep.

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
+
+## Recent Changes
+
+ - BugFix: CICS extension 3.1.0 will not load correctly. [#174](https://github.com/zowe/cics-for-zowe-client/issues/174)
+
 ## `3.0.2`
 
 - BugFix: Correcting condition to read team configuration file. [#160](https://github.com/zowe/cics-for-zowe-client/pull/160)

--- a/packages/vsce/tsup.config.json
+++ b/packages/vsce/tsup.config.json
@@ -8,8 +8,7 @@
   "format": "cjs",
   "dts": true,
   "external": [
-    "vscode",
-    "ssh2"
+    "vscode"
   ],
   "minify": "terser",
   "noExternal": []


### PR DESCRIPTION
**What It Does**
The PR https://github.com/zowe/cics-for-zowe-client/pull/165 marks SSH2 as an external dependency for tsup. This breaks the CICS extension - reverting for now.

**How to Test**
Created the vsix package, which I then installed and tested manually.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
Resolves #174 
