### PR TITLE
[v2] Remove bundled deps and update release config

### DIFF
--- a/.github/release.config.js
+++ b/.github/release.config.js
@@ -10,12 +10,12 @@ module.exports = {
             }
         },
         {
-            name: "zowe-v1-lts",
-            channel: "zowe-v1-lts",
+            name: "zowe-v2-lts",
+            channel: "zowe-v2-lts",
             level: "patch",
             devDependencies: {
-                "@zowe/imperative": "zowe-v1-lts",
-                "@zowe/zowe-explorer-api": ["zowe-v1-lts", "@zowe:registry=https://registry.npmjs.org/"],
+                "@zowe/imperative": "zowe-v2-lts",
+                "@zowe/zowe-explorer-api": ["zowe-v2-lts", "@zowe:registry=https://registry.npmjs.org/"],
             }
         },
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13993,9 +13993,6 @@
     "packages/cli": {
       "name": "@zowe/cics-for-zowe-cli",
       "version": "5.0.6",
-      "bundleDependencies": [
-        "@zowe/cics-for-zowe-sdk"
-      ],
       "license": "EPL-2.0",
       "dependencies": {
         "@zowe/cics-for-zowe-sdk": "5.0.6"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,8 @@
   },
   "main": "lib/index.js",
   "files": [
-    "lib"
+    "lib",
+    "npm-shrinkwrap.json"
   ],
   "publishConfig": {
     "registry": "https://zowe.jfrog.io/zowe/api/npm/npm-local-release/"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -52,8 +52,5 @@
   },
   "peerDependencies": {
     "@zowe/imperative": "^5.0.0"
-  },
-  "bundledDependencies": [
-    "@zowe/cics-for-zowe-sdk"
-  ]
+  }
 }

--- a/scripts/bundleTgz.js
+++ b/scripts/bundleTgz.js
@@ -19,7 +19,7 @@ const rootDir = path.join(__dirname, "..");
 process.chdir(rootDir);
 const cliPkgDir = path.join(process.cwd(), "packages", "cli");
 const pkgJsonFile = path.join(cliPkgDir, "package.json");
-const tempPkgJson = JSON.parse(fsE.readFileSync(pkgJsonFile, "utf-8"));
+const sdkPkgJson = JSON.parse(fsE.readFileSync(path.join(cliPkgDir, "../sdk/package.json"), "utf-8"));
 const npmInstallCmd = "npm install --ignore-scripts --workspaces=false";
 const execCmd = (cmd) => childProcess.execSync(cmd, { cwd: cliPkgDir, stdio: "inherit" });
 fsE.mkdirpSync("dist");
@@ -41,12 +41,12 @@ if (fs.existsSync(path.join(cliPkgDir, "node_modules"))) {
 }
 fsE.copyFileSync(pkgJsonFile, pkgJsonFile + ".bak");
 try {
-    // Install node_modules directly inside packages/cli
-    execCmd("npm run preshrinkwrap");
     try {
-        execCmd(`npm view @zowe/cics-for-zowe-sdk`);
+        // Install node_modules directly inside packages/cli
+        execCmd("npm run preshrinkwrap");
+        execCmd(`npm view @zowe/cics-for-zowe-sdk@${sdkPkgJson.version}`);
     } catch (err) {
-        const sdkTgzPath = path.relative(__dirname, "../dist/zowe-cics-for-zowe-sdk-" + tempPkgJson.version + ".tgz");
+        const sdkTgzPath = path.relative(__dirname, "../dist/zowe-cics-for-zowe-sdk-" + sdkPkgJson.version + ".tgz");
         execCmd(`${npmInstallCmd} ${sdkTgzPath}`);
     }
     execCmd(npmInstallCmd);


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Removes the SDK as bundled dependency of the CLI. It will be temporarily restored when `npm run package` is run to create an offline TGZ.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
1. `cd` into the CLI package folder
1. Run `npm pack` and confirm no deps are bundled
1. Run `npm run package` and confirm that deps are bundled

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
This should be published as `release-patch` since release was skipped for the last V2 PR:
https://github.com/zowe/cics-for-zowe-client/actions/runs/12603902416/job/35130057064