### PR TITLE
show library datasets under correct library name

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 ## Recent Changes
 
 - Updated status icons for local transactions, local files, tasks and programs. [#203](https://github.com/zowe/cics-for-zowe-client/issues/203)
+- BugFix: Display correct LibraryDatasets under the Library resource trees. [#212](https://github.com/zowe/cics-for-zowe-client/issues/212)
 
 ## `3.3.0`
 

--- a/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
+++ b/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { CICSLibraryDatasets } from "./CICSLibraryDatasets";
-import { toEscapedCriteriaString } from "../../utils/filterUtils";
 import { getFolderIcon } from "../../utils/iconUtils";
 import { toArray } from "../../utils/commandUtils";
 
@@ -47,11 +46,11 @@ export class CICSLibraryTreeItem extends TreeItem {
   }
 
   public async loadContents() {
-    const defaultCriteria = "(DSNAME=*)";
+    const defaultCriteria = `(LIBRARY=${this.library.name})`;
     let criteria;
 
     if (this.activeFilter) {
-      criteria = toEscapedCriteriaString(this.activeFilter, "DSNAME");
+      criteria = `(LIBRARY=${this.library.name} AND DSNAME=${this.activeFilter})`;
     } else {
       criteria = defaultCriteria;
     }


### PR DESCRIPTION
**What It Does**
Resolves #212 .

This changes the LibraryTreeItems to use a default filter of their Library name so only the Library datasets in that Library show up in that tree. Then it appends the active filter of the library to that filter to search the DSName attribute. 

Resulting behaviour is only the library datasets with the correct library name show up under that tree, with the filter applying to the dsname attribute.

**How to Test**

Have multiple Library resources with different datasets in. Expand each library. Before this update, they would show the same datasets - now they should show correct datasets. 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

Updated view with bug fixed.
<img width="371" alt="Screenshot 2025-01-27 at 10 44 31 AM" src="https://github.com/user-attachments/assets/d45072ab-79d6-4503-8770-b03328b780eb" />