### PR TITLE
Change criteria bracketing behaviour

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Change getResource criteria bracketing behaviour. [#180](https://github.com/zowe/cics-for-zowe-client/issues/180)
+
 ## `6.2.0`
 
 - Enhancement: Add optional query parameters on getResource SDK method. [#168](https://github.com/zowe/cics-for-zowe-client/issues/168)

--- a/packages/sdk/__tests__/__unit__/utils/Utils.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/utils/Utils.unit.test.ts
@@ -398,12 +398,12 @@ describe('Utils - enforceParentheses', () => {
 
   it("should add first bracket when end exists", () => {
     const output = Utils.enforceParentheses("input with spaces)");
-    expect(output).toEqual("(input with spaces)");
+    expect(output).toEqual("(input with spaces))");
   });
 
   it("should add last bracket when first exists", () => {
     const output = Utils.enforceParentheses("(input with spec1@| characters");
-    expect(output).toEqual("(input with spec1@| characters)");
+    expect(output).toEqual("(input with spec1@| characters");
   });
 
   it("should do nothing when both brackets exist", () => {
@@ -414,6 +414,11 @@ describe('Utils - enforceParentheses', () => {
   it("should do nothing when multiple brackets exist", () => {
     const output = Utils.enforceParentheses("((()))");
     expect(output).toEqual("((()))");
+  });
+
+  it("should add appropriate brackets", () => {
+    const output = Utils.enforceParentheses("NOT (PROGRAM=CEE* OR PROGRAM=DFH* OR PROGRAM=CJ* OR PROGRAM=EYU* OR PROGRAM=CSQ* OR PROGRAM=CEL* OR PROGRAM=IGZ*)");
+    expect(output).toEqual("(NOT (PROGRAM=CEE* OR PROGRAM=DFH* OR PROGRAM=CJ* OR PROGRAM=EYU* OR PROGRAM=CSQ* OR PROGRAM=CEL* OR PROGRAM=IGZ*))");
   });
 });
 

--- a/packages/sdk/src/utils/Utils.ts
+++ b/packages/sdk/src/utils/Utils.ts
@@ -93,13 +93,6 @@ export class Utils {
   }
 
   public static enforceParentheses(input: string): string {
-    if (!input.startsWith('(') && !input.endsWith(')')) {
-      return `(${input})`;
-    } else if (input.startsWith('(') && !input.endsWith(')')) {
-      return `${input})`;
-    } else if (!input.startsWith('(') && input.endsWith(')')) {
-      return `(${input}`;
-    }
-    return input;
+    return input.startsWith("(") ? input : `(${input})`;
   }
 }


### PR DESCRIPTION
**What It Does**

Resolves #180 

Adds vagueness to the bracketing behaviour to allow a string that ends in brackets but not starts with to be handled correctly. This does add some responsibility to the user creating the criteria string, but prevents unwanted behaviour like the below example.

Currently, if you pass a string like `NOT (PROGRAM=ABC* OR PROGRAM=BCD*)`, it will send back `(NOT (PROGRAM=ABC* OR PROGRAM=BCD*)`, whereas we would want a bracket at the end too.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
