### PR TITLE
handle getCache returning non-array

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 ## Recent Changes
 
 - BugFix: Remove create profile gif from readme. [#33](https://github.com/zowe/cics-for-zowe-client/issues/33)
+- BugFix: Handle getCache returning non-array. [#178](https://github.com/zowe/cics-for-zowe-client/issues/178)
 
 ## `3.2.4`
 

--- a/packages/vsce/src/utils/commandUtils.ts
+++ b/packages/vsce/src/utils/commandUtils.ts
@@ -63,6 +63,6 @@ export function splitCmciErrorMessage(message: any) {
   return [resp, resp2, respAlt, eibfnAlt];
 }
 
-export function toArray<T>(input: T | [T]): [T] {
+export function toArray<T>(input: T | T[]): T[] {
   return Array.isArray(input) ? input : [input];
 }

--- a/packages/vsce/src/utils/profileManagement.ts
+++ b/packages/vsce/src/utils/profileManagement.ts
@@ -220,12 +220,14 @@ export class ProfileManagement {
     if (isPlex) {
       try {
         const { response } = await getCache(session, { cacheToken: isPlex, nodiscard: false });
-        for (const plex of response.records.cicscicsplex || []) {
-          infoLoaded.push({
-            plexname: plex.plexname,
-            regions: [],
-            group: false,
-          });
+        if (response.records.cicscicsplex) {
+          for (const plex of toArray(response.records.cicscicsplex)) {
+            infoLoaded.push({
+              plexname: plex.plexname,
+              regions: [],
+              group: false,
+            });
+          }
         }
       } catch (error) {
         window.showErrorMessage(


### PR DESCRIPTION
**What It Does**
Fixes using a profile without a plex specified that only has 1 plex available - it was trying to loop an array when the response was actually an object.

Follow on fix for #178

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

