### PR TITLE
Catch NODATA response when generating cache

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Inform user no resources found when filtering trees. [#200](https://github.com/zowe/cics-for-zowe-client/issues/200)
+
 ## `3.2.5`
 
 - BugFix: Remove create profile gif from readme. [#33](https://github.com/zowe/cics-for-zowe-client/issues/33)
 - BugFix: Handle getCache returning non-array. [#178](https://github.com/zowe/cics-for-zowe-client/issues/178)
-- BugFix: Inform user no resources found when filtering trees. [#200](https://github.com/zowe/cics-for-zowe-client/issues/200)
 
 ## `3.2.4`
 

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 
 - BugFix: Remove create profile gif from readme. [#33](https://github.com/zowe/cics-for-zowe-client/issues/33)
 - BugFix: Handle getCache returning non-array. [#178](https://github.com/zowe/cics-for-zowe-client/issues/178)
+- BugFix: Inform user no resources found when filtering trees. [#200](https://github.com/zowe/cics-for-zowe-client/issues/200)
 
 ## `3.2.4`
 


### PR DESCRIPTION
**What It Does**
Resolves #200 

Adds a check for a NODATA response when generating a cache token for the combined trees. If the query comes back with NODATA, an error is thrown by the SDK. This was not handled and ignored by the VSCE.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

<img width="465" alt="Screenshot 2025-01-09 at 10 59 38 PM" src="https://github.com/user-attachments/assets/c7cbc314-15cf-4521-aa9d-5fb9c8efab73" />
