### PR TITLE
Fix lint warnings

### DIFF
--- a/packages/vsce/src/commands/clearResourceFilterCommand.ts
+++ b/packages/vsce/src/commands/clearResourceFilterCommand.ts
@@ -10,19 +10,19 @@
  */
 
 import { commands, ProgressLocation, TreeView, window } from "vscode";
-import { CICSLibraryDatasets } from "../trees/treeItems/CICSLibraryDatasets";
 import { CICSLibraryTree } from "../trees/CICSLibraryTree";
 import { CICSLocalFileTree } from "../trees/CICSLocalFileTree";
 import { CICSProgramTree } from "../trees/CICSProgramTree";
 import { CICSTaskTree } from "../trees/CICSTaskTree";
 import { CICSTransactionTree } from "../trees/CICSTransactionTree";
 import { CICSTree } from "../trees/CICSTree";
-import { findSelectedNodes } from "../utils/commandUtils";
+import { CICSLibraryDatasets } from "../trees/treeItems/CICSLibraryDatasets";
 import { CICSLibraryTreeItem } from "../trees/treeItems/CICSLibraryTreeItem";
+import { CICSPipelineTree } from "../trees/treeItems/web/CICSPipelineTree";
 import { CICSTCPIPServiceTree } from "../trees/treeItems/web/CICSTCPIPServiceTree";
 import { CICSURIMapTree } from "../trees/treeItems/web/CICSURIMapTree";
 import { CICSWebServiceTree } from "../trees/treeItems/web/CICSWebServiceTree";
-import { CICSPipelineTree } from "../trees/treeItems/web/CICSPipelineTree";
+import { findSelectedNodes } from "../utils/commandUtils";
 
 export function getClearResourceFilterCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.clearFilter", async (node) => {
@@ -63,9 +63,7 @@ export function getClearResourceFilterCommand(tree: CICSTree, treeview: TreeView
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of resources");
-          });
+          token.onCancellationRequested(() => { });
           await selectedNode.loadContents();
           tree._onDidChangeTreeData.fire(undefined);
         }

--- a/packages/vsce/src/commands/closeLocalFileCommand.ts
+++ b/packages/vsce/src/commands/closeLocalFileCommand.ts
@@ -12,13 +12,14 @@
 import { CicsCmciConstants, CicsCmciRestClient, ICMCIApiResponse, Utils, IGetResourceUriOptions } from "@zowe/cics-for-zowe-sdk";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedLocalFileTree } from "../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
+import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
-import { CICSCombinedLocalFileTree } from "../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
 import { ICommandParams } from "./ICommandParams";
+import constants from "../utils/constants";
 
 export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.closeLocalFile", async (clickedNode) => {
@@ -42,13 +43,11 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
           cancellable: true,
         },
         async (progress, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the Close");
-          });
+          token.onCancellationRequested(() => { });
           for (const index in allSelectedNodes) {
             progress.report({
               message: `Closing ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-              increment: (parseInt(index) / allSelectedNodes.length) * 100,
+              increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
@@ -69,7 +68,7 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
               // @ts-ignore
               if (error.mMessage) {
                 // @ts-ignore
-                const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
+                const [_resp, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
 
                 window.showErrorMessage(
                   `Perform CLOSE on local file "${allSelectedNodes[parseInt(index)].localFile.file
@@ -117,7 +116,7 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
   });
 }
 
-async function closeLocalFile(
+function closeLocalFile(
   session: imperative.AbstractSession,
   parms: ICommandParams,
   busyDecision: string
@@ -146,5 +145,5 @@ async function closeLocalFile(
 
   const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, options);
 
-  return await CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
+  return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
@@ -12,13 +12,14 @@
 import { CicsCmciConstants, CicsCmciRestClient, ICMCIApiResponse, Utils, IGetResourceUriOptions } from "@zowe/cics-for-zowe-sdk";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedLocalFileTree } from "../../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
+import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
-import { CICSLocalFileTreeItem } from "../../trees/treeItems/CICSLocalFileTreeItem";
-import { CICSCombinedLocalFileTree } from "../../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
 import { ICommandParams } from "../ICommandParams";
+import { CICSLocalFileTreeItem } from "../../trees/treeItems/CICSLocalFileTreeItem";
+import constants from "../../utils/constants";
 
 export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.disableLocalFile", async (clickedNode) => {
@@ -42,13 +43,11 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<an
           cancellable: true,
         },
         async (progress, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the Disable");
-          });
+          token.onCancellationRequested(() => { });
           for (const index in allSelectedNodes) {
             progress.report({
               message: `Disabling ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-              increment: (parseInt(index) / allSelectedNodes.length) * 100,
+              increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
@@ -106,7 +105,7 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<an
   });
 }
 
-async function disableLocalFile(
+function disableLocalFile(
   session: imperative.AbstractSession,
   parms: ICommandParams,
   busyDecision: string
@@ -135,5 +134,5 @@ async function disableLocalFile(
 
   const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, options);
 
-  return await CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
+  return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
@@ -12,13 +12,14 @@
 import { CicsCmciConstants, CicsCmciRestClient, ICMCIApiResponse, Utils, IGetResourceUriOptions } from "@zowe/cics-for-zowe-sdk";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedProgramTree } from "../../trees/CICSCombinedTrees/CICSCombinedProgramTree";
+import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSProgramTreeItem } from "../../trees/treeItems/CICSProgramTreeItem";
-import { CICSCombinedProgramTree } from "../../trees/CICSCombinedTrees/CICSCombinedProgramTree";
 import { ICommandParams } from "../ICommandParams";
+import constants from "../../utils/constants";
 
 /**
  * Performs disable on selected CICSProgram nodes.
@@ -40,13 +41,11 @@ export function getDisableProgramCommand(tree: CICSTree, treeview: TreeView<any>
         cancellable: true,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the Disable");
-        });
+        token.onCancellationRequested(() => { });
         for (const index in allSelectedNodes) {
           progress.report({
             message: `Disabling ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-            increment: (parseInt(index) / allSelectedNodes.length) * 100,
+            increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 

--- a/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
@@ -12,13 +12,14 @@
 import { CicsCmciConstants, CicsCmciRestClient, ICMCIApiResponse, Utils, IGetResourceUriOptions } from "@zowe/cics-for-zowe-sdk";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedLocalFileTree } from "../../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
+import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes } from "../../utils/commandUtils";
-import { CICSCombinedLocalFileTree } from "../../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
 import { ICommandParams } from "../ICommandParams";
+import constants from "../../utils/constants";
 
 export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.enableLocalFile", async (clickedNode) => {
@@ -35,13 +36,11 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any
         cancellable: true,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the Enable");
-        });
+        token.onCancellationRequested(() => { });
         for (const index in allSelectedNodes) {
           progress.report({
             message: `Enabling ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-            increment: (parseInt(index) / allSelectedNodes.length) * 100,
+            increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
@@ -96,7 +95,7 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any
   });
 }
 
-async function enableLocalFile(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
+function enableLocalFile(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {
@@ -115,5 +114,5 @@ async function enableLocalFile(session: imperative.AbstractSession, parms: IComm
 
   const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, options);
 
-  return await CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
+  return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
@@ -12,13 +12,14 @@
 import { CicsCmciConstants, CicsCmciRestClient, ICMCIApiResponse, Utils, IGetResourceUriOptions } from "@zowe/cics-for-zowe-sdk";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedProgramTree } from "../../trees/CICSCombinedTrees/CICSCombinedProgramTree";
+import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes } from "../../utils/commandUtils";
-import { CICSCombinedProgramTree } from "../../trees/CICSCombinedTrees/CICSCombinedProgramTree";
 import { ICommandParams } from "../ICommandParams";
+import constants from "../../utils/constants";
 
 /**
  * Performs enable on selected CICSProgram nodes.
@@ -40,13 +41,11 @@ export function getEnableProgramCommand(tree: CICSTree, treeview: TreeView<any>)
         cancellable: true,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the Enable");
-        });
+        token.onCancellationRequested(() => { });
         for (const index in allSelectedNodes) {
           progress.report({
             message: `Enabling ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-            increment: (parseInt(index) / allSelectedNodes.length) * 100,
+            increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
@@ -100,7 +99,7 @@ export function getEnableProgramCommand(tree: CICSTree, treeview: TreeView<any>)
   });
 }
 
-async function enableProgram(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
+function enableProgram(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {
@@ -119,5 +118,5 @@ async function enableProgram(session: imperative.AbstractSession, parms: IComman
 
   const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_PROGRAM_RESOURCE, options);
 
-  return await CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
+  return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
@@ -12,13 +12,14 @@
 import { CicsCmciConstants, CicsCmciRestClient, ICMCIApiResponse, Utils, IGetResourceUriOptions } from "@zowe/cics-for-zowe-sdk";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedTransactionsTree } from "../../trees/CICSCombinedTrees/CICSCombinedTransactionTree";
+import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSTransactionTreeItem } from "../../trees/treeItems/CICSTransactionTreeItem";
-import { CICSCombinedTransactionsTree } from "../../trees/CICSCombinedTrees/CICSCombinedTransactionTree";
 import { ICommandParams } from "../ICommandParams";
+import constants from "../../utils/constants";
 
 export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.enableTransaction", async (clickedNode) => {
@@ -36,13 +37,11 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
         cancellable: true,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the Enable");
-        });
+        token.onCancellationRequested(() => { });
         for (const index in allSelectedNodes) {
           progress.report({
             message: `Enabling ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-            increment: (parseInt(index) / allSelectedNodes.length) * 100,
+            increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
@@ -96,7 +95,7 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
   });
 }
 
-async function enableTransaction(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
+function enableTransaction(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {
@@ -115,5 +114,5 @@ async function enableTransaction(session: imperative.AbstractSession, parms: ICo
 
   const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_LOCAL_TRANSACTION, options);
 
-  return await CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
+  return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/packages/vsce/src/commands/filterResourceCommands.ts
+++ b/packages/vsce/src/commands/filterResourceCommands.ts
@@ -16,14 +16,14 @@ import { CICSProgramTree } from "../trees/CICSProgramTree";
 import { CICSTaskTree } from "../trees/CICSTaskTree";
 import { CICSTransactionTree } from "../trees/CICSTransactionTree";
 import { CICSTree } from "../trees/CICSTree";
-import { CICSTCPIPServiceTree } from "../trees/treeItems/web/CICSTCPIPServiceTree";
 import { CICSLibraryDatasets } from "../trees/treeItems/CICSLibraryDatasets";
 import { CICSLibraryTreeItem } from "../trees/treeItems/CICSLibraryTreeItem";
+import { CICSPipelineTree } from "../trees/treeItems/web/CICSPipelineTree";
+import { CICSTCPIPServiceTree } from "../trees/treeItems/web/CICSTCPIPServiceTree";
+import { CICSURIMapTree } from "../trees/treeItems/web/CICSURIMapTree";
+import { CICSWebServiceTree } from "../trees/treeItems/web/CICSWebServiceTree";
 import { getPatternFromFilter } from "../utils/filterUtils";
 import { PersistentStorage } from "../utils/PersistentStorage";
-import { CICSURIMapTree } from "../trees/treeItems/web/CICSURIMapTree";
-import { CICSPipelineTree } from "../trees/treeItems/web/CICSPipelineTree";
-import { CICSWebServiceTree } from "../trees/treeItems/web/CICSWebServiceTree";
 
 export function getFilterLibrariesCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.filterLibraries", async (node) => {
@@ -51,9 +51,7 @@ export function getFilterLibrariesCommand(tree: CICSTree, treeview: TreeView<any
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of libraries");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -87,9 +85,7 @@ export function getFilterDatasetsCommand(tree: CICSTree, treeview: TreeView<any>
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of datasets");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -123,9 +119,7 @@ export function getFilterProgramsCommand(tree: CICSTree, treeview: TreeView<any>
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of programs");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -159,9 +153,7 @@ export function getFilterDatasetProgramsCommand(tree: CICSTree, treeview: TreeVi
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of programs");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -195,9 +187,7 @@ export function getFilterLocalFilesCommand(tree: CICSTree, treeview: TreeView<an
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of local files");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -231,9 +221,7 @@ export function getFilterTasksCommand(tree: CICSTree, treeview: TreeView<any>) {
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of tasks");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -267,9 +255,7 @@ export function getFilterTransactionCommand(tree: CICSTree, treeview: TreeView<a
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of transactions");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -303,9 +289,7 @@ export function getFilterTCPIPSCommand(tree: CICSTree, treeview: TreeView<any>) 
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of TCPIP Services");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -339,9 +323,7 @@ export function getFilterURIMapsCommand(tree: CICSTree, treeview: TreeView<any>)
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of URI Maps");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -375,9 +357,7 @@ export function getFilterPipelinesCommand(tree: CICSTree, treeview: TreeView<any
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of Pipelines");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }
@@ -411,9 +391,7 @@ export function getFilterWebServicesCommand(tree: CICSTree, treeview: TreeView<a
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of Web Services");
-        });
+        token.onCancellationRequested(() => { });
         await chosenNode.loadContents();
         tree._onDidChangeTreeData.fire(undefined);
       }

--- a/packages/vsce/src/commands/getFilterPlexResources.ts
+++ b/packages/vsce/src/commands/getFilterPlexResources.ts
@@ -88,9 +88,7 @@ export function getFilterPlexResources(tree: CICSTree, treeview: TreeView<any>) 
             cancellable: true,
           },
           async (_, token) => {
-            token.onCancellationRequested(() => {
-              console.log("Cancelling the loading of resources");
-            });
+            token.onCancellationRequested(() => { });
             for (const region of chosenNode.children) {
               if (region instanceof CICSRegionTree) {
                 if (region.getIsActive()) {

--- a/packages/vsce/src/commands/inquireTransaction.ts
+++ b/packages/vsce/src/commands/inquireTransaction.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { commands, TreeItemCollapsibleState, TreeView, window } from "vscode";
+import { commands, TreeView, window } from "vscode";
 import { CICSCombinedTaskTree } from "../trees/CICSCombinedTrees/CICSCombinedTaskTree";
 import { CICSPlexTree } from "../trees/CICSPlexTree";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";

--- a/packages/vsce/src/commands/newCopyCommand.ts
+++ b/packages/vsce/src/commands/newCopyCommand.ts
@@ -11,12 +11,13 @@
 
 import { programNewcopy } from "@zowe/cics-for-zowe-sdk";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedProgramTree } from "../trees/CICSCombinedTrees/CICSCombinedProgramTree";
+import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
-import { CICSCombinedProgramTree } from "../trees/CICSCombinedTrees/CICSCombinedProgramTree";
+import constants from "../utils/constants";
 
 /**
  * Performs new copy on selected CICSProgram nodes.
@@ -38,13 +39,11 @@ export function getNewCopyCommand(tree: CICSTree, treeview: TreeView<any>) {
         cancellable: true,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the New Copy");
-        });
+        token.onCancellationRequested(() => { });
         for (const index in allSelectedNodes) {
           progress.report({
             message: `New Copying ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-            increment: (parseInt(index) / allSelectedNodes.length) * 100,
+            increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
@@ -62,7 +61,7 @@ export function getNewCopyCommand(tree: CICSTree, treeview: TreeView<any>) {
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore
-              const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
+              const [_resp, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
               window.showErrorMessage(
                 `Perform NEWCOPY on Program "${allSelectedNodes[parseInt(index)].program.program
                 }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`

--- a/packages/vsce/src/commands/openLocalFileCommand.ts
+++ b/packages/vsce/src/commands/openLocalFileCommand.ts
@@ -12,13 +12,14 @@
 import { CicsCmciConstants, CicsCmciRestClient, ICMCIApiResponse, Utils, IGetResourceUriOptions } from "@zowe/cics-for-zowe-sdk";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedLocalFileTree } from "../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
+import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
-import { CICSCombinedLocalFileTree } from "../trees/CICSCombinedTrees/CICSCombinedLocalFileTree";
 import { ICommandParams } from "./ICommandParams";
+import constants from "../utils/constants";
 
 export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.openLocalFile", async (clickedNode) => {
@@ -35,13 +36,11 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
         cancellable: true,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the Open");
-        });
+        token.onCancellationRequested(() => { });
         for (const index in allSelectedNodes) {
           progress.report({
             message: `Opening ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-            increment: (parseInt(index) / allSelectedNodes.length) * 100,
+            increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
@@ -58,7 +57,7 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore
-              const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
+              const [_resp, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
               window.showErrorMessage(
                 `Perform OPEN on local file "${allSelectedNodes[parseInt(index)].localFile.file
                 }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
@@ -104,7 +103,7 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
   });
 }
 
-async function openLocalFile(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
+function openLocalFile(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   const requestBody: any = {
     request: {
       action: {
@@ -123,5 +122,5 @@ async function openLocalFile(session: imperative.AbstractSession, parms: IComman
 
   const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, options);
 
-  return await CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
+  return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/packages/vsce/src/commands/phaseInCommand.ts
+++ b/packages/vsce/src/commands/phaseInCommand.ts
@@ -12,12 +12,13 @@
 import { CicsCmciConstants, CicsCmciRestClient, Utils, IGetResourceUriOptions } from "@zowe/cics-for-zowe-sdk";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedProgramTree } from "../trees/CICSCombinedTrees/CICSCombinedProgramTree";
+import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
-import { CICSCombinedProgramTree } from "../trees/CICSCombinedTrees/CICSCombinedProgramTree";
+import constants from "../utils/constants";
 
 /**
  * Performs PHASE IN on selected CICSProgram nodes.
@@ -39,13 +40,11 @@ export function getPhaseInCommand(tree: CICSTree, treeview: TreeView<any>) {
         cancellable: true,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the Phase In");
-        });
+        token.onCancellationRequested(() => { });
         for (const index in allSelectedNodes) {
           progress.report({
             message: `Phase In ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-            increment: (parseInt(index) / allSelectedNodes.length) * 100,
+            increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
@@ -63,7 +62,7 @@ export function getPhaseInCommand(tree: CICSTree, treeview: TreeView<any>) {
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore
-              const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
+              const [_resp, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
               window.showErrorMessage(
                 `Perform PHASEIN on Program "${allSelectedNodes[parseInt(index)].program.program
                 }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`

--- a/packages/vsce/src/commands/purgeTaskCommand.ts
+++ b/packages/vsce/src/commands/purgeTaskCommand.ts
@@ -12,13 +12,14 @@
 import { CicsCmciConstants, CicsCmciRestClient, ICMCIApiResponse, Utils, IGetResourceUriOptions } from "@zowe/cics-for-zowe-sdk";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
+import { CICSCombinedTaskTree } from "../trees/CICSCombinedTrees/CICSCombinedTaskTree";
+import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
 import { CICSTaskTreeItem } from "../trees/treeItems/CICSTaskTreeItem";
-import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
-import { CICSCombinedTaskTree } from "../trees/CICSCombinedTrees/CICSCombinedTaskTree";
 import { ICommandParams } from "./ICommandParams";
+import constants from "../utils/constants";
 
 /**
  * Purge a CICS Task and reload the CICS Task tree contents and the combined Task tree contents
@@ -45,13 +46,11 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
           cancellable: true,
         },
         async (progress, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the Purge");
-          });
+          token.onCancellationRequested(() => { });
           for (const index in allSelectedNodes) {
             progress.report({
               message: `Purging ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-              increment: (parseInt(index) / allSelectedNodes.length) * 100,
+              increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
@@ -72,7 +71,7 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
               // @ts-ignore
               if (error.mMessage) {
                 // @ts-ignore
-                const [_, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
+                const [_resp, resp2, respAlt, eibfnAlt] = splitCmciErrorMessage(error.mMessage);
                 window.showErrorMessage(
                   `Perform ${purgeType?.toUpperCase()} on CICSTask "${allSelectedNodes[parseInt(index)].task.task
                   }" failed: EXEC CICS command (${eibfnAlt}) RESP(${respAlt}) RESP2(${resp2})`
@@ -129,7 +128,7 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
  * @param purgeType
  * @returns
  */
-async function purgeTask(
+function purgeTask(
   session: imperative.AbstractSession,
   parms: ICommandParams,
   purgeType: string
@@ -158,5 +157,5 @@ async function purgeTask(
 
   const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_CMCI_TASK, options);
 
-  return await CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
+  return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }

--- a/packages/vsce/src/commands/refreshCommand.ts
+++ b/packages/vsce/src/commands/refreshCommand.ts
@@ -11,7 +11,6 @@
 
 import { commands, ProgressLocation, window } from "vscode";
 import { CICSTree } from "../trees/CICSTree";
-import { ProfileManagement } from "../utils/profileManagement";
 
 export function getRefreshCommand(tree: CICSTree) {
   return commands.registerCommand("cics-extension-for-zowe.refreshTree", async () => {
@@ -26,8 +25,6 @@ export function getRefreshCommand(tree: CICSTree) {
           await tree.refreshLoadedProfiles();
         }
       );
-    } catch (error) {
-      console.log(error);
     } finally {
       // window.withProgress({
       //   title: 'Refresh',

--- a/packages/vsce/src/commands/removeSessionCommand.ts
+++ b/packages/vsce/src/commands/removeSessionCommand.ts
@@ -13,6 +13,7 @@ import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSSessionTree } from "../trees/CICSSessionTree";
 import { CICSTree } from "../trees/CICSTree";
 import { findSelectedNodes } from "../utils/commandUtils";
+import constants from "../utils/constants";
 
 export function getRemoveSessionCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.removeSession", async (node) => {
@@ -28,13 +29,11 @@ export function getRemoveSessionCommand(tree: CICSTree, treeview: TreeView<any>)
         cancellable: true,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the hide command");
-        });
+        token.onCancellationRequested(() => { });
         for (const index in allSelectedNodes) {
           progress.report({
             message: `Hiding ${parseInt(index) + 1} of ${allSelectedNodes.length}`,
-            increment: (parseInt(index) / allSelectedNodes.length) * 100,
+            increment: (parseInt(index) / allSelectedNodes.length) * constants.PERCENTAGE_MAX,
           });
           try {
             const currentNode = allSelectedNodes[parseInt(index)];

--- a/packages/vsce/src/commands/showAttributesCommand.ts
+++ b/packages/vsce/src/commands/showAttributesCommand.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { commands, window, WebviewPanel, TreeView } from "vscode";
+import { commands, TreeView, WebviewPanel, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSLibraryDatasets } from "../trees/treeItems/CICSLibraryDatasets";
 import { CICSLibraryTreeItem } from "../trees/treeItems/CICSLibraryTreeItem";
@@ -17,7 +17,6 @@ import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem"
 import { CICSProgramTreeItem } from "../trees/treeItems/CICSProgramTreeItem";
 import { CICSTaskTreeItem } from "../trees/treeItems/CICSTaskTreeItem";
 import { CICSTransactionTreeItem } from "../trees/treeItems/CICSTransactionTreeItem";
-import { CICSTCPIPServiceTree } from "../trees/treeItems/web/CICSTCPIPServiceTree";
 import { CICSPipelineTreeItem } from "../trees/treeItems/web/treeItems/CICSPipelineTreeItem";
 import { CICSTCPIPServiceTreeItem } from "../trees/treeItems/web/treeItems/CICSTCPIPServiceTreeItem";
 import { CICSURIMapTreeItem } from "../trees/treeItems/web/treeItems/CICSURIMapTreeItem";
@@ -35,8 +34,10 @@ export function getShowProgramAttributesCommand(treeview: TreeView<any>) {
     for (const programTreeItem of allSelectedNodes) {
       const program = programTreeItem.program;
       const attributeHeadings = Object.keys(program);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr>`;
+      webText += `<th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th>`;
+      webText += `</tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${program[heading]}</td></tr>`;
       }
@@ -65,8 +66,8 @@ export function getShowRegionAttributes(treeview: TreeView<any>) {
     for (const regionTree of allSelectedNodes) {
       const region = regionTree.region;
       const attributeHeadings = Object.keys(region);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..." /></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..." /></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${region[heading]}</td></tr>`;
       }
@@ -93,8 +94,8 @@ export function getShowLocalFileAttributesCommand(treeview: TreeView<any>) {
     for (const localFileTreeItem of allSelectedNodes) {
       const localFile = localFileTreeItem.localFile;
       const attributeHeadings = Object.keys(localFile);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${localFile[heading]}</td></tr>`;
       }
@@ -124,8 +125,8 @@ export function getShowTransactionAttributesCommand(treeview: TreeView<any>) {
     for (const localTransactionTreeItem of allSelectedNodes) {
       const transaction = localTransactionTreeItem.transaction;
       const attributeHeadings = Object.keys(transaction);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${transaction[heading]}</td></tr>`;
       }
@@ -156,8 +157,8 @@ export function getShowTaskAttributesCommand(treeview: TreeView<any>) {
     for (const localTaskTreeItem of allSelectedNodes) {
       const task = localTaskTreeItem.task;
       const attributeHeadings = Object.keys(task);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${task[heading]}</td></tr>`;
       }
@@ -184,8 +185,8 @@ export function getShowLibraryAttributesCommand(treeview: TreeView<any>) {
     for (const libraryTreeItem of allSelectedNodes) {
       const library = libraryTreeItem.library;
       const attributeHeadings = Object.keys(library);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${library[heading]}</td></tr>`;
       }
@@ -214,8 +215,8 @@ export function getShowLibraryDatasetsAttributesCommand(treeview: TreeView<any>)
     for (const datasetTreeItem of allSelectedNodes) {
       const dataset = datasetTreeItem.dataset;
       const attributeHeadings = Object.keys(dataset);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${dataset[heading]}</td></tr>`;
       }
@@ -244,8 +245,8 @@ export function getShowTCPIPServiceAttributesCommand(treeview: TreeView<any>) {
     for (const tcpipsTreeItem of allSelectedNodes) {
       const tcpips = tcpipsTreeItem.tcpips;
       const attributeHeadings = Object.keys(tcpips);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${tcpips[heading]}</td></tr>`;
       }
@@ -271,8 +272,8 @@ export function getShowURIMapAttributesCommand(treeview: TreeView<any>) {
     for (const urimapTreeItem of allSelectedNodes) {
       const urimap = urimapTreeItem.urimap;
       const attributeHeadings = Object.keys(urimap);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${urimap[heading]}</td></tr>`;
       }
@@ -298,8 +299,8 @@ export function getShowPipelineAttributesCommand(treeview: TreeView<any>) {
     for (const pipelineTreeItem of allSelectedNodes) {
       const pipeline = pipelineTreeItem.pipeline;
       const attributeHeadings = Object.keys(pipeline);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${pipeline[heading]}</td></tr>`;
       }
@@ -328,8 +329,8 @@ export function getShowWebServiceAttributesCommand(treeview: TreeView<any>) {
     for (const webServiceTreeItem of allSelectedNodes) {
       const webService = webServiceTreeItem.webservice;
       const attributeHeadings = Object.keys(webService);
-      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th><th class="valueHeading">Value</th></tr></thead>`;
-      webText += "<tbody>";
+      let webText = `<thead><tr><th class="headingTH">Attribute <input type="text" id="searchBox" placeholder="Search Attribute..."/></th>`;
+      webText += `<th class="valueHeading">Value</th></tr></thead><tbody>`;
       for (const heading of attributeHeadings) {
         webText += `<tr><th class="colHeading">${heading.toUpperCase()}</th><td>${webService[heading]}</td></tr>`;
       }

--- a/packages/vsce/src/commands/showParameterCommand.ts
+++ b/packages/vsce/src/commands/showParameterCommand.ts
@@ -9,10 +9,10 @@
  *
  */
 
-import { commands, window, WebviewPanel, TreeView } from "vscode";
+import { getResource } from "@zowe/cics-for-zowe-sdk";
+import { commands, TreeView, WebviewPanel, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { findSelectedNodes } from "../utils/commandUtils";
-import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { getParametersHtml } from "../utils/webviewHTML";
 
 export function getShowRegionSITParametersCommand(treeview: TreeView<any>) {
@@ -34,7 +34,6 @@ export function getShowRegionSITParametersCommand(treeview: TreeView<any>) {
         cicsPlex: regionTree.parentPlex ? regionTree.parentPlex!.getPlexName() : undefined,
         parameter: "PARMSRCE(COMBINED) PARMTYPE(SIT)",
       });
-      // let webText = `<thead><tr><th class="headingTH">CICS Name <input type="text" id="searchBox" placeholder="Search Attribute..." /></th><th class="sourceHeading">Source<input type="text" id="searchBox" placeholder="Search Source..." /></th><th class="valueHeading">Value</th></tr></thead>`;
       let webText = `<thead><tr><th class="headingTH">CICS Name <input type="text" id="searchBox" placeholder="Search Attribute..." /></th>
         <th class="sourceHeading">Source
           <select id="filterSource" name="cars" id="cars">
@@ -48,8 +47,8 @@ export function getShowRegionSITParametersCommand(treeview: TreeView<any>) {
         <th class="valueHeading">Value</th></tr></thead>`;
       webText += "<tbody>";
       for (const systemParameter of db2transactionResponse.response.records.cicssystemparameter) {
-        const attributeHeadings = Object.keys(systemParameter);
-        webText += `<tr><th class="colHeading">${systemParameter.keyword.toUpperCase()}</th><td>${systemParameter.source.toUpperCase()}</td><td>${systemParameter.value.toUpperCase()}</td></tr>`;
+        webText += `<tr><th class="colHeading">${systemParameter.keyword.toUpperCase()}</th>`;
+        webText += `<td>${systemParameter.source.toUpperCase()}</td><td>${systemParameter.value.toUpperCase()}</td></tr>`;
       }
       webText += "</tbody>";
       const webviewHTML = getParametersHtml(regionTree.getRegionName(), webText);

--- a/packages/vsce/src/commands/viewMoreCommand.ts
+++ b/packages/vsce/src/commands/viewMoreCommand.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { commands, TreeView, window } from "vscode";
+import { commands, TreeView } from "vscode";
 import { CICSTree } from "../trees/CICSTree";
 import { ViewMore } from "../trees/treeItems/utils/ViewMore";
 

--- a/packages/vsce/src/extension.ts
+++ b/packages/vsce/src/extension.ts
@@ -9,75 +9,75 @@
  *
  */
 
-import { getDisableProgramCommand } from "./commands/disableCommands/disableProgramCommand";
-import { getRemoveSessionCommand } from "./commands/removeSessionCommand";
-import { getEnableProgramCommand } from "./commands/enableCommands/enableProgramCommand";
-import { getAddSessionCommand } from "./commands/addSessionCommand";
-import { getNewCopyCommand } from "./commands/newCopyCommand";
 import { ExtensionContext, ProgressLocation, TreeItemCollapsibleState, window } from "vscode";
-import { getPhaseInCommand } from "./commands/phaseInCommand";
+import { getAddSessionCommand } from "./commands/addSessionCommand";
+import { getClearPlexFilterCommand } from "./commands/clearPlexFilterCommand";
+import { getClearResourceFilterCommand } from "./commands/clearResourceFilterCommand";
+import { getCloseLocalFileCommand } from "./commands/closeLocalFileCommand";
+import { getDeleteSessionCommand } from "./commands/deleteSessionCommand";
+import { getDisableLocalFileCommand } from "./commands/disableCommands/disableLocalFileCommand";
+import { getDisableProgramCommand } from "./commands/disableCommands/disableProgramCommand";
+import { getDisableTransactionCommand } from "./commands/disableCommands/disableTransactionCommand";
+import { getEnableLocalFileCommand } from "./commands/enableCommands/enableLocalFileCommand";
+import { getEnableProgramCommand } from "./commands/enableCommands/enableProgramCommand";
+import { getEnableTransactionCommand } from "./commands/enableCommands/enableTransactionCommand";
 import {
-  getShowProgramAttributesCommand,
+  getFilterAllLibrariesCommand,
+  getFilterAllLocalFilesCommand,
+  getFilterAllPipelinesCommand,
+  getFilterAllProgramsCommand,
+  getFilterAllTasksCommand,
+  getFilterAllTCPIPServicesCommand,
+  getFilterAllTransactionsCommand,
+  getFilterAllURIMapsCommand,
+  getFilterAllWebServicesCommand,
+} from "./commands/filterAllResourceCommand";
+import {
+  getFilterDatasetProgramsCommand,
+  getFilterDatasetsCommand,
+  getFilterLibrariesCommand,
+  getFilterLocalFilesCommand,
+  getFilterPipelinesCommand,
+  getFilterProgramsCommand,
+  getFilterTasksCommand,
+  getFilterTCPIPSCommand,
+  getFilterTransactionCommand,
+  getFilterURIMapsCommand,
+  getFilterWebServicesCommand,
+} from "./commands/filterResourceCommands";
+import { getFilterPlexResources } from "./commands/getFilterPlexResources";
+import { getNewCopyCommand } from "./commands/newCopyCommand";
+import { getOpenLocalFileCommand } from "./commands/openLocalFileCommand";
+import { getPhaseInCommand } from "./commands/phaseInCommand";
+import { getRefreshCommand } from "./commands/refreshCommand";
+import { getRemoveSessionCommand } from "./commands/removeSessionCommand";
+import {
   getShowLibraryAttributesCommand,
   getShowLibraryDatasetsAttributesCommand,
-  getShowTCPIPServiceAttributesCommand,
-  getShowURIMapAttributesCommand,
-  getShowRegionAttributes,
-  getShowTransactionAttributesCommand,
   getShowLocalFileAttributesCommand,
-  getShowTaskAttributesCommand,
   getShowPipelineAttributesCommand,
+  getShowProgramAttributesCommand,
+  getShowRegionAttributes,
+  getShowTaskAttributesCommand,
+  getShowTCPIPServiceAttributesCommand,
+  getShowTransactionAttributesCommand,
+  getShowURIMapAttributesCommand,
   getShowWebServiceAttributesCommand,
 } from "./commands/showAttributesCommand";
 import { getShowRegionSITParametersCommand } from "./commands/showParameterCommand";
-import {
-  getFilterProgramsCommand,
-  getFilterDatasetProgramsCommand,
-  getFilterLibrariesCommand,
-  getFilterDatasetsCommand,
-  getFilterTransactionCommand,
-  getFilterLocalFilesCommand,
-  getFilterTasksCommand,
-  getFilterTCPIPSCommand,
-  getFilterURIMapsCommand,
-  getFilterPipelinesCommand,
-  getFilterWebServicesCommand,
-} from "./commands/filterResourceCommands";
-import { ProfileManagement } from "./utils/profileManagement";
-import { CICSTree } from "./trees/CICSTree";
-import { getClearResourceFilterCommand } from "./commands/clearResourceFilterCommand";
-import { getFilterPlexResources } from "./commands/getFilterPlexResources";
-import { getClearPlexFilterCommand } from "./commands/clearPlexFilterCommand";
-import { getRefreshCommand } from "./commands/refreshCommand";
 import { getUpdateSessionCommand } from "./commands/updateSessionCommand";
-import { getDeleteSessionCommand } from "./commands/deleteSessionCommand";
-import { getDisableTransactionCommand } from "./commands/disableCommands/disableTransactionCommand";
-import { getEnableTransactionCommand } from "./commands/enableCommands/enableTransactionCommand";
-import { getEnableLocalFileCommand } from "./commands/enableCommands/enableLocalFileCommand";
-import { getDisableLocalFileCommand } from "./commands/disableCommands/disableLocalFileCommand";
-import { getCloseLocalFileCommand } from "./commands/closeLocalFileCommand";
-import { getOpenLocalFileCommand } from "./commands/openLocalFileCommand";
-import { CICSSessionTree } from "./trees/CICSSessionTree";
 import { viewMoreCommand } from "./commands/viewMoreCommand";
-import {
-  getFilterAllProgramsCommand,
-  getFilterAllLibrariesCommand,
-  getFilterAllTransactionsCommand,
-  getFilterAllLocalFilesCommand,
-  getFilterAllURIMapsCommand,
-  getFilterAllTCPIPServicesCommand,
-  getFilterAllTasksCommand,
-  getFilterAllPipelinesCommand,
-  getFilterAllWebServicesCommand,
-} from "./commands/filterAllResourceCommand";
 import { getIconOpen, getIconPathInResources } from "./utils/profileUtils";
 import { plexExpansionHandler, sessionExpansionHandler, regionContainerExpansionHandler } from "./utils/expansionHandler";
+import { CICSSessionTree } from "./trees/CICSSessionTree";
+import { CICSTree } from "./trees/CICSTree";
+import { ProfileManagement } from "./utils/profileManagement";
 import { getZoweExplorerVersion } from "./utils/workspaceUtils";
 
+import { Logger } from "@zowe/imperative";
+import { getInquireProgramCommand } from "./commands/inquireProgram";
 import { getInquireTransactionCommand } from "./commands/inquireTransaction";
 import { getPurgeTaskCommand } from "./commands/purgeTaskCommand";
-import { getInquireProgramCommand } from "./commands/inquireProgram";
-import { Logger } from "@zowe/imperative";
 
 /**
  * Initializes the extension
@@ -109,13 +109,13 @@ export async function activate(context: ExtensionContext) {
       }
       logger.debug("Zowe Explorer was modified for the CICS Extension.");
     } catch (error) {
-      console.log(error);
       logger.error("IBM CICS for Zowe Explorer was not initialized correctly");
       return;
     }
   } else {
     window.showErrorMessage(
-      "Zowe Explorer was not found: either it is not installed or you are using an older version without extensibility API. Please ensure Zowe Explorer v2.0.0-next.202202221200 or higher is installed"
+      "Zowe Explorer was not found: either it is not installed or you are using an older version without extensibility API. " +
+      "Please ensure Zowe Explorer v2.0.0-next.202202221200 or higher is installed"
     );
     return;
   }
@@ -130,17 +130,12 @@ export async function activate(context: ExtensionContext) {
   treeview.onDidExpandElement(async (node) => {
     // Profile node expanded
     if (node.element.contextValue.includes("cicssession.")) {
-      try {
-        await sessionExpansionHandler(node.element, treeDataProv);
-      } catch (error) {
-        console.log(error);
-      }
+      await sessionExpansionHandler(node.element, treeDataProv);
       // Plex node expanded
     } else if (node.element.contextValue.includes("cicsplex.")) {
       try {
         await plexExpansionHandler(node.element, treeDataProv);
       } catch (error) {
-        console.log(error);
         const newSessionTree = new CICSSessionTree(
           node.element.getParent().profile,
           getIconPathInResources("profile-disconnected-dark.svg", "profile-disconnected-light.svg")
@@ -159,9 +154,7 @@ export async function activate(context: ExtensionContext) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of resources");
-          });
+          token.onCancellationRequested(() => { });
           await node.element.loadContents();
           treeDataProv._onDidChangeTreeData.fire(undefined);
         }
@@ -176,9 +169,7 @@ export async function activate(context: ExtensionContext) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of programs");
-          });
+          token.onCancellationRequested(() => { });
           await node.element.loadContents();
           treeDataProv._onDidChangeTreeData.fire(undefined);
         }
@@ -194,9 +185,7 @@ export async function activate(context: ExtensionContext) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of transactions");
-          });
+          token.onCancellationRequested(() => { });
           await node.element.loadContents();
           treeDataProv._onDidChangeTreeData.fire(undefined);
         }
@@ -212,9 +201,7 @@ export async function activate(context: ExtensionContext) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of local files");
-          });
+          token.onCancellationRequested(() => { });
           await node.element.loadContents();
           treeDataProv._onDidChangeTreeData.fire(undefined);
         }
@@ -230,9 +217,7 @@ export async function activate(context: ExtensionContext) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of tasks");
-          });
+          token.onCancellationRequested(() => { });
           await node.element.loadContents();
           treeDataProv._onDidChangeTreeData.fire(undefined);
         }
@@ -293,9 +278,7 @@ export async function activate(context: ExtensionContext) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of TCPIP services");
-          });
+          token.onCancellationRequested(() => { });
           await node.element.loadContents();
           treeDataProv._onDidChangeTreeData.fire(undefined);
         }
@@ -311,9 +294,7 @@ export async function activate(context: ExtensionContext) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of Web Services");
-          });
+          token.onCancellationRequested(() => { });
           await node.element.loadContents();
           treeDataProv._onDidChangeTreeData.fire(undefined);
         }
@@ -329,9 +310,7 @@ export async function activate(context: ExtensionContext) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of Pipelines");
-          });
+          token.onCancellationRequested(() => { });
           await node.element.loadContents();
           treeDataProv._onDidChangeTreeData.fire(undefined);
         }
@@ -347,9 +326,7 @@ export async function activate(context: ExtensionContext) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of URIMaps");
-          });
+          token.onCancellationRequested(() => { });
           await node.element.loadContents();
           treeDataProv._onDidChangeTreeData.fire(undefined);
         }

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLibraryTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLibraryTree.ts
@@ -9,17 +9,17 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation, workspace } from "vscode";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window, workspace } from "vscode";
+import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { ProfileManagement } from "../../utils/profileManagement";
 import { CICSPlexTree } from "../CICSPlexTree";
-import { CICSLibraryTreeItem } from "../treeItems/CICSLibraryTreeItem";
+import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { CICSTree } from "../CICSTree";
-import { ProfileManagement } from "../../utils/profileManagement";
-import { ViewMore } from "../treeItems/utils/ViewMore";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
-import { CICSRegionsContainer } from "../CICSRegionsContainer";
+import { CICSLibraryTreeItem } from "../treeItems/CICSLibraryTreeItem";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen } from "../../utils/profileUtils";
+import { ViewMore } from "../treeItems/utils/ViewMore";
 
 export class CICSCombinedLibraryTree extends TreeItem {
   children: (CICSLibraryTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -48,9 +48,7 @@ export class CICSCombinedLibraryTree extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the load");
-        });
+        token.onCancellationRequested(() => { });
         try {
           let criteria;
           if (this.activeFilter) {

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLocalFileTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedLocalFileTree.ts
@@ -9,17 +9,17 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation, workspace } from "vscode";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window, workspace } from "vscode";
+import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { ProfileManagement } from "../../utils/profileManagement";
 import { CICSPlexTree } from "../CICSPlexTree";
+import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { CICSTree } from "../CICSTree";
-import { ProfileManagement } from "../../utils/profileManagement";
-import { ViewMore } from "../treeItems/utils/ViewMore";
 import { CICSLocalFileTreeItem } from "../treeItems/CICSLocalFileTreeItem";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
-import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen } from "../../utils/profileUtils";
+import { ViewMore } from "../treeItems/utils/ViewMore";
 
 export class CICSCombinedLocalFileTree extends TreeItem {
   children: (CICSLocalFileTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -48,9 +48,7 @@ export class CICSCombinedLocalFileTree extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the load");
-        });
+        token.onCancellationRequested(() => { });
         let criteria;
         if (this.activeFilter) {
           criteria = toEscapedCriteriaString(this.activeFilter, "file");

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedPipelineTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedPipelineTree.ts
@@ -9,16 +9,16 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation, workspace } from "vscode";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window, workspace } from "vscode";
+import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { ProfileManagement } from "../../utils/profileManagement";
 import { CICSPlexTree } from "../CICSPlexTree";
+import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { CICSTree } from "../CICSTree";
-import { ProfileManagement } from "../../utils/profileManagement";
-import { ViewMore } from "../treeItems/utils/ViewMore";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
-import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen } from "../../utils/profileUtils";
+import { ViewMore } from "../treeItems/utils/ViewMore";
 import { CICSPipelineTreeItem } from "../treeItems/web/treeItems/CICSPipelineTreeItem";
 
 export class CICSCombinedPipelineTree extends TreeItem {
@@ -48,9 +48,7 @@ export class CICSCombinedPipelineTree extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the load");
-        });
+        token.onCancellationRequested(() => { });
         try {
           let criteria;
           if (this.activeFilter) {

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedProgramTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedProgramTree.ts
@@ -9,19 +9,19 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation, workspace } from "vscode";
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window, workspace } from "vscode";
+import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { ProfileManagement } from "../../utils/profileManagement";
 import { CICSPlexTree } from "../CICSPlexTree";
-import { CICSProgramTreeItem } from "../treeItems/CICSProgramTreeItem";
+import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { CICSTree } from "../CICSTree";
-import { ProfileManagement } from "../../utils/profileManagement";
-import { ViewMore } from "../treeItems/utils/ViewMore";
-import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
-import { CICSRegionsContainer } from "../CICSRegionsContainer";
+import { CICSProgramTreeItem } from "../treeItems/CICSProgramTreeItem";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen, getIconPathInResources } from "../../utils/profileUtils";
 import { imperative } from "@zowe/zowe-explorer-api";
+import { ViewMore } from "../treeItems/utils/ViewMore";
 
 export class CICSCombinedProgramTree extends TreeItem {
   children: (CICSProgramTreeItem | ViewMore)[] | [TextTreeItem] | null;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTCPIPServiceTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTCPIPServiceTree.ts
@@ -9,17 +9,17 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation, workspace } from "vscode";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window, workspace } from "vscode";
+import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { ProfileManagement } from "../../utils/profileManagement";
 import { CICSPlexTree } from "../CICSPlexTree";
-import { CICSTCPIPServiceTreeItem } from "../treeItems/web/treeItems/CICSTCPIPServiceTreeItem";
+import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { CICSTree } from "../CICSTree";
-import { ProfileManagement } from "../../utils/profileManagement";
-import { ViewMore } from "../treeItems/utils/ViewMore";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
-import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen } from "../../utils/profileUtils";
+import { ViewMore } from "../treeItems/utils/ViewMore";
+import { CICSTCPIPServiceTreeItem } from "../treeItems/web/treeItems/CICSTCPIPServiceTreeItem";
 
 export class CICSCombinedTCPIPServiceTree extends TreeItem {
   children: (CICSTCPIPServiceTreeItem | ViewMore)[] | [TextTreeItem] | null;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTaskTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTaskTree.ts
@@ -9,14 +9,14 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation, workspace } from "vscode";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window, workspace } from "vscode";
+import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { ProfileManagement } from "../../utils/profileManagement";
 import { CICSPlexTree } from "../CICSPlexTree";
+import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { CICSTree } from "../CICSTree";
-import { ProfileManagement } from "../../utils/profileManagement";
 import { ViewMore } from "../treeItems/utils/ViewMore";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
-import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen } from "../../utils/profileUtils";
 import { CICSTaskTreeItem } from "../treeItems/CICSTaskTreeItem";

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTransactionTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedTransactionTree.ts
@@ -9,18 +9,18 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation, workspace } from "vscode";
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window, workspace } from "vscode";
+import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { ProfileManagement } from "../../utils/profileManagement";
 import { CICSPlexTree } from "../CICSPlexTree";
+import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { CICSTree } from "../CICSTree";
-import { ProfileManagement } from "../../utils/profileManagement";
-import { ViewMore } from "../treeItems/utils/ViewMore";
-import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { CICSTransactionTreeItem } from "../treeItems/CICSTransactionTreeItem";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
-import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen } from "../../utils/profileUtils";
+import { ViewMore } from "../treeItems/utils/ViewMore";
 
 export class CICSCombinedTransactionsTree extends TreeItem {
   children: (CICSTransactionTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -49,9 +49,7 @@ export class CICSCombinedTransactionsTree extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the load");
-        });
+        token.onCancellationRequested(() => { });
         try {
           let criteria;
           if (this.activeFilter) {

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedURIMapTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedURIMapTree.ts
@@ -9,17 +9,17 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation, workspace } from "vscode";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window, workspace } from "vscode";
+import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { ProfileManagement } from "../../utils/profileManagement";
 import { CICSPlexTree } from "../CICSPlexTree";
-import { CICSURIMapTreeItem } from "../treeItems/web/treeItems/CICSURIMapTreeItem";
+import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { CICSTree } from "../CICSTree";
-import { ProfileManagement } from "../../utils/profileManagement";
-import { ViewMore } from "../treeItems/utils/ViewMore";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
-import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen } from "../../utils/profileUtils";
+import { ViewMore } from "../treeItems/utils/ViewMore";
+import { CICSURIMapTreeItem } from "../treeItems/web/treeItems/CICSURIMapTreeItem";
 
 export class CICSCombinedURIMapTree extends TreeItem {
   children: (CICSURIMapTreeItem | ViewMore)[] | [TextTreeItem] | null;

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedWebServiceTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedWebServiceTree.ts
@@ -9,16 +9,16 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation, workspace } from "vscode";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window, workspace } from "vscode";
+import { toEscapedCriteriaString } from "../../utils/filterUtils";
+import { ProfileManagement } from "../../utils/profileManagement";
 import { CICSPlexTree } from "../CICSPlexTree";
+import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { CICSTree } from "../CICSTree";
-import { ProfileManagement } from "../../utils/profileManagement";
-import { ViewMore } from "../treeItems/utils/ViewMore";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
-import { CICSRegionsContainer } from "../CICSRegionsContainer";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { getIconOpen } from "../../utils/profileUtils";
+import { ViewMore } from "../treeItems/utils/ViewMore";
 import { CICSWebServiceTreeItem } from "../treeItems/web/treeItems/CICSWebServiceTreeItem";
 
 export class CICSCombinedWebServiceTree extends TreeItem {

--- a/packages/vsce/src/trees/CICSRegionsContainer.ts
+++ b/packages/vsce/src/trees/CICSRegionsContainer.ts
@@ -9,13 +9,13 @@
  *
  */
 
-import { TreeItemCollapsibleState, TreeItem, window, ProgressLocation } from "vscode";
+import { getResource } from "@zowe/cics-for-zowe-sdk";
+import { ProgressLocation, TreeItem, TreeItemCollapsibleState, window } from "vscode";
+import { ProfileManagement } from "../utils/profileManagement";
 import { CICSPlexTree } from "./CICSPlexTree";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { CICSTree } from "./CICSTree";
-import { ProfileManagement } from "../utils/profileManagement";
 import { getIconOpen } from "../utils/profileUtils";
-import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { toArray } from "../utils/commandUtils";
 
 export class CICSRegionsContainer extends TreeItem {
@@ -43,9 +43,7 @@ export class CICSRegionsContainer extends TreeItem {
         cancellable: true,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the filter");
-        });
+        token.onCancellationRequested(() => { });
         const regionInfo = await ProfileManagement.getRegionInfoInPlex(this.parent);
         this.addRegionsUtility(regionInfo);
         this.collapsibleState = TreeItemCollapsibleState.Expanded;

--- a/packages/vsce/src/trees/CICSWebTree.ts
+++ b/packages/vsce/src/trees/CICSWebTree.ts
@@ -53,7 +53,7 @@ export class CICSWebTree extends TreeItem {
     this.collapsibleState = TreeItemCollapsibleState.Expanded;*/
   }
 
-  public setFilter(newFilter: string) {
+  public setFilter(_newFilter: string) {
     /*this.activeFilter = newFilter;
     this.contextValue = `cicstreeweb.${this.activeFilter ? 'filtered' : 'unfiltered'}.web`;
     this.collapsibleState = TreeItemCollapsibleState.Expanded;*/

--- a/packages/vsce/src/utils/PersistentStorage.ts
+++ b/packages/vsce/src/utils/PersistentStorage.ts
@@ -10,6 +10,7 @@
  */
 
 import { ConfigurationTarget, workspace } from "vscode";
+import constants from "./constants";
 
 export class PersistentStorage {
   public schema: string;
@@ -292,7 +293,7 @@ export class PersistentStorage {
 
       this.mProgramSearchHistory.unshift(criteria);
 
-      if (this.mProgramSearchHistory.length > 10) {
+      if (this.mProgramSearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mProgramSearchHistory.pop();
       }
       await this.updateProgramSearchHistory();
@@ -307,7 +308,7 @@ export class PersistentStorage {
 
       this.mLibrarySearchHistory.unshift(criteria);
 
-      if (this.mLibrarySearchHistory.length > 10) {
+      if (this.mLibrarySearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mLibrarySearchHistory.pop();
       }
       await this.updateLibrarySearchHistory();
@@ -322,7 +323,7 @@ export class PersistentStorage {
 
       this.mDatasetSearchHistory.unshift(criteria);
 
-      if (this.mDatasetSearchHistory.length > 10) {
+      if (this.mDatasetSearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mDatasetSearchHistory.pop();
       }
       await this.updateDatasetSearchHistory();
@@ -337,7 +338,7 @@ export class PersistentStorage {
 
       this.mTransactionSearchHistory.unshift(criteria);
 
-      if (this.mTransactionSearchHistory.length > 10) {
+      if (this.mTransactionSearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mTransactionSearchHistory.pop();
       }
       await this.updateTransactionSearchHistory();
@@ -352,7 +353,7 @@ export class PersistentStorage {
 
       this.mLocalFileSearchHistory.unshift(criteria);
 
-      if (this.mLocalFileSearchHistory.length > 10) {
+      if (this.mLocalFileSearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mLocalFileSearchHistory.pop();
       }
       await this.updateLocalFileSearchHistory();
@@ -367,7 +368,7 @@ export class PersistentStorage {
 
       this.mRegionSearchHistory.unshift(criteria);
 
-      if (this.mRegionSearchHistory.length > 10) {
+      if (this.mRegionSearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mRegionSearchHistory.pop();
       }
       await this.updateRegionSearchHistory();
@@ -393,7 +394,7 @@ export class PersistentStorage {
 
       this.mTCPIPSSearchHistory.unshift(criteria);
 
-      if (this.mTCPIPSSearchHistory.length > 10) {
+      if (this.mTCPIPSSearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mTCPIPSSearchHistory.pop();
       }
       await this.updateTCPIPSSearchHistory();
@@ -408,7 +409,7 @@ export class PersistentStorage {
 
       this.mURIMapsSearchHistory.unshift(criteria);
 
-      if (this.mURIMapsSearchHistory.length > 10) {
+      if (this.mURIMapsSearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mURIMapsSearchHistory.pop();
       }
       await this.updateURIMapsSearchHistory();
@@ -423,7 +424,7 @@ export class PersistentStorage {
 
       this.mPipelineSearchHistory.unshift(criteria);
 
-      if (this.mPipelineSearchHistory.length > 10) {
+      if (this.mPipelineSearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mPipelineSearchHistory.pop();
       }
       await this.updatePipelineSearchHistory();
@@ -438,7 +439,7 @@ export class PersistentStorage {
 
       this.mWebServiceSearchHistory.unshift(criteria);
 
-      if (this.mWebServiceSearchHistory.length > 10) {
+      if (this.mWebServiceSearchHistory.length > constants.PERSISTENT_STORAGE_MAX_LENGTH) {
         this.mWebServiceSearchHistory.pop();
       }
       await this.updateWebServiceSearchHistory();

--- a/packages/vsce/src/utils/constants.ts
+++ b/packages/vsce/src/utils/constants.ts
@@ -1,0 +1,48 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export default {
+
+  /**
+   * Default maximum number of resources returned from a CMCI request
+   */
+  RESOURCES_MAX: 800,
+
+  /**
+   * Default maximum number of items stored in persistent storage
+   */
+  PERSISTENT_STORAGE_MAX_LENGTH: 10,
+
+  /**
+   * 100 percent for progress bars
+   */
+  PERCENTAGE_MAX: 100,
+
+  /**
+   * HTTP return code for OK
+   */
+  HTTP_OK: 200,
+
+  /**
+   * HTTP return code for Unauthorized
+   */
+  HTTP_ERROR_UNAUTHORIZED: 401,
+
+  /**
+   * HTTP return code for Not Found
+   */
+  HTTP_ERROR_NOT_FOUND: 404,
+
+  /**
+   * HTTP return code for Server Error
+   */
+  HTTP_ERROR_SERVER_ERROR: 500,
+};

--- a/packages/vsce/src/utils/expansionHandler.ts
+++ b/packages/vsce/src/utils/expansionHandler.ts
@@ -38,9 +38,7 @@ export function regionContainerExpansionHandler(regionContiner: CICSRegionsConta
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of the regions");
-          });
+          token.onCancellationRequested(() => { });
           regionContiner.clearChildren();
           await regionContiner.loadRegionsInCICSGroup(tree);
           regionContiner.iconPath = getIconOpen(true);
@@ -56,9 +54,7 @@ export function regionContainerExpansionHandler(regionContiner: CICSRegionsConta
         cancellable: false,
       },
       async (_, token) => {
-        token.onCancellationRequested(() => {
-          console.log("Cancelling the loading of regions");
-        });
+        token.onCancellationRequested(() => { });
         regionContiner.clearChildren();
         await regionContiner.loadRegionsInPlex();
         regionContiner.iconPath = getIconOpen(true);
@@ -86,9 +82,7 @@ export function plexExpansionHandler(plex: CICSPlexTree, tree: CICSTree) {
           cancellable: false,
         },
         async (_, token) => {
-          token.onCancellationRequested(() => {
-            console.log("Cancelling the loading of the region");
-          });
+          token.onCancellationRequested(() => { });
           await plex.loadOnlyRegion();
           tree._onDidChangeTreeData.fire(undefined);
         }

--- a/packages/vsce/src/utils/filterUtils.ts
+++ b/packages/vsce/src/utils/filterUtils.ts
@@ -16,7 +16,7 @@ export async function resolveQuickPickHelper(quickpick: QuickPick<QuickPickItem>
 }
 
 export class FilterDescriptor implements QuickPickItem {
-  constructor(private text: string) {}
+  constructor(private text: string) { }
   get label(): string {
     return this.text;
   }
@@ -57,7 +57,7 @@ export async function getPatternFromFilter(resourceName: string, resourceHistory
     value: pattern,
   };
   if (!options2.validateInput) {
-    options2.validateInput = (value) => null;
+    options2.validateInput = (_value) => null;
   }
   pattern = (await window.showInputBox(options2)) || "";
   if (!pattern) {

--- a/packages/vsce/src/utils/profileManagement.ts
+++ b/packages/vsce/src/utils/profileManagement.ts
@@ -16,6 +16,7 @@ import { window } from "vscode";
 import { xml2json } from "xml-js";
 import { CICSPlexTree } from "../trees/CICSPlexTree";
 import { toArray } from "./commandUtils";
+import constants from "./constants";
 import cicsProfileMeta from "./profileDefinition";
 
 export class ProfileManagement {
@@ -329,7 +330,12 @@ export class ProfileManagement {
     return { cacheToken: null, recordCount: 0 };
   }
 
-  public static async getCachedResources(profile: imperative.IProfileLoaded, cacheToken: string, resourceName: string, start = 1, increment = 800) {
+  public static async getCachedResources(
+    profile: imperative.IProfileLoaded,
+    cacheToken: string,
+    resourceName: string,
+    start = 1,
+    increment = constants.RESOURCES_MAX) {
     const session = this.getSessionFromProfile(profile.profile);
     const allItemsresponse = await getCache(session, {
       cacheToken,


### PR DESCRIPTION
**What It Does**

Partial fix for #146.
Resolves basic lint warnings in packages. Does NOT resolve complexity or `any` return type warnings - these will be in a follow-up PR as they require more refactoring.

Introduces a constants file for repeated, magic values throughout the VSCE package.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
