### PR TITLE
Remove duplicate plex names if multiple CMASs are present

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
+## Recent Changes
+
+- BugFix: Remove duplicates plexes from the session tree. [#227](https://github.com/zowe/cics-for-zowe-client/issues/227)
+
 ## `3.3.2`
 
 - BugFix: Editing profile results in exception - removed ability to multi-select profiles. [#222](https://github.com/zowe/cics-for-zowe-client/issues/222)

--- a/packages/vsce/src/utils/profileManagement.ts
+++ b/packages/vsce/src/utils/profileManagement.ts
@@ -216,13 +216,19 @@ export class ProfileManagement {
       try {
         const { response } = await getCache(session, { cacheToken: isPlex, nodiscard: false });
         if (response.records.cicscicsplex) {
+
+          const plexes = new Set<string>();
           for (const plex of toArray(response.records.cicscicsplex)) {
+            plexes.add(plex.plexname);
+          }
+
+          [...plexes].forEach((plexname) => {
             infoLoaded.push({
-              plexname: plex.plexname,
+              plexname,
               regions: [],
               group: false,
             });
-          }
+          });
         }
       } catch (error) {
         window.showErrorMessage(


### PR DESCRIPTION
**What It Does**
Current behaviour lists all CICSplexes returned from CMCI. If you have a multi-CMAS system, you can get multiple records with the same plex name with different cmas names. This results in duplicate plex entries.

This PR removes duplicates from the plex tree if multiple are returned.

Resolves #227 

**How to Test**
Connect to a system with multiple cmas's and list the plexes, and don't see duplicates.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
