### PR TITLE
Remove the sit param menu option when a region is inactive

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
 ## Recent Changes
-- BugFix: Now the 'Show SIT Parameters' menu option is grayed out for inactive regions. [#167](https://github.com/zowe/cics-for-zowe-client/issues/167)
+- BugFix: Remove the 'Show SIT Parameters' menu option when a region is inactive. [#167](https://github.com/zowe/cics-for-zowe-client/issues/167)
 
 ## `3.2.0`
 

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
+## Recent Changes
+- BugFix: Now the 'Show SIT Parameters' menu option is grayed out for inactive regions. [#167](https://github.com/zowe/cics-for-zowe-client/issues/167)
+
 ## `3.2.0`
 
 - BugFix: Initializing new Team Configuration File. [#33](https://github.com/zowe/cics-for-zowe-client/issues/33)

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -337,8 +337,7 @@
       {
         "command": "cics-extension-for-zowe.showRegionParameters",
         "title": "Show SIT Parameters",
-        "category": "IBM CICS for Zowe Explorer",
-        "enablement": "(viewItem =~ /\\.active/)"
+        "category": "IBM CICS for Zowe Explorer"
       },
       {
         "command": "cics-extension-for-zowe.enableProgram",
@@ -465,7 +464,7 @@
           "group": ""
         },
         {
-          "when": "view == cics-view && viewItem =~ /cicsregion\\..*/",
+          "when": "view == cics-view && viewItem =~ /cicsregion.*\\.active/",
           "command": "cics-extension-for-zowe.showRegionParameters",
           "group": ""
         },

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -337,7 +337,14 @@
       {
         "command": "cics-extension-for-zowe.showRegionParameters",
         "title": "Show SIT Parameters",
-        "category": "IBM CICS for Zowe Explorer"
+        "category": "IBM CICS for Zowe Explorer",
+        "enablement": "true"
+      },
+      {
+        "command": "cics-extension-for-zowe.showRegionParametersInactive",
+        "title": "Show SIT Parameters",
+        "category": "IBM CICS for Zowe Explorer",
+        "enablement": "false"
       },
       {
         "command": "cics-extension-for-zowe.enableProgram",
@@ -464,8 +471,13 @@
           "group": ""
         },
         {
-          "when": "view == cics-view && viewItem =~ /^cicsregion\\./",
+          "when": "view == cics-view && viewItem =~ /^cicsregion\\..*\\.active/",
           "command": "cics-extension-for-zowe.showRegionParameters",
+          "group": ""
+        },
+        {
+          "when": "view == cics-view && viewItem =~ /^cicsregion\\..*\\.inactive.*/",
+          "command": "cics-extension-for-zowe.showRegionParametersInactive",
           "group": ""
         },
         {

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -338,13 +338,7 @@
         "command": "cics-extension-for-zowe.showRegionParameters",
         "title": "Show SIT Parameters",
         "category": "IBM CICS for Zowe Explorer",
-        "enablement": "true"
-      },
-      {
-        "command": "cics-extension-for-zowe.showRegionParametersInactive",
-        "title": "Show SIT Parameters",
-        "category": "IBM CICS for Zowe Explorer",
-        "enablement": "false"
+        "enablement": "(viewItem =~ /\\.active/)"
       },
       {
         "command": "cics-extension-for-zowe.enableProgram",
@@ -471,13 +465,8 @@
           "group": ""
         },
         {
-          "when": "view == cics-view && viewItem =~ /^cicsregion\\..*\\.active/",
+          "when": "view == cics-view && viewItem =~ /cicsregion\\..*/",
           "command": "cics-extension-for-zowe.showRegionParameters",
-          "group": ""
-        },
-        {
-          "when": "view == cics-view && viewItem =~ /^cicsregion\\..*\\.inactive.*/",
-          "command": "cics-extension-for-zowe.showRegionParametersInactive",
           "group": ""
         },
         {

--- a/packages/vsce/src/commands/showParameterCommand.ts
+++ b/packages/vsce/src/commands/showParameterCommand.ts
@@ -23,6 +23,11 @@ export function getShowRegionSITParametersCommand(treeview: TreeView<any>) {
       return;
     }
     for (const regionTree of allSelectedNodes) {
+      if (regionTree.contextValue.includes(".inactive")) {
+        // Ignore region if not active - required for the command palette.
+        continue;
+      }
+
       const db2transactionResponse = await getResource(regionTree.parentSession.session, {
         name: "CICSSystemParameter",
         regionName: regionTree.label,

--- a/packages/vsce/src/trees/CICSRegionTree.ts
+++ b/packages/vsce/src/trees/CICSRegionTree.ts
@@ -55,7 +55,9 @@ export class CICSRegionTree extends TreeItem {
       this.children = null;
       this.collapsibleState = TreeItemCollapsibleState.None;
       this.iconPath = getIconPathInResources("region-dark-disabled.svg", "region-light-disabled.svg");
+      this.contextValue += ".inactive";
     } else {
+      this.contextValue += ".active";
       this.children = [
         new CICSProgramTree(this),
         new CICSTransactionTree(this),


### PR DESCRIPTION
**What It Does**
Currently the "Show SIT Parameters" menu option can be selected on inactive regions which will cause an error. I've changed this so that this option is greyed out when the region is inactive. I've also added a check in the command so that the error does not surface when executed from the command palette.

**How to Test**
Connected to a plex with both active and inactive regions and verified that the menu item for 'Show SIT Parameters' is grayed out when the region is inactive. This will also be the case if multi-select is used and includes an inactive region.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
Resolves https://github.com/zowe/cics-for-zowe-client/issues/167
