### PR TITLE
Refactor command registration and tree expansion events

### DIFF
--- a/packages/vsce/src/commands/disableCommands/index.ts
+++ b/packages/vsce/src/commands/disableCommands/index.ts
@@ -1,0 +1,15 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export * from './disableLocalFileCommand';
+export * from './disableProgramCommand';
+export * from './disableTransactionCommand';
+

--- a/packages/vsce/src/commands/enableCommands/index.ts
+++ b/packages/vsce/src/commands/enableCommands/index.ts
@@ -1,0 +1,15 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export * from './enableLocalFileCommand';
+export * from './enableProgramCommand';
+export * from './enableTransactionCommand';
+

--- a/packages/vsce/src/commands/index.ts
+++ b/packages/vsce/src/commands/index.ts
@@ -1,0 +1,110 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import * as disableCommands from './disableCommands';
+import * as enableCommands from './enableCommands';
+
+import { TreeView } from 'vscode';
+import { CICSTree } from '../trees/CICSTree';
+import { getAddSessionCommand } from "./addSessionCommand";
+import { getClearPlexFilterCommand } from "./clearPlexFilterCommand";
+import { getClearResourceFilterCommand } from "./clearResourceFilterCommand";
+import { getCloseLocalFileCommand } from "./closeLocalFileCommand";
+import { getDeleteSessionCommand } from "./deleteSessionCommand";
+import * as filterAllResourceCommands from "./filterAllResourceCommand";
+import * as filterResourceCommands from "./filterResourceCommands";
+import { getFilterPlexResources } from "./getFilterPlexResources";
+import { getInquireProgramCommand } from "./inquireProgram";
+import { getInquireTransactionCommand } from "./inquireTransaction";
+import { getNewCopyCommand } from "./newCopyCommand";
+import { getOpenLocalFileCommand } from "./openLocalFileCommand";
+import { getPhaseInCommand } from "./phaseInCommand";
+import { getPurgeTaskCommand } from "./purgeTaskCommand";
+import { getRefreshCommand } from "./refreshCommand";
+import { getRemoveSessionCommand } from "./removeSessionCommand";
+import * as showAttributesCommands from "./showAttributesCommand";
+import { getShowRegionSITParametersCommand } from "./showParameterCommand";
+import { getUpdateSessionCommand } from "./updateSessionCommand";
+import { viewMoreCommand } from "./viewMoreCommand";
+
+export const getCommands = (treeDataProv: CICSTree, treeview: TreeView<any>) => {
+
+  return [
+    getAddSessionCommand(treeDataProv),
+    getRemoveSessionCommand(treeDataProv, treeview),
+    getUpdateSessionCommand(treeDataProv, treeview),
+    getDeleteSessionCommand(treeDataProv, treeview),
+
+    getRefreshCommand(treeDataProv),
+
+    getNewCopyCommand(treeDataProv, treeview),
+    getPhaseInCommand(treeDataProv, treeview),
+
+    enableCommands.getEnableProgramCommand(treeDataProv, treeview),
+    enableCommands.getEnableTransactionCommand(treeDataProv, treeview),
+    enableCommands.getEnableLocalFileCommand(treeDataProv, treeview),
+    disableCommands.getDisableProgramCommand(treeDataProv, treeview),
+    disableCommands.getDisableTransactionCommand(treeDataProv, treeview),
+    disableCommands.getDisableLocalFileCommand(treeDataProv, treeview),
+
+    getCloseLocalFileCommand(treeDataProv, treeview),
+    getOpenLocalFileCommand(treeDataProv, treeview),
+
+    getPurgeTaskCommand(treeDataProv, treeview),
+
+    showAttributesCommands.getShowRegionAttributes(treeview),
+    showAttributesCommands.getShowProgramAttributesCommand(treeview),
+    showAttributesCommands.getShowLibraryAttributesCommand(treeview),
+    showAttributesCommands.getShowLibraryDatasetsAttributesCommand(treeview),
+    showAttributesCommands.getShowTCPIPServiceAttributesCommand(treeview),
+    showAttributesCommands.getShowURIMapAttributesCommand(treeview),
+    showAttributesCommands.getShowTransactionAttributesCommand(treeview),
+    showAttributesCommands.getShowLocalFileAttributesCommand(treeview),
+    showAttributesCommands.getShowTaskAttributesCommand(treeview),
+    showAttributesCommands.getShowPipelineAttributesCommand(treeview),
+    showAttributesCommands.getShowWebServiceAttributesCommand(treeview),
+
+    getShowRegionSITParametersCommand(treeview),
+
+    filterResourceCommands.getFilterProgramsCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterDatasetProgramsCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterLibrariesCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterDatasetsCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterTransactionCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterLocalFilesCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterTasksCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterTCPIPSCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterURIMapsCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterPipelinesCommand(treeDataProv, treeview),
+    filterResourceCommands.getFilterWebServicesCommand(treeDataProv, treeview),
+
+    filterAllResourceCommands.getFilterAllProgramsCommand(treeDataProv, treeview),
+    filterAllResourceCommands.getFilterAllLibrariesCommand(treeDataProv, treeview),
+    filterAllResourceCommands.getFilterAllWebServicesCommand(treeDataProv, treeview),
+    filterAllResourceCommands.getFilterAllPipelinesCommand(treeDataProv, treeview),
+    filterAllResourceCommands.getFilterAllTransactionsCommand(treeDataProv, treeview),
+    filterAllResourceCommands.getFilterAllLocalFilesCommand(treeDataProv, treeview),
+    filterAllResourceCommands.getFilterAllTasksCommand(treeDataProv, treeview),
+    filterAllResourceCommands.getFilterAllTCPIPServicesCommand(treeDataProv, treeview),
+    filterAllResourceCommands.getFilterAllURIMapsCommand(treeDataProv, treeview),
+
+    getFilterPlexResources(treeDataProv, treeview),
+
+    getClearResourceFilterCommand(treeDataProv, treeview),
+    getClearPlexFilterCommand(treeDataProv, treeview),
+
+    viewMoreCommand(treeDataProv, treeview),
+
+    getInquireTransactionCommand(treeDataProv, treeview),
+    getInquireProgramCommand(treeDataProv, treeview),
+  ];
+
+};

--- a/packages/vsce/src/extension.ts
+++ b/packages/vsce/src/extension.ts
@@ -10,74 +10,15 @@
  */
 
 import { ExtensionContext, ProgressLocation, TreeItemCollapsibleState, window } from "vscode";
-import { getAddSessionCommand } from "./commands/addSessionCommand";
-import { getClearPlexFilterCommand } from "./commands/clearPlexFilterCommand";
-import { getClearResourceFilterCommand } from "./commands/clearResourceFilterCommand";
-import { getCloseLocalFileCommand } from "./commands/closeLocalFileCommand";
-import { getDeleteSessionCommand } from "./commands/deleteSessionCommand";
-import { getDisableLocalFileCommand } from "./commands/disableCommands/disableLocalFileCommand";
-import { getDisableProgramCommand } from "./commands/disableCommands/disableProgramCommand";
-import { getDisableTransactionCommand } from "./commands/disableCommands/disableTransactionCommand";
-import { getEnableLocalFileCommand } from "./commands/enableCommands/enableLocalFileCommand";
-import { getEnableProgramCommand } from "./commands/enableCommands/enableProgramCommand";
-import { getEnableTransactionCommand } from "./commands/enableCommands/enableTransactionCommand";
-import {
-  getFilterAllLibrariesCommand,
-  getFilterAllLocalFilesCommand,
-  getFilterAllPipelinesCommand,
-  getFilterAllProgramsCommand,
-  getFilterAllTasksCommand,
-  getFilterAllTCPIPServicesCommand,
-  getFilterAllTransactionsCommand,
-  getFilterAllURIMapsCommand,
-  getFilterAllWebServicesCommand,
-} from "./commands/filterAllResourceCommand";
-import {
-  getFilterDatasetProgramsCommand,
-  getFilterDatasetsCommand,
-  getFilterLibrariesCommand,
-  getFilterLocalFilesCommand,
-  getFilterPipelinesCommand,
-  getFilterProgramsCommand,
-  getFilterTasksCommand,
-  getFilterTCPIPSCommand,
-  getFilterTransactionCommand,
-  getFilterURIMapsCommand,
-  getFilterWebServicesCommand,
-} from "./commands/filterResourceCommands";
-import { getFilterPlexResources } from "./commands/getFilterPlexResources";
-import { getNewCopyCommand } from "./commands/newCopyCommand";
-import { getOpenLocalFileCommand } from "./commands/openLocalFileCommand";
-import { getPhaseInCommand } from "./commands/phaseInCommand";
-import { getRefreshCommand } from "./commands/refreshCommand";
-import { getRemoveSessionCommand } from "./commands/removeSessionCommand";
-import {
-  getShowLibraryAttributesCommand,
-  getShowLibraryDatasetsAttributesCommand,
-  getShowLocalFileAttributesCommand,
-  getShowPipelineAttributesCommand,
-  getShowProgramAttributesCommand,
-  getShowRegionAttributes,
-  getShowTaskAttributesCommand,
-  getShowTCPIPServiceAttributesCommand,
-  getShowTransactionAttributesCommand,
-  getShowURIMapAttributesCommand,
-  getShowWebServiceAttributesCommand,
-} from "./commands/showAttributesCommand";
-import { getShowRegionSITParametersCommand } from "./commands/showParameterCommand";
-import { getUpdateSessionCommand } from "./commands/updateSessionCommand";
-import { viewMoreCommand } from "./commands/viewMoreCommand";
-import { getIconOpen, getIconPathInResources } from "./utils/profileUtils";
-import { plexExpansionHandler, sessionExpansionHandler, regionContainerExpansionHandler } from "./utils/expansionHandler";
 import { CICSSessionTree } from "./trees/CICSSessionTree";
 import { CICSTree } from "./trees/CICSTree";
+import { plexExpansionHandler, regionContainerExpansionHandler, sessionExpansionHandler } from "./utils/expansionHandler";
 import { ProfileManagement } from "./utils/profileManagement";
+import { getIconOpen, getIconPathInResources } from "./utils/profileUtils";
 import { getZoweExplorerVersion } from "./utils/workspaceUtils";
 
 import { Logger } from "@zowe/imperative";
-import { getInquireProgramCommand } from "./commands/inquireProgram";
-import { getInquireTransactionCommand } from "./commands/inquireTransaction";
-import { getPurgeTaskCommand } from "./commands/purgeTaskCommand";
+import { getCommands } from "./commands";
 
 /**
  * Initializes the extension
@@ -127,14 +68,56 @@ export async function activate(context: ExtensionContext) {
     canSelectMany: true,
   });
 
-  treeview.onDidExpandElement(async (node) => {
-    // Profile node expanded
-    if (node.element.contextValue.includes("cicssession.")) {
+  const expandCombinedTree = async (node: any) => {
+    if (node.element.getActiveFilter()) {
+      await node.element.loadContents(treeDataProv);
+    }
+    node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
+  };
+
+  const expandResourceTree = (node: any) => {
+    window.withProgress({
+      location: ProgressLocation.Notification,
+      title: "Loading resources...",
+      cancellable: true
+    }, async (_progress, _token) => {
+      await node.element.loadContents();
+      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
+      treeDataProv._onDidChangeTreeData.fire(undefined);
+    });
+  };
+
+  const contextMap: { [key: string]: (node: any) => Promise<void> | void; } = {
+    cicscombinedprogramtree: expandCombinedTree,
+    cicscombinedtransactiontree: expandCombinedTree,
+    cicscombinedlocalfiletree: expandCombinedTree,
+    cicscombinedtasktree: expandCombinedTree,
+    cicscombinedlibrarytree: expandCombinedTree,
+    cicscombinedtcpipstree: expandCombinedTree,
+    cicscombinedurimapstree: expandCombinedTree,
+    cicscombinedpipelinetree: expandCombinedTree,
+    cicscombinedwebservicetree: expandCombinedTree,
+
+    cicstreeweb: expandResourceTree,
+    cicstreeprogram: expandResourceTree,
+    cicstreetransaction: expandResourceTree,
+    cicstreelocalfile: expandResourceTree,
+    cicstreetask: expandResourceTree,
+    cicstreelibrary: expandResourceTree,
+    cicslibrary: expandResourceTree,
+    cicsdatasets: expandResourceTree,
+    cicstreetcpips: expandResourceTree,
+    cicstreewebservice: expandResourceTree,
+    cicstreepipeline: expandResourceTree,
+    cicstreeurimaps: expandResourceTree,
+
+    cicssession: async (node: any) => {
       await sessionExpansionHandler(node.element, treeDataProv);
-      // Plex node expanded
-    } else if (node.element.contextValue.includes("cicsplex.")) {
+    },
+
+    cicsplex: (node: any) => {
       try {
-        await plexExpansionHandler(node.element, treeDataProv);
+        plexExpansionHandler(node.element, treeDataProv);
       } catch (error) {
         const newSessionTree = new CICSSessionTree(
           node.element.getParent().profile,
@@ -143,269 +126,24 @@ export async function activate(context: ExtensionContext) {
         treeDataProv.loadedProfiles.splice(treeDataProv.getLoadedProfiles().indexOf(node.element.getParent()), 1, newSessionTree);
         treeDataProv._onDidChangeTreeData.fire(undefined);
       }
-      // Region node expanded
-    } else if (node.element.contextValue.includes("cicsregion.")) {
-      // Web folder node expanded
-    } else if (node.element.contextValue.includes("cicstreeweb.")) {
-      window.withProgress(
-        {
-          title: "Loading Resources",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async (_, token) => {
-          token.onCancellationRequested(() => { });
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-      // Programs folder node expanded
-    } else if (node.element.contextValue.includes("cicstreeprogram.")) {
-      window.withProgress(
-        {
-          title: "Loading Programs",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async (_, token) => {
-          token.onCancellationRequested(() => { });
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
+    },
 
-      // Transaction folder node expanded
-    } else if (node.element.contextValue.includes("cicstreetransaction.")) {
-      window.withProgress(
-        {
-          title: "Loading Transactions",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async (_, token) => {
-          token.onCancellationRequested(() => { });
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // Local file folder node expanded
-    } else if (node.element.contextValue.includes("cicstreelocalfile.")) {
-      window.withProgress(
-        {
-          title: "Loading Local Files",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async (_, token) => {
-          token.onCancellationRequested(() => { });
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // Task folder node expanded
-    } else if (node.element.contextValue.includes("cicstreetask.")) {
-      window.withProgress(
-        {
-          title: "Loading Tasks",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async (_, token) => {
-          token.onCancellationRequested(() => { });
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // Library folder node expanded
-    } else if (node.element.contextValue.includes("cicstreelibrary.")) {
-      window.withProgress(
-        {
-          title: "Loading Libraries",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async () => {
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // Library tree item node expanded to view datasets
-    } else if (node.element.contextValue.includes("cicslibrary.")) {
-      window.withProgress(
-        {
-          title: "Loading Datasets",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async () => {
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // Dataset node expanded
-    } else if (node.element.contextValue.includes("cicsdatasets.")) {
-      window.withProgress(
-        {
-          title: "Loading Programs",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async () => {
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // TCPIP folder node expanded
-    } else if (node.element.contextValue.includes("cicstreetcpips.")) {
-      window.withProgress(
-        {
-          title: "Loading TCPIP Services",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async (_, token) => {
-          token.onCancellationRequested(() => { });
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // Web Services folder node expanded
-    } else if (node.element.contextValue.includes("cicstreewebservice.")) {
-      window.withProgress(
-        {
-          title: "Loading Web Services",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async (_, token) => {
-          token.onCancellationRequested(() => { });
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // Pipeline folder node expanded
-    } else if (node.element.contextValue.includes("cicstreepipeline.")) {
-      window.withProgress(
-        {
-          title: "Loading Pipeline",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async (_, token) => {
-          token.onCancellationRequested(() => { });
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // URIMap folder node expanded
-    } else if (node.element.contextValue.includes("cicstreeurimaps.")) {
-      window.withProgress(
-        {
-          title: "Loading URIMaps",
-          location: ProgressLocation.Notification,
-          cancellable: false,
-        },
-        async (_, token) => {
-          token.onCancellationRequested(() => { });
-          await node.element.loadContents();
-          treeDataProv._onDidChangeTreeData.fire(undefined);
-        }
-      );
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // All programs folder node expanded
-    } else if (node.element.contextValue.includes("cicscombinedprogramtree.")) {
-      // Children only loaded if filter has been applied
-      if (node.element.getActiveFilter()) {
-        await node.element.loadContents(treeDataProv);
-      }
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // All transactions folder node expanded
-    } else if (node.element.contextValue.includes("cicscombinedtransactiontree.")) {
-      if (node.element.getActiveFilter()) {
-        await node.element.loadContents(treeDataProv);
-      }
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // All local files folder node expanded
-    } else if (node.element.contextValue.includes("cicscombinedlocalfiletree.")) {
-      if (node.element.getActiveFilter()) {
-        await node.element.loadContents(treeDataProv);
-      }
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // All tasks folder node expanded
-    } else if (node.element.contextValue.includes("cicscombinedtasktree.")) {
-      if (node.element.getActiveFilter()) {
-        await node.element.loadContents(treeDataProv);
-      }
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-    }
-
-    // All libraries folder node expanded
-    else if (node.element.contextValue.includes("cicscombinedlibrarytree.")) {
-      if (node.element.getActiveFilter()) {
-        await node.element.loadContents(treeDataProv);
-      }
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-    }
-
-    // All TCPIP Services node expanded
-    else if (node.element.contextValue.includes("cicscombinedtcpipstree.")) {
-      if (node.element.getActiveFilter()) {
-        await node.element.loadContents(treeDataProv);
-      }
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-    }
-
-    // All URI Maps node expanded
-    else if (node.element.contextValue.includes("cicscombinedurimapstree.")) {
-      if (node.element.getActiveFilter()) {
-        await node.element.loadContents(treeDataProv);
-      }
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // All Pipeline folder node expanded
-    } else if (node.element.contextValue.includes("cicscombinedpipelinetree.")) {
-      if (node.element.getActiveFilter()) {
-        await node.element.loadContents(treeDataProv);
-      }
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // All Web Services folder node expanded
-    } else if (node.element.contextValue.includes("cicscombinedwebservicetree.")) {
-      if (node.element.getActiveFilter()) {
-        await node.element.loadContents(treeDataProv);
-      }
-      node.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-
-      // Regions container folder node expanded
-    } else if (node.element.contextValue.includes("cicsregionscontainer.")) {
+    cicsregionscontainer: (node: any) => {
       node.element.iconPath = getIconOpen(true);
-      await regionContainerExpansionHandler(node.element, treeDataProv);
+      regionContainerExpansionHandler(node.element, treeDataProv);
       treeDataProv._onDidChangeTreeData.fire(undefined);
     }
+  };
+
+  treeview.onDidExpandElement((node) => {
+
+    const contextValue = node.element.contextValue;
+    const initialContext = contextValue.split(".")[0];
+
+    if (initialContext in contextMap) {
+      contextMap[initialContext](node);
+    }
+
   });
 
   treeview.onDidCollapseElement((node) => {
@@ -441,73 +179,5 @@ export async function activate(context: ExtensionContext) {
     treeDataProv._onDidChangeTreeData.fire(undefined);
   });
 
-  context.subscriptions.push(
-    getAddSessionCommand(treeDataProv),
-    getRemoveSessionCommand(treeDataProv, treeview),
-    getUpdateSessionCommand(treeDataProv, treeview),
-    getDeleteSessionCommand(treeDataProv, treeview),
-
-    getRefreshCommand(treeDataProv),
-
-    getNewCopyCommand(treeDataProv, treeview),
-    getPhaseInCommand(treeDataProv, treeview),
-
-    getEnableProgramCommand(treeDataProv, treeview),
-    getDisableProgramCommand(treeDataProv, treeview),
-    getEnableTransactionCommand(treeDataProv, treeview),
-    getDisableTransactionCommand(treeDataProv, treeview),
-    getEnableLocalFileCommand(treeDataProv, treeview),
-    getDisableLocalFileCommand(treeDataProv, treeview),
-
-    getCloseLocalFileCommand(treeDataProv, treeview),
-    getOpenLocalFileCommand(treeDataProv, treeview),
-
-    getPurgeTaskCommand(treeDataProv, treeview),
-
-    getShowRegionAttributes(treeview),
-    getShowProgramAttributesCommand(treeview),
-    getShowLibraryAttributesCommand(treeview),
-    getShowLibraryDatasetsAttributesCommand(treeview),
-    getShowTCPIPServiceAttributesCommand(treeview),
-    getShowURIMapAttributesCommand(treeview),
-    getShowTransactionAttributesCommand(treeview),
-    getShowLocalFileAttributesCommand(treeview),
-    getShowTaskAttributesCommand(treeview),
-    getShowPipelineAttributesCommand(treeview),
-    getShowWebServiceAttributesCommand(treeview),
-
-    getShowRegionSITParametersCommand(treeview),
-
-    getFilterProgramsCommand(treeDataProv, treeview),
-    getFilterDatasetProgramsCommand(treeDataProv, treeview),
-    getFilterLibrariesCommand(treeDataProv, treeview),
-    getFilterDatasetsCommand(treeDataProv, treeview),
-    getFilterTransactionCommand(treeDataProv, treeview),
-    getFilterLocalFilesCommand(treeDataProv, treeview),
-    getFilterTasksCommand(treeDataProv, treeview),
-    getFilterTCPIPSCommand(treeDataProv, treeview),
-    getFilterURIMapsCommand(treeDataProv, treeview),
-    getFilterPipelinesCommand(treeDataProv, treeview),
-    getFilterWebServicesCommand(treeDataProv, treeview),
-
-    getFilterAllProgramsCommand(treeDataProv, treeview),
-    getFilterAllLibrariesCommand(treeDataProv, treeview),
-    getFilterAllWebServicesCommand(treeDataProv, treeview),
-    getFilterAllPipelinesCommand(treeDataProv, treeview),
-    getFilterAllTransactionsCommand(treeDataProv, treeview),
-    getFilterAllLocalFilesCommand(treeDataProv, treeview),
-    getFilterAllTasksCommand(treeDataProv, treeview),
-    getFilterAllTCPIPServicesCommand(treeDataProv, treeview),
-    getFilterAllURIMapsCommand(treeDataProv, treeview),
-
-    getFilterPlexResources(treeDataProv, treeview),
-
-    getClearResourceFilterCommand(treeDataProv, treeview),
-    getClearPlexFilterCommand(treeDataProv, treeview),
-
-    viewMoreCommand(treeDataProv, treeview),
-
-    getInquireTransactionCommand(treeDataProv, treeview),
-    getInquireProgramCommand(treeDataProv, treeview)
-  );
+  context.subscriptions.concat(getCommands(treeDataProv, treeview));
 }


### PR DESCRIPTION
**What It Does**
Refactor `extension.ts` to reduce repetition. The majority of the expansion events were 1 of 2 methods, with a couple of exceptions. The refactor ensures the common behaviour share a single method.

I also moved the commands registration out of the file to it's own method for tidiness.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
