### PR TITLE
Standardise cics profile definition for CLI and VSCE

### DIFF
--- a/packages/cli/src/imperative.ts
+++ b/packages/cli/src/imperative.ts
@@ -11,8 +11,8 @@
 
 // Imperative version of Zowe CLI
 import { IImperativeConfig } from "@zowe/imperative";
-import { CicsSession } from "./CicsSession";
 import { PluginConstants } from "./PluginConstants";
+import { getCICSProfileDefinition } from "@zowe/cics-for-zowe-sdk";
 
 const config: IImperativeConfig = {
   commandModuleGlobs: ["*/*.definition!(.d).*s"],
@@ -27,85 +27,7 @@ const config: IImperativeConfig = {
   //     }
   // ],
   profiles: [
-    {
-      type: "cics",
-      schema: {
-        type: "object",
-        title: "CICS Profile",
-        description:
-          "A cics profile is required to issue commands in the cics command group that interact with " +
-          "CICS regions. The cics profile contains your host, port, user name, and password " +
-          "for the IBM CICS management client interface (CMCI) server of your choice.",
-        properties: {
-          host: {
-            type: "string",
-            optionDefinition: {
-              name: "host",
-              aliases: ["H"],
-              description: "The CMCI server host name",
-              type: "string",
-            },
-          },
-          port: {
-            type: "number",
-            optionDefinition: {
-              name: "port",
-              aliases: ["P"],
-              description: "The CMCI server port",
-              type: "number",
-              defaultValue: 1490,
-            },
-          },
-          user: {
-            type: "string",
-            secure: true,
-            optionDefinition: {
-              name: "user",
-              aliases: ["u"],
-              description: "Your username to connect to CICS",
-              type: "string",
-              implies: ["password"],
-            },
-          },
-          password: {
-            type: "string",
-            secure: true,
-            optionDefinition: {
-              name: "password",
-              aliases: ["p"],
-              description: "Your password to connect to CICS",
-              type: "string",
-              implies: ["user"],
-            },
-          },
-          regionName: {
-            type: "string",
-            optionDefinition: {
-              name: "region-name",
-              description: "The name of the CICS region name to interact with",
-              type: "string",
-            },
-          },
-          cicsPlex: {
-            type: "string",
-            optionDefinition: {
-              name: "cics-plex",
-              description: "The name of the CICSPlex to interact with",
-              type: "string",
-            },
-          },
-          rejectUnauthorized: {
-            type: "boolean",
-            optionDefinition: CicsSession.CICS_OPTION_REJECT_UNAUTHORIZED,
-          },
-          protocol: {
-            type: "string",
-            optionDefinition: CicsSession.CICS_OPTION_PROTOCOL,
-          },
-        },
-        required: [],
-      },
-    },
+    getCICSProfileDefinition(),
   ],
 };
 

--- a/packages/sdk/src/constants/CICSProfileDefinition.ts
+++ b/packages/sdk/src/constants/CICSProfileDefinition.ts
@@ -11,8 +11,8 @@
 
 import { imperative } from "@zowe/zowe-explorer-api";
 
-const cicsProfileMeta: imperative.ICommandProfileTypeConfiguration[] = [
-  {
+export const getCICSProfileDefinition = (): imperative.ICommandProfileTypeConfiguration => {
+  return {
     type: "cics",
     schema: {
       type: "object",
@@ -105,7 +105,5 @@ const cicsProfileMeta: imperative.ICommandProfileTypeConfiguration[] = [
       },
       required: [],
     },
-  },
-];
-
-export default cicsProfileMeta;
+  };
+};

--- a/packages/sdk/src/constants/index.ts
+++ b/packages/sdk/src/constants/index.ts
@@ -11,3 +11,4 @@
 
 export * from "./CicsCmci.constants";
 export * from "./CicsCmci.messages";
+export * from "./CICSProfileDefinition";

--- a/packages/vsce/src/utils/profileManagement.ts
+++ b/packages/vsce/src/utils/profileManagement.ts
@@ -9,14 +9,13 @@
  *
  */
 
-import { CicsCmciConstants, CicsCmciRestError, getCache } from "@zowe/cics-for-zowe-sdk";
+import { CicsCmciConstants, CicsCmciRestError, getCache, getCICSProfileDefinition } from "@zowe/cics-for-zowe-sdk";
 import { Session } from "@zowe/imperative";
 import { Gui, MessageSeverity, Types, ZoweVsCodeExtension, imperative } from "@zowe/zowe-explorer-api";
 import { CICSPlexTree } from "../trees/CICSPlexTree";
 import { toArray } from "./commandUtils";
 import constants from "./constants";
 import { getBestCICSplexes } from "./plexUtils";
-import cicsProfileMeta from "./profileDefinition";
 import { runGetResource } from "./resourceUtils";
 
 export class ProfileManagement {
@@ -33,7 +32,7 @@ export class ProfileManagement {
   }
 
   public static async registerCICSProfiles() {
-    await ProfileManagement.zoweExplorerAPI.getExplorerExtenderApi().initForZowe("cics", cicsProfileMeta);
+    await ProfileManagement.zoweExplorerAPI.getExplorerExtenderApi().initForZowe("cics", [getCICSProfileDefinition()]);
   }
 
   public static getExplorerApis() {


### PR DESCRIPTION
**What It Does**
Profile definition was repeated for CLI and VSCE. This PR adds a method to the SDK to retrieve the profile definition to use in both.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
