### PR TITLE
update regions icon when auto-expanded

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -1,14 +1,15 @@
 # Change Log
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
-## `3.2.3`
-
-- Changed icons for: folder, local file, local transaction, program and task. Updated 16 icons for different status and themes. [#182](https://github.com/zowe/cics-for-zowe-client/pull/182)
-
 
 ## Recent Changes
 
 - BugFix: Updated commands to use Utils.getResourceURI. [#178](https://github.com/zowe/cics-for-zowe-client/issues/178)
+- BugFix: Regions icon updates when plex tree is expanded. [#194](https://github.com/zowe/cics-for-zowe-client/issues/194)
+
+## `3.2.3`
+
+- Changed icons for: folder, local file, local transaction, program and task. Updated 16 icons for different status and themes. [#182](https://github.com/zowe/cics-for-zowe-client/pull/182)
 
 ## `3.2.2`
 

--- a/packages/vsce/src/extension.ts
+++ b/packages/vsce/src/extension.ts
@@ -70,7 +70,7 @@ import {
   getFilterAllPipelinesCommand,
   getFilterAllWebServicesCommand,
 } from "./commands/filterAllResourceCommand";
-import { getIconPathInResources, setIconClosed } from "./utils/profileUtils";
+import { getIconOpen, getIconPathInResources } from "./utils/profileUtils";
 import { plexExpansionHandler, sessionExpansionHandler, regionContainerExpansionHandler } from "./utils/expansionHandler";
 import { getZoweExplorerVersion } from "./utils/workspaceUtils";
 
@@ -425,57 +425,43 @@ export async function activate(context: ExtensionContext) {
 
       // Regions container folder node expanded
     } else if (node.element.contextValue.includes("cicsregionscontainer.")) {
-      node.element.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      node.element.iconPath = getIconOpen(true);
       await regionContainerExpansionHandler(node.element, treeDataProv);
       treeDataProv._onDidChangeTreeData.fire(undefined);
     }
   });
 
   treeview.onDidCollapseElement((node) => {
-    if (node.element.contextValue.includes("cicsregionscontainer.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicscombinedprogramtree.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicscombinedtransactiontree.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicscombinedlocalfiletree.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicscombinedtasktree.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicscombinedlibrarytree.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicscombinedtcpipstree.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicscombinedurimapstree.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicscombinedpipelinetree.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicscombinedwebservicetree.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreeprogram.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreetransaction.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreelocalfile.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreetask.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreelibrary.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicslibrary.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreeweb.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreetcpips.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreepipeline.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreewebservice.")) {
-      setIconClosed(node, treeDataProv);
-    } else if (node.element.contextValue.includes("cicstreeurimaps.")) {
-      setIconClosed(node, treeDataProv);
+
+    const interestedContextValues = [
+      "cicsregionscontainer.",
+      "cicscombinedprogramtree.",
+      "cicscombinedtransactiontree.",
+      "cicscombinedlocalfiletree.",
+      "cicscombinedtasktree.",
+      "cicscombinedlibrarytree.",
+      "cicscombinedtcpipstree.",
+      "cicscombinedurimapstree.",
+      "cicscombinedpipelinetree.",
+      "cicscombinedwebservicetree.",
+      "cicstreeprogram.",
+      "cicstreetransaction.",
+      "cicstreelocalfile.",
+      "cicstreetask.",
+      "cicstreelibrary.",
+      "cicslibrary.",
+      "cicstreeweb.",
+      "cicstreetcpips.",
+      "cicstreepipeline.",
+      "cicstreewebservice.",
+      "cicstreeurimaps.",
+    ];
+
+    if (interestedContextValues.some(item => node.element.contextValue.includes(item))) {
+      node.element.iconPath = getIconOpen(false);
     }
     node.element.collapsibleState = TreeItemCollapsibleState.Collapsed;
+    treeDataProv._onDidChangeTreeData.fire(undefined);
   });
 
   context.subscriptions.push(

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLibraryTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLibraryTree.ts
@@ -19,7 +19,7 @@ import { ViewMore } from "../treeItems/utils/ViewMore";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconPathInResources } from "../../utils/profileUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 
 export class CICSCombinedLibraryTree extends TreeItem {
   children: (CICSLibraryTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -29,7 +29,7 @@ export class CICSCombinedLibraryTree extends TreeItem {
   incrementCount: number;
   constant: string;
 
-  constructor(parentPlex: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentPlex: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("All Libraries", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicscombinedlibrarytree.`;
     this.parentPlex = parentPlex;
@@ -87,11 +87,11 @@ export class CICSCombinedLibraryTree extends TreeItem {
                 count = parseInt(recordsCount);
               }
               this.addLibrariesUtil([], allLibraries, count);
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
             } else {
               this.children = [];
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
               window.showInformationMessage(`No libraries found`);
               this.label = `All Libraries${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLocalFileTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLocalFileTree.ts
@@ -19,7 +19,7 @@ import { CICSLocalFileTreeItem } from "../treeItems/CICSLocalFileTreeItem";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconPathInResources } from "../../utils/profileUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 
 export class CICSCombinedLocalFileTree extends TreeItem {
   children: (CICSLocalFileTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -29,7 +29,7 @@ export class CICSCombinedLocalFileTree extends TreeItem {
   incrementCount: number;
   constant: string;
 
-  constructor(parentPlex: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentPlex: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("All Local Files", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicscombinedlocalfiletree.`;
     this.parentPlex = parentPlex;
@@ -87,11 +87,11 @@ export class CICSCombinedLocalFileTree extends TreeItem {
                 count = parseInt(recordsCount);
               }
               this.addLocalFilesUtil([], allLocalFiles, count);
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
             } else {
               this.children = [];
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
               window.showInformationMessage(`No local files found`);
               this.label = `All Local Files${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedPipelineTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedPipelineTree.ts
@@ -18,7 +18,7 @@ import { ViewMore } from "../treeItems/utils/ViewMore";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconPathInResources } from "../../utils/profileUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 import { CICSPipelineTreeItem } from "../treeItems/web/treeItems/CICSPipelineTreeItem";
 
 export class CICSCombinedPipelineTree extends TreeItem {
@@ -29,7 +29,7 @@ export class CICSCombinedPipelineTree extends TreeItem {
   incrementCount: number;
   constant: string;
 
-  constructor(parentPlex: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentPlex: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("All Pipelines", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicscombinedpipelinetree.`;
     this.parentPlex = parentPlex;
@@ -87,11 +87,11 @@ export class CICSCombinedPipelineTree extends TreeItem {
                 count = parseInt(recordsCount);
               }
               this.addPipelinesUtil([], allPipelines, count);
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
             } else {
               this.children = [];
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
               window.showInformationMessage(`No pipelines found`);
               this.label = `All Pipelines${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedProgramTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedProgramTree.ts
@@ -20,7 +20,7 @@ import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconPathInResources } from "../../utils/profileUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 
 export class CICSCombinedProgramTree extends TreeItem {
   children: (CICSProgramTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -30,7 +30,7 @@ export class CICSCombinedProgramTree extends TreeItem {
   incrementCount: number;
   constant: string;
 
-  constructor(parentPlex: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentPlex: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("All Programs", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicscombinedprogramtree.`;
     this.parentPlex = parentPlex;
@@ -88,11 +88,11 @@ export class CICSCombinedProgramTree extends TreeItem {
                 count = parseInt(recordsCount);
               }
               this.addProgramsUtil([], allPrograms, count);
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
             } else {
               this.children = [];
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
               window.showInformationMessage(`No programs found`);
               this.label = `All Programs${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTCPIPServiceTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTCPIPServiceTree.ts
@@ -19,7 +19,7 @@ import { ViewMore } from "../treeItems/utils/ViewMore";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconPathInResources } from "../../utils/profileUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 
 export class CICSCombinedTCPIPServiceTree extends TreeItem {
   children: (CICSTCPIPServiceTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -29,7 +29,7 @@ export class CICSCombinedTCPIPServiceTree extends TreeItem {
   incrementCount: number;
   constant: string;
 
-  constructor(parentPlex: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentPlex: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("All TCPIP Services", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicscombinedtcpipstree.`;
     this.parentPlex = parentPlex;
@@ -87,11 +87,11 @@ export class CICSCombinedTCPIPServiceTree extends TreeItem {
                 count = parseInt(recordsCount);
               }
               this.addTCPIPSUtil([], allTCPIPS, count);
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
             } else {
               this.children = [];
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
               window.showInformationMessage(`No TCPIP Services found`);
               this.label = `All TCPIP Services${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTaskTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTaskTree.ts
@@ -18,7 +18,7 @@ import { ViewMore } from "../treeItems/utils/ViewMore";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconPathInResources } from "../../utils/profileUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 import { CICSTaskTreeItem } from "../treeItems/CICSTaskTreeItem";
 
 export class CICSCombinedTaskTree extends TreeItem {
@@ -29,7 +29,7 @@ export class CICSCombinedTaskTree extends TreeItem {
   incrementCount: number;
   constant: string;
 
-  constructor(parentPlex: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentPlex: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("All Tasks", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicscombinedtasktree.`;
     this.parentPlex = parentPlex;
@@ -87,11 +87,11 @@ export class CICSCombinedTaskTree extends TreeItem {
                 count = parseInt(recordsCount);
               }
               this.addTasksUtil([], allTasks, count);
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
             } else {
               this.children = [];
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
               window.showInformationMessage(`No tasks found`);
               this.label = `All Tasks${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTransactionTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTransactionTree.ts
@@ -20,7 +20,7 @@ import { CICSTransactionTreeItem } from "../treeItems/CICSTransactionTreeItem";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconPathInResources } from "../../utils/profileUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 
 export class CICSCombinedTransactionsTree extends TreeItem {
   children: (CICSTransactionTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -30,7 +30,7 @@ export class CICSCombinedTransactionsTree extends TreeItem {
   incrementCount: number;
   constant: string;
 
-  constructor(parentPlex: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentPlex: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("All Local Transactions", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicscombinedtransactiontree.`;
     this.parentPlex = parentPlex;
@@ -88,11 +88,11 @@ export class CICSCombinedTransactionsTree extends TreeItem {
                 count = parseInt(recordsCount);
               }
               this.addLocalTransactionsUtil([], allLocalTransactions, count);
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
             } else {
               this.children = [];
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
               window.showInformationMessage(`No local transactions found`);
               this.label = `All Local Transactions${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedURIMapTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedURIMapTree.ts
@@ -19,7 +19,7 @@ import { ViewMore } from "../treeItems/utils/ViewMore";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconPathInResources } from "../../utils/profileUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 
 export class CICSCombinedURIMapTree extends TreeItem {
   children: (CICSURIMapTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -29,7 +29,7 @@ export class CICSCombinedURIMapTree extends TreeItem {
   incrementCount: number;
   constant: string;
 
-  constructor(parentPlex: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentPlex: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("All URI Maps", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicscombinedurimapstree.`;
     this.parentPlex = parentPlex;
@@ -87,11 +87,11 @@ export class CICSCombinedURIMapTree extends TreeItem {
                 count = parseInt(recordsCount);
               }
               this.addURIMapsUtil([], allURIMaps, count);
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
             } else {
               this.children = [];
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
               window.showInformationMessage(`No URI Maps found`);
               this.label = `All URI Maps ${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedWebServiceTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedWebServiceTree.ts
@@ -18,7 +18,7 @@ import { ViewMore } from "../treeItems/utils/ViewMore";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
-import { getIconPathInResources } from "../../utils/profileUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 import { CICSWebServiceTreeItem } from "../treeItems/web/treeItems/CICSWebServiceTreeItem";
 
 export class CICSCombinedWebServiceTree extends TreeItem {
@@ -29,7 +29,7 @@ export class CICSCombinedWebServiceTree extends TreeItem {
   incrementCount: number;
   constant: string;
 
-  constructor(parentPlex: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentPlex: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("All Web Services", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicscombinedwebservicetree.`;
     this.parentPlex = parentPlex;
@@ -87,11 +87,11 @@ export class CICSCombinedWebServiceTree extends TreeItem {
                 count = parseInt(recordsCount);
               }
               this.addWebServicesUtil([], allWebServices, count);
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
             } else {
               this.children = [];
-              this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+              this.iconPath = getIconOpen(true);
               tree._onDidChangeTreeData.fire(undefined);
               window.showInformationMessage(`No Web Services found`);
               this.label = `All Web Services${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[${recordsCount}]`;

--- a/packages/vsce/src/trees/CICSLibraryTree.ts
+++ b/packages/vsce/src/trees/CICSLibraryTree.ts
@@ -13,7 +13,7 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
-import { getIconPathInResources } from "../utils/profileUtils";
+import { getIconOpen } from "../utils/profileUtils";
 import { CICSLibraryTreeItem } from "./treeItems/CICSLibraryTreeItem";
 import { toEscapedCriteriaString } from "../utils/filterUtils";
 
@@ -22,7 +22,7 @@ export class CICSLibraryTree extends TreeItem {
   parentRegion: CICSRegionTree;
   activeFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("Libraries", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreelibrary.${this.activeFilter ? "filtered" : "unfiltered"}.libraries`;
     this.parentRegion = parentRegion;
@@ -59,7 +59,7 @@ export class CICSLibraryTree extends TreeItem {
         const newLibraryItem = new CICSLibraryTreeItem(library, this.parentRegion, this);
         this.addLibrary(newLibraryItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
@@ -67,6 +67,7 @@ export class CICSLibraryTree extends TreeItem {
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No libraries found`);
         this.label = `Libraries${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching libraries - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/trees/CICSLocalFileTree.ts
+++ b/packages/vsce/src/trees/CICSLocalFileTree.ts
@@ -15,14 +15,14 @@ import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { CICSRegionTree } from "./CICSRegionTree";
 import * as https from "https";
 import { toEscapedCriteriaString } from "../utils/filterUtils";
-import { getIconPathInResources } from "../utils/profileUtils";
+import { getIconOpen } from "../utils/profileUtils";
 
 export class CICSLocalFileTree extends TreeItem {
   children: CICSLocalFileTreeItem[] = [];
   parentRegion: CICSRegionTree;
   activeFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("Local Files", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreelocalfile.${this.activeFilter ? "filtered" : "unfiltered"}.localFiles`;
     this.parentRegion = parentRegion;
@@ -63,7 +63,7 @@ export class CICSLocalFileTree extends TreeItem {
         const newLocalFileItem = new CICSLocalFileTreeItem(localFile, this.parentRegion, this);
         this.addLocalFile(newLocalFileItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       // @ts-ignore
@@ -73,6 +73,7 @@ export class CICSLocalFileTree extends TreeItem {
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No local files found`);
         this.label = `Local Files${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching local files - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/trees/CICSProgramTree.ts
+++ b/packages/vsce/src/trees/CICSProgramTree.ts
@@ -15,13 +15,14 @@ import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
 import { getDefaultProgramFilter, toEscapedCriteriaString } from "../utils/filterUtils";
-import { getIconPathInResources } from "../utils/profileUtils";
+import { getIconOpen } from "../utils/profileUtils";
+
 export class CICSProgramTree extends TreeItem {
   children: CICSProgramTreeItem[] = [];
   parentRegion: CICSRegionTree;
   activeFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("Programs", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreeprogram.${this.activeFilter ? "filtered" : "unfiltered"}.programs`;
     this.parentRegion = parentRegion;
@@ -58,7 +59,7 @@ export class CICSProgramTree extends TreeItem {
         const newProgramItem = new CICSProgramTreeItem(program, this.parentRegion, this);
         this.addProgram(newProgramItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
@@ -66,6 +67,7 @@ export class CICSProgramTree extends TreeItem {
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No programs found`);
         this.label = `Programs${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching programs - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/trees/CICSRegionsContainer.ts
+++ b/packages/vsce/src/trees/CICSRegionsContainer.ts
@@ -14,7 +14,7 @@ import { CICSPlexTree } from "./CICSPlexTree";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { CICSTree } from "./CICSTree";
 import { ProfileManagement } from "../utils/profileManagement";
-import { getIconPathInResources } from "../utils/profileUtils";
+import { getIconOpen } from "../utils/profileUtils";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
 
@@ -24,7 +24,7 @@ export class CICSRegionsContainer extends TreeItem {
   resourceFilters: any;
   activeFilter: string;
 
-  constructor(parent: CICSPlexTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parent: CICSPlexTree, public iconPath = getIconOpen(false)) {
     super("Regions", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicsregionscontainer.`;
     this.parent = parent;
@@ -49,7 +49,7 @@ export class CICSRegionsContainer extends TreeItem {
         const regionInfo = await ProfileManagement.getRegionInfoInPlex(this.parent);
         this.addRegionsUtility(regionInfo);
         this.collapsibleState = TreeItemCollapsibleState.Expanded;
-        this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+        this.iconPath = getIconOpen(true);
         tree._onDidChangeTreeData.fire(undefined);
         if (!this.children.length) {
           window.showInformationMessage(`No regions found for ${this.parent.getPlexName()}`);

--- a/packages/vsce/src/trees/CICSTaskTree.ts
+++ b/packages/vsce/src/trees/CICSTaskTree.ts
@@ -14,7 +14,7 @@ import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
 import { toEscapedCriteriaString } from "../utils/filterUtils";
-import { getIconPathInResources } from "../utils/profileUtils";
+import { getIconOpen } from "../utils/profileUtils";
 import { CICSTaskTreeItem } from "./treeItems/CICSTaskTreeItem";
 
 export class CICSTaskTree extends TreeItem {
@@ -22,7 +22,7 @@ export class CICSTaskTree extends TreeItem {
   parentRegion: CICSRegionTree;
   activeTransactionFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("Tasks", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreetask.${this.activeTransactionFilter ? "filtered" : "unfiltered"}.tasks`;
     this.parentRegion = parentRegion;
@@ -70,7 +70,7 @@ export class CICSTaskTree extends TreeItem {
         );
         this.addTask(newTaskItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
@@ -78,6 +78,7 @@ export class CICSTaskTree extends TreeItem {
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No tasks found`);
         this.label = `Tasks${this.activeTransactionFilter ? ` (${this.activeTransactionFilter}) ` : " "}[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching tasks - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(/(\\n\t|\\n|\\t)/gm, " ")}`

--- a/packages/vsce/src/trees/CICSTransactionTree.ts
+++ b/packages/vsce/src/trees/CICSTransactionTree.ts
@@ -15,14 +15,14 @@ import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
 import { getDefaultTransactionFilter, toEscapedCriteriaString } from "../utils/filterUtils";
-import { getIconPathInResources } from "../utils/profileUtils";
+import { getIconOpen } from "../utils/profileUtils";
 
 export class CICSTransactionTree extends TreeItem {
   children: CICSTransactionTreeItem[] = [];
   parentRegion: CICSRegionTree;
   activeFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("Transactions", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreetransaction.${this.activeFilter ? "filtered" : "unfiltered"}.transactions`;
     this.parentRegion = parentRegion;
@@ -59,7 +59,7 @@ export class CICSTransactionTree extends TreeItem {
         const newTransactionItem = new CICSTransactionTreeItem(transaction, this.parentRegion, this);
         this.addTransaction(newTransactionItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       // @ts-ignore
@@ -69,6 +69,7 @@ export class CICSTransactionTree extends TreeItem {
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No transactions found`);
         this.label = `Transactions${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching transaction - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/trees/CICSWebTree.ts
+++ b/packages/vsce/src/trees/CICSWebTree.ts
@@ -10,7 +10,7 @@
  */
 
 import { TreeItemCollapsibleState, TreeItem } from "vscode";
-import { getIconPathInResources } from "../utils/profileUtils";
+import { getIconOpen } from "../utils/profileUtils";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { CICSURIMapTree } from "./treeItems/web/CICSURIMapTree";
 import { CICSTCPIPServiceTree } from "./treeItems/web/CICSTCPIPServiceTree";
@@ -22,7 +22,7 @@ export class CICSWebTree extends TreeItem {
   parentRegion: CICSRegionTree | undefined;
   //activeFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("Web", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreeweb.web`;
     this.parentRegion = parentRegion;
@@ -36,7 +36,7 @@ export class CICSWebTree extends TreeItem {
   }
 
   public loadContents() {
-    this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+    this.iconPath = getIconOpen(true);
   }
 
   public getChildren() {

--- a/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
+++ b/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
@@ -13,9 +13,9 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
-import { getIconPathInResources } from "../../utils/profileUtils";
 import { CICSLibraryDatasets } from "./CICSLibraryDatasets";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { getIconOpen } from "../../utils/profileUtils";
 
 export class CICSLibraryTreeItem extends TreeItem {
   children: CICSLibraryDatasets[] = [];
@@ -28,7 +28,7 @@ export class CICSLibraryTreeItem extends TreeItem {
     library: any,
     parentRegion: CICSRegionTree,
     directParent: any,
-    public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")
+    public iconPath = getIconOpen(false)
   ) {
     super(`${library.name}`, TreeItemCollapsibleState.Collapsed);
 
@@ -77,7 +77,7 @@ export class CICSLibraryTreeItem extends TreeItem {
         const newDatasetItem = new CICSLibraryDatasets(dataset, this.parentRegion, this); //this=CICSLibraryTreeItem
         this.addDataset(newDatasetItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
@@ -87,6 +87,7 @@ export class CICSLibraryTreeItem extends TreeItem {
         this.label = `${this.library.name}${this.parentRegion.parentPlex ? ` (${this.library.eyu_cicsname})` : ""}${
           this.activeFilter ? ` (${this.activeFilter}) ` : " "
         }[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching datasets - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
@@ -15,13 +15,14 @@ import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
-import { getIconPathInResources } from "../../../utils/profileUtils";
+import { getIconOpen } from "../../../utils/profileUtils";
+
 export class CICSPipelineTree extends TreeItem {
   children: CICSPipelineTreeItem[] = [];
   parentRegion: CICSRegionTree;
   activeFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("Pipelines", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreepipeline.${this.activeFilter ? "filtered" : "unfiltered"}.pipelines`;
     this.parentRegion = parentRegion;
@@ -59,7 +60,7 @@ export class CICSPipelineTree extends TreeItem {
         newPipelineItem.setLabel(newPipelineItem.label.toString().replace(pipeline.name, `${pipeline.name}`));
         this.addPipeline(newPipelineItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
@@ -67,6 +68,7 @@ export class CICSPipelineTree extends TreeItem {
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No Pipelines found`);
         this.label = `Pipelines${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching Pipelines - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
@@ -15,13 +15,14 @@ import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
-import { getIconPathInResources } from "../../../utils/profileUtils";
+import { getIconOpen } from "../../../utils/profileUtils";
+
 export class CICSTCPIPServiceTree extends TreeItem {
   children: CICSTCPIPServiceTreeItem[] = [];
   parentRegion: CICSRegionTree;
   activeFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("TCPIP Services", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreetcpips.${this.activeFilter ? "filtered" : "unfiltered"}.tcpips`;
     this.parentRegion = parentRegion;
@@ -61,7 +62,7 @@ export class CICSTCPIPServiceTree extends TreeItem {
         );
         this.addTCPIPS(newTCPIPServiceItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
@@ -69,6 +70,7 @@ export class CICSTCPIPServiceTree extends TreeItem {
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No TCPIP Services found`);
         this.label = `TCPIP Services${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching TCPIP services - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
@@ -15,13 +15,14 @@ import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
-import { getIconPathInResources } from "../../../utils/profileUtils";
+import { getIconOpen } from "../../../utils/profileUtils";
+
 export class CICSURIMapTree extends TreeItem {
   children: CICSURIMapTreeItem[] = [];
   parentRegion: CICSRegionTree;
   activeFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("URI Maps", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreeurimaps.${this.activeFilter ? "filtered" : "unfiltered"}.urimaps`;
     this.parentRegion = parentRegion;
@@ -61,7 +62,7 @@ export class CICSURIMapTree extends TreeItem {
         );
         this.addURIMAP(newURIMapItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
@@ -69,6 +70,7 @@ export class CICSURIMapTree extends TreeItem {
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No URI Maps found`);
         this.label = `URI Maps${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching URI Maps - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
@@ -15,13 +15,14 @@ import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
-import { getIconPathInResources } from "../../../utils/profileUtils";
+import { getIconOpen } from "../../../utils/profileUtils";
+
 export class CICSWebServiceTree extends TreeItem {
   children: CICSWebServiceTreeItem[] = [];
   parentRegion: CICSRegionTree;
   activeFilter: string | undefined = undefined;
 
-  constructor(parentRegion: CICSRegionTree, public iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg")) {
+  constructor(parentRegion: CICSRegionTree, public iconPath = getIconOpen(false)) {
     super("Web Services", TreeItemCollapsibleState.Collapsed);
     this.contextValue = `cicstreewebservice.${this.activeFilter ? "filtered" : "unfiltered"}.webservices`;
     this.parentRegion = parentRegion;
@@ -59,7 +60,7 @@ export class CICSWebServiceTree extends TreeItem {
         newWebServiceItem.setLabel(newWebServiceItem.label.toString().replace(webservice.name, `${webservice.name}`));
         this.addWebService(newWebServiceItem);
       }
-      this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
+      this.iconPath = getIconOpen(true);
     } catch (error) {
       https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
@@ -67,6 +68,7 @@ export class CICSWebServiceTree extends TreeItem {
       } else if (this.children.length === 0) {
         window.showInformationMessage(`No Web Services found`);
         this.label = `Web Services${this.activeFilter ? ` (${this.activeFilter}) ` : " "}[0]`;
+        this.iconPath = getIconOpen(true);
       } else {
         window.showErrorMessage(
           `Something went wrong when fetching Web Services - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/utils/expansionHandler.ts
+++ b/packages/vsce/src/utils/expansionHandler.ts
@@ -15,6 +15,7 @@ import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSSessionTree } from "../trees/CICSSessionTree";
 import { CICSTree } from "../trees/CICSTree";
 import { ProfileManagement } from "./profileManagement";
+import { getIconOpen } from "./profileUtils";
 
 export async function sessionExpansionHandler(session: CICSSessionTree, tree: CICSTree) {
   const profile = await ProfileManagement.getProfilesCache().getLoadedProfConfig(session.label?.toString()!);
@@ -42,6 +43,7 @@ export function regionContainerExpansionHandler(regionContiner: CICSRegionsConta
           });
           regionContiner.clearChildren();
           await regionContiner.loadRegionsInCICSGroup(tree);
+          regionContiner.iconPath = getIconOpen(true);
           tree._onDidChangeTreeData.fire(undefined);
         }
       );
@@ -59,6 +61,7 @@ export function regionContainerExpansionHandler(regionContiner: CICSRegionsConta
         });
         regionContiner.clearChildren();
         await regionContiner.loadRegionsInPlex();
+        regionContiner.iconPath = getIconOpen(true);
         if (!regionContiner.getChildren().length) {
           window.showInformationMessage(`No regions found for plex ${parentPlex.getPlexName()}`);
         }

--- a/packages/vsce/src/utils/profileUtils.ts
+++ b/packages/vsce/src/utils/profileUtils.ts
@@ -11,7 +11,6 @@
 
 import { ZoweVsCodeExtension, imperative } from "@zowe/zowe-explorer-api";
 import { join } from "path";
-import { CICSTree } from "../trees/CICSTree";
 import { window } from "vscode";
 import { ProfileManagement } from "./profileManagement";
 
@@ -51,7 +50,8 @@ export async function promptCredentials(sessionName: string, rePrompt?: boolean)
   return promptInfo;
 }
 
-export function setIconClosed(node: any, tree: CICSTree): void {
-  node.element.iconPath = getIconPathInResources("folder-closed-dark.svg", "folder-closed-light.svg");
-  tree._onDidChangeTreeData.fire(undefined);
+export function getIconOpen(open: boolean = true) {
+  return getIconPathInResources(
+    `folder-${open ? "open" : "closed"}-dark.svg`,
+    `folder-${open ? "open" : "closed"}-light.svg`);
 }


### PR DESCRIPTION
**What It Does**
Resolves #194 
Updates the Regions container tree icon when auto-expanded by the Plex tree expanding.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
