### PR TITLE
SDK getResource failOnNoData flag

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Add requestOptions to getResource and getCache method. [#220](https://github.com/zowe/cics-for-zowe-client/issues/220)
+
 ## `6.2.4`
 
 - BugFix: URI encoding the region and cicsplex names. [#178](https://github.com/zowe/cics-for-zowe-client/issues/178)

--- a/packages/sdk/__tests__/__mocks__/CmciGetResponse.ts
+++ b/packages/sdk/__tests__/__mocks__/CmciGetResponse.ts
@@ -17,7 +17,7 @@ export const ok1RecordXmlResponse = readFileSync(join(__dirname, "ok.1_record.xm
 export const ok2RecordsXmlResponse = readFileSync(join(__dirname, "ok.2_records.xml")).toString();
 export const okCacheXmlResponse = readFileSync(join(__dirname, "ok.cache.xml")).toString();
 
-export const okContent1Record = {
+export const okContent1Record: any = {
   response: {
     xmlns: "http://www.ibm.com/xmlns/prod/CICS/smw2int",
     "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
@@ -108,7 +108,7 @@ export const okContent1Record = {
   },
 };
 
-export const okCache = {
+export const okCache: any = {
   response: {
     xmlns: "http://www.ibm.com/xmlns/prod/CICS/smw2int",
     "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
@@ -126,7 +126,7 @@ export const okCache = {
   },
 };
 
-export const okContent2Records = {
+export const okContent2Records: any = {
   response: {
     xmlns: "http://www.ibm.com/xmlns/prod/CICS/smw2int",
     "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
@@ -180,7 +180,7 @@ export const okContent2Records = {
   },
 };
 
-export const nodataContent = {
+export const nodataContent: any = {
   response: {
     xmlns: "http://www.ibm.com/xmlns/prod/CICS/smw2int",
     "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
@@ -196,5 +196,8 @@ export const nodataContent = {
       api_response2_alt: "",
       recordcount: "0",
     },
+    records: {
+      cicscicsplex: [],
+    }
   },
 };

--- a/packages/sdk/__tests__/__unit__/CicsCmciRestClient.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/CicsCmciRestClient.unit.test.ts
@@ -13,9 +13,9 @@ import { IImperativeError, RestClient, Session } from "@zowe/imperative";
 import { CicsCmciRestClient } from "../../src";
 
 describe("CicsCmciRestClient tests", () => {
-  const dummySession = new Session({hostname: "dummy"});
-  const testEndpoint = "testing";
-  const dummyHeaders = [{testEndpoint}];
+  const dummySession = new Session({ hostname: "dummy" });
+  const testEndpoint = "/CICSSystemManagement/testing";
+  const dummyHeaders = [{ testEndpoint }];
 
   const restClientExpect = jest.spyOn(RestClient, "getExpectString");
 
@@ -40,11 +40,11 @@ describe("CicsCmciRestClient tests", () => {
                 "</food>\n" +
                 "</breakfast_menu>" +
             "</response>";
-    const breakfastMenuJson = {
+    const breakfastMenuJson: any = {
       response: {
         resultsummary: {
           api_response1: "1024",
-          api_response2: "0"
+          api_response2: "0",
         },
         breakfast_menu: {
           food: [

--- a/packages/sdk/__tests__/__unit__/cache/Cache.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/cache/Cache.unit.test.ts
@@ -54,6 +54,7 @@ describe("CMCI - Get Cache", () => {
 
     it("should throw error if no parms are defined", async () => {
       try {
+        // @ts-ignore - cannot be undefined
         response = await getCache(dummySession, undefined);
       } catch (err) {
         error = err;
@@ -66,6 +67,7 @@ describe("CMCI - Get Cache", () => {
 
     it("should throw error if cache token is not defined", async () => {
       try {
+        // @ts-ignore - cacheToken cannot be undefined
         response = await getCache(dummySession, { cacheToken: undefined });
       } catch (err) {
         error = err;
@@ -115,7 +117,7 @@ describe("CMCI - Get Cache", () => {
         "/" + cacheParms.cacheToken + "?" + CicsCmciConstants.NO_DISCARD;
 
       expect(response).toEqual(content);
-      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, [], undefined);
     });
 
     it("should be able to get a result cache with SUMMONLY", async () => {
@@ -132,7 +134,7 @@ describe("CMCI - Get Cache", () => {
         "&" + CicsCmciConstants.SUMM_ONLY;
 
       expect(response).toEqual(content);
-      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, [], undefined);
     });
 
     it("should be able to get a result cache with start index", async () => {
@@ -149,7 +151,7 @@ describe("CMCI - Get Cache", () => {
         "10?" + CicsCmciConstants.NO_DISCARD;
 
       expect(response).toEqual(content);
-      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, [], undefined);
     });
 
     it("should be able to get a result cache with start index and count", async () => {
@@ -167,7 +169,7 @@ describe("CMCI - Get Cache", () => {
         "15/5?" + CicsCmciConstants.NO_DISCARD;
 
       expect(response).toEqual(content);
-      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, [], undefined);
     });
 
     it("should be able to get a result cache without NODISCARD", async () => {
@@ -183,7 +185,7 @@ describe("CMCI - Get Cache", () => {
         "/" + cacheParms.cacheToken;
 
       expect(response).toEqual(content);
-      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, []);
+      expect(cmciGetSpy).toHaveBeenCalledWith(dummySession, endPoint, [], undefined);
     });
   });
 });

--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -53,6 +53,26 @@ export const CicsCmciConstants = {
      */
   CICS_URIMAP: "CICSURIMap",
 
+  /*
+     * Specifies the required part of the REST interface URI to access Region Groups
+     */
+  CICS_CMCI_REGION_GROUP: "CICSRegionGroup",
+
+  /*
+     * Specifies the required part of the REST interface URI to access CICS Plexes
+     */
+  CICS_CMCI_CICS_PLEX: "CICSCICSPlex",
+
+  /*
+     * Specifies the required part of the REST interface URI to access Managed Regions
+     */
+  CICS_CMCI_MANAGED_REGION: "CICSManagedRegion",
+
+  /*
+     * Specifies the required part of the REST interface URI to access Regions
+     */
+  CICS_CMCI_REGION: "CICSRegion",
+
   /**
      * Specifies the required part of the REST interface URI to access CSD Group definitions
      */
@@ -127,5 +147,35 @@ export const CicsCmciConstants = {
   /**
      * CICSTask parameter
      */
-  CICS_CMCI_TASK: "CICSTask"
+  CICS_CMCI_TASK: "CICSTask",
+
+  /**
+     * CICS CMCI Response 1 Codes
+     */
+  RESPONSE_1_CODES: {
+    /**
+     * CMCI RESP 1 Code for OK
+     */
+    OK: 1024,
+
+    /**
+     * CMCI RESP 1 Code for NODATA
+     */
+    NODATA: 1027,
+
+    /**
+     * CMCI RESP 1 Code for INVALIDPARM
+     */
+    INVALIDPARM: 1028,
+
+    /**
+     * CMCI RESP 1 Code for NOTAVAILABLE
+     */
+    NOTAVAILABLE: 1034,
+
+    /**
+     * CMCI RESP 1 Code for INVALIDDATA
+     */
+    INVALIDDATA: 1041,
+  }
 };

--- a/packages/sdk/src/doc/ICMCIRequestOptions.ts
+++ b/packages/sdk/src/doc/ICMCIRequestOptions.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export interface ICMCIRequestOptions {
+  /**
+   * If False, the request does NOT fail if CMCI gives a NODATA response, indicating 0 results.
+   */
+  failOnNoData?: boolean;
+
+  /**
+   * If True, a new CicsCmciRestError is returned with formatted CMCI response codes.
+   * Default value is False to maintain backward compatibility.
+   */
+  useCICSCmciRestError?: boolean;
+}

--- a/packages/sdk/src/doc/index.ts
+++ b/packages/sdk/src/doc/index.ts
@@ -11,6 +11,7 @@
 
 export * from "./ICacheParms";
 export * from "./ICMCIApiResponse";
+export * from "./ICMCIRequestOptions";
 export * from "./ICMCIResponseResultSummary";
 export * from "./ICSDGroupParms";
 export * from "./IProgramParms";

--- a/packages/sdk/src/methods/cache/Cache.ts
+++ b/packages/sdk/src/methods/cache/Cache.ts
@@ -15,8 +15,9 @@ import { ICacheParms } from "../../doc/ICacheParms";
 import { IResultCacheParms } from "../../doc/IResultCacheParms";
 import { CicsCmciRestClient } from "../../rest";
 import { Utils } from "../../utils";
+import { ICMCIRequestOptions } from "../../doc/ICMCIRequestOptions";
 
-export async function getCache(session: AbstractSession, parms: ICacheParms): Promise<ICMCIApiResponse> {
+export async function getCache(session: AbstractSession, parms: ICacheParms, requestOptions?: ICMCIRequestOptions): Promise<ICMCIApiResponse> {
   ImperativeExpect.toBeDefinedAndNonBlank(parms.cacheToken, "CICS Result Cache Token", "CICS Result Cache Token is required");
   Logger.getAppLogger().debug("Attempting to get cache with the following parameters:\n%s", JSON.stringify(parms));
 
@@ -28,5 +29,5 @@ export async function getCache(session: AbstractSession, parms: ICacheParms): Pr
   };
   const cmciResource = Utils.getCacheUri(parms.cacheToken, options);
 
-  return CicsCmciRestClient.getExpectParsedXml(session, cmciResource, []);
+  return CicsCmciRestClient.getExpectParsedXml(session, cmciResource, [], requestOptions);
 }

--- a/packages/sdk/src/methods/get/Get.ts
+++ b/packages/sdk/src/methods/get/Get.ts
@@ -11,6 +11,7 @@
 
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { ICMCIApiResponse, IGetResourceUriOptions, IResourceParms } from "../../doc";
+import { ICMCIRequestOptions } from "../../doc/ICMCIRequestOptions";
 import { CicsCmciRestClient } from "../../rest";
 import { Utils } from "../../utils";
 
@@ -24,7 +25,10 @@ import { Utils } from "../../utils";
  * @throws {ImperativeError} CICS region name not defined or blank
  * @throws {ImperativeError} CicsCmciRestClient request fails
  */
-export async function getResource(session: AbstractSession, parms: IResourceParms): Promise<ICMCIApiResponse> {
+export async function getResource(
+  session: AbstractSession,
+  parms: IResourceParms,
+  requestOptions?: ICMCIRequestOptions): Promise<ICMCIApiResponse> {
   ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Resource name", "CICS resource name is required");
 
   Logger.getAppLogger().debug("Attempting to get resource(s) with the following parameters:\n%s", JSON.stringify(parms));
@@ -39,5 +43,5 @@ export async function getResource(session: AbstractSession, parms: IResourceParm
 
   const cmciResource = Utils.getResourceUri(parms.name, options);
 
-  return CicsCmciRestClient.getExpectParsedXml(session, cmciResource, []);
+  return CicsCmciRestClient.getExpectParsedXml(session, cmciResource, [], requestOptions);
 }

--- a/packages/sdk/src/rest/CicsCmciRestError.ts
+++ b/packages/sdk/src/rest/CicsCmciRestError.ts
@@ -1,0 +1,39 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { ImperativeError } from "@zowe/imperative";
+import { ICMCIResponseResultSummary } from "../doc";
+
+export class CicsCmciRestError extends ImperativeError {
+
+  resultSummary: ICMCIResponseResultSummary;
+
+  RESPONSE_1: number;
+  RESPONSE_2: number;
+  RESPONSE_1_ALT: string;
+  RESPONSE_2_ALT: string;
+
+  constructor(msg: string, resultSummary: ICMCIResponseResultSummary) {
+    super({
+      msg,
+    });
+    this.resultSummary = resultSummary;
+    this.parseResultSummary();
+  }
+
+  parseResultSummary() {
+    this.RESPONSE_1 = parseInt(this.resultSummary.api_response1);
+    this.RESPONSE_2 = parseInt(this.resultSummary.api_response2);
+    this.RESPONSE_1_ALT = this.resultSummary.api_response1_alt;
+    this.RESPONSE_2_ALT = this.resultSummary.api_response2_alt;
+  }
+
+}

--- a/packages/sdk/src/rest/index.ts
+++ b/packages/sdk/src/rest/index.ts
@@ -10,3 +10,4 @@
  */
 
 export * from "./CicsCmciRestClient";
+export * from "./CicsCmciRestError";

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Show CMCI error response codes when failing to make requests. [#220](https://github.com/zowe/cics-for-zowe-client/issues/220)
+
 ## `3.3.2`
 
 - BugFix: Editing profile results in exception - removed ability to multi-select profiles. [#222](https://github.com/zowe/cics-for-zowe-client/issues/222)

--- a/packages/vsce/src/trees/CICSPlexTree.ts
+++ b/packages/vsce/src/trees/CICSPlexTree.ts
@@ -169,8 +169,10 @@ export class CICSPlexTree extends TreeItem {
     this.children.push(new CICSCombinedPipelineTree(this));
   }
 
-  public addRegionContainer() {
-    this.children.push(new CICSRegionsContainer(this));
+  public addRegionContainer(): CICSRegionsContainer {
+    const regionContainer = new CICSRegionsContainer(this);
+    this.children.push(regionContainer);
+    return regionContainer;
   }
 
   public getGroupName() {

--- a/packages/vsce/src/utils/expansionHandler.ts
+++ b/packages/vsce/src/utils/expansionHandler.ts
@@ -90,17 +90,14 @@ export function plexExpansionHandler(plex: CICSPlexTree, tree: CICSTree) {
       // CICSGroup
     } else {
       plex.clearChildren();
-      plex.addRegionContainer();
-      const regionsContainer = findRegionsContainerFromPlex(plex);
-      // Run region container expansion handler by forcing execution
+      const regionsContainer = plex.addRegionContainer();
       regionContainerExpansionHandler(regionsContainer, tree);
       plex.addNewCombinedTrees();
       tree._onDidChangeTreeData.fire(undefined);
     }
   } else {
     plex.clearChildren();
-    plex.addRegionContainer();
-    const regionsContainer = findRegionsContainerFromPlex(plex);
+    const regionsContainer = plex.addRegionContainer();
     regionContainerExpansionHandler(regionsContainer, tree);
     plex.addNewCombinedTrees();
     tree._onDidChangeTreeData.fire(undefined);
@@ -108,12 +105,3 @@ export function plexExpansionHandler(plex: CICSPlexTree, tree: CICSTree) {
   tree._onDidChangeTreeData.fire(undefined);
 }
 
-/**
- * Return a plex node's child 'Regions' container tree node.
- * @param plex plex tree node from where to start the search
- * @returns CICSRegionsContainer
- */
-function findRegionsContainerFromPlex(plex: CICSPlexTree): CICSRegionsContainer {
-  const regionsContainer = plex.children.filter((child) => child instanceof CICSRegionsContainer)?.[0] as CICSRegionsContainer;
-  return regionsContainer;
-}


### PR DESCRIPTION
**What It Does**
Adds a failOnNodata flag, defaulting to true (which is the current behaviour), to dictate if CMCI sending a NODATA response should throw an error or not.

* PR relies on #204 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
