### PR TITLE
remove multi-select, simplify profile selection code

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 
 ## Recent Changes
 
+- BugFix: Editing profile results in exception - removed ability to multi-select profiles. [#222](https://github.com/zowe/cics-for-zowe-client/issues/222)
 - BugFix: Update documentation to reflect changes to fully support V3 profiles. [#209](https://github.com/zowe/cics-for-zowe-client/issues/209)
 
 ## `3.3.1`

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -719,7 +719,7 @@
           "group": ""
         },
         {
-          "when": "view == cics-view && viewItem =~ /^cicssession.*/",
+          "when": "view == cics-view && viewItem =~ /^cicssession.*/ && !listMultiSelection",
           "command": "cics-extension-for-zowe.manageSession",
           "title": "Manage Session"
         },


### PR DESCRIPTION
Resolves #222 

**What It Does**
Removes multi-select
Simplifies profile selection code so edit and delete profile match
Behaviour now in line with Zowe Explorer

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
