### PR TITLE
Genericize resource TreeItems and refactor tree structure

### DIFF
--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -49,6 +49,11 @@ export const CicsCmciConstants = {
   CICS_LIBRARY_RESOURCE: "CICSLibrary",
 
   /**
+   * Specifies the required part of the REST interface URI to access library dataset resources
+   */
+  CICS_LIBRARY_DATASET_RESOURCE: "CICSLibraryDatasetName",
+
+  /**
    * Specifies the required part of the REST interface URI to access URIMap definitions
    */
   CICS_DEFINITION_URIMAP: "CICSDefinitionURIMap",
@@ -62,6 +67,16 @@ export const CicsCmciConstants = {
    * Specifies the required part of the REST interface URI to access tcp/ip service resources
    */
   CICS_TCPIPSERVICE_RESOURCE: "CICSTCPIPService",
+
+  /**
+   * Specifies the required part of the REST interface URI to access pipeline service resources
+   */
+  CICS_PIPELINE_RESOURCE: "CICSPipeline",
+
+  /**
+   * Specifies the required part of the REST interface URI to access pipeline service resources
+   */
+  CICS_WEBSERVICE_RESOURCE: "CICSWebService",
 
   /*
    * Specifies the required part of the REST interface URI to access URIMaps

--- a/packages/vsce/src/doc/meta/IResourceMeta.ts
+++ b/packages/vsce/src/doc/meta/IResourceMeta.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Resource } from "../../resources/Resource";
+import { IResource } from "../resources/IResource";
+
+export interface IResourceMeta<T extends IResource> {
+  resourceName: string;
+  humanReadableName: string;
+
+  getDefaultFilter(parentResource?: IResource): string;
+  getLabel(resource: Resource<T>): string;
+  getContext(resource: Resource<T>): string;
+  getIconName(resource: Resource<T>): string;
+  getName(resource: Resource<T>): string;
+
+  childType?: IResourceMeta<IResource>;
+}

--- a/packages/vsce/src/doc/meta/bundle.meta.ts
+++ b/packages/vsce/src/doc/meta/bundle.meta.ts
@@ -1,0 +1,57 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IBundle } from "../resources";
+import { BundlePartMeta } from "./bundlePart.meta";
+import { IResourceMeta } from "./IResourceMeta";
+
+export const BundleMeta: IResourceMeta<IBundle> = {
+  resourceName: CicsCmciConstants.CICS_CMCI_BUNDLE,
+  humanReadableName: "Bundles",
+
+  getDefaultFilter: function (): string {
+    return "name=*";
+  },
+
+  getLabel: function (bundle: Resource<IBundle>): string {
+    let label = `${bundle.attributes.name}`;
+
+    if (bundle.attributes.enablestatus.trim().toLowerCase() === "disabled") {
+      label += " (Disabled)";
+    }
+
+    return label;
+  },
+
+  getContext: function (bundle: Resource<IBundle>): string {
+    let context = `${CicsCmciConstants.CICS_CMCI_BUNDLE}.${bundle.attributes.name}`;
+    if (bundle.attributes.enablestatus.trim().toUpperCase() === "DISABLED") {
+      context += `.disabled`;
+    }
+    return context;
+  },
+
+  getIconName: function (bundle: Resource<IBundle>): string {
+    let iconName = `bundle`;
+    if (bundle.attributes.enablestatus.trim().toUpperCase() === "DISABLED") {
+      iconName += `-disabled`;
+    }
+    return iconName;
+  },
+
+  getName(bundle: Resource<IBundle>) {
+    return bundle.attributes.name;
+  },
+
+  childType: BundlePartMeta,
+};

--- a/packages/vsce/src/doc/meta/bundlePart.meta.ts
+++ b/packages/vsce/src/doc/meta/bundlePart.meta.ts
@@ -1,0 +1,54 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IBundle, IBundlePart } from "../resources";
+import { IResourceMeta } from "./IResourceMeta";
+
+export const BundlePartMeta: IResourceMeta<IBundlePart> = {
+  resourceName: CicsCmciConstants.CICS_CMCI_BUNDLE_PART,
+  humanReadableName: "Bundle Parts",
+
+  getDefaultFilter: function (parentResource: IBundle): string {
+    return `BUNDLE='${parentResource.name}'`;
+  },
+
+  getLabel: function (bundlePart: Resource<IBundlePart>): string {
+    let label = `${bundlePart.attributes.bundlepart}`;
+
+    if (bundlePart.attributes.enablestatus.trim().toLowerCase() === "disabled") {
+      label += " (Disabled)";
+    }
+
+    return label;
+  },
+
+  getContext: function (bundlePart: Resource<IBundlePart>): string {
+    let context = `${CicsCmciConstants.CICS_CMCI_BUNDLE_PART}.${bundlePart.attributes.bundlepart}`;
+    if (bundlePart.attributes.enablestatus.trim().toUpperCase() === "DISABLED") {
+      context += `.disabled`;
+    }
+    return context;
+  },
+
+  getIconName: function (bundlePart: Resource<IBundlePart>): string {
+    let iconName = `bundle-part`;
+    if (bundlePart.attributes.enablestatus.trim().toUpperCase() === "DISABLED") {
+      iconName += `-disabled`;
+    }
+    return iconName;
+  },
+
+  getName(bundlePart: Resource<IBundlePart>) {
+    return bundlePart.attributes.bundlepart;
+  },
+};

--- a/packages/vsce/src/doc/meta/index.ts
+++ b/packages/vsce/src/doc/meta/index.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export * from "./bundle.meta";
+export * from "./bundlePart.meta";
+export * from "./IResourceMeta";
+export * from "./library.meta";
+export * from "./libraryDataset.meta";
+export * from "./localFile.meta";
+export * from "./pipeline.meta";
+export * from "./program.meta";
+export * from "./task.meta";
+export * from "./tcpip.meta";
+export * from "./transaction.meta";
+export * from "./urimap.meta";
+export * from "./webservice.meta";

--- a/packages/vsce/src/doc/meta/library.meta.ts
+++ b/packages/vsce/src/doc/meta/library.meta.ts
@@ -1,0 +1,43 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IResourceMeta } from "./IResourceMeta";
+import { ILibrary } from "../resources";
+import { LibraryDatasetMeta } from "./libraryDataset.meta";
+
+export const LibraryMeta: IResourceMeta<ILibrary> = {
+  resourceName: CicsCmciConstants.CICS_LIBRARY_RESOURCE,
+  humanReadableName: "Libraries",
+
+  getDefaultFilter: function (): string {
+    return "name=*";
+  },
+
+  getLabel: function (resource: Resource<ILibrary>): string {
+    return `${resource.attributes.name}`;
+  },
+
+  getContext: function (resource: Resource<ILibrary>): string {
+    return `${CicsCmciConstants.CICS_LIBRARY_RESOURCE}.${resource.attributes.name}`;
+  },
+
+  getIconName: function (resource: Resource<ILibrary>): string {
+    return "library";
+  },
+
+  getName(resource: Resource<ILibrary>): string {
+    return resource.attributes.name;
+  },
+
+  childType: LibraryDatasetMeta,
+};

--- a/packages/vsce/src/doc/meta/libraryDataset.meta.ts
+++ b/packages/vsce/src/doc/meta/libraryDataset.meta.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IResourceMeta } from "./IResourceMeta";
+import { ILibrary, ILibraryDataset } from "../resources";
+
+export const LibraryDatasetMeta: IResourceMeta<ILibraryDataset> = {
+  resourceName: CicsCmciConstants.CICS_LIBRARY_DATASET_RESOURCE,
+  humanReadableName: "Library Datasets",
+
+  getDefaultFilter: function (parentResource: ILibrary): string {
+    return `LIBRARY=${parentResource.name}`;
+  },
+
+  getLabel: function (resource: Resource<ILibraryDataset>): string {
+    return `${resource.attributes.dsname}`;
+  },
+
+  getContext: function (resource: Resource<ILibraryDataset>): string {
+    return `${CicsCmciConstants.CICS_LIBRARY_DATASET_RESOURCE}.${resource.attributes.dsname}`;
+  },
+
+  getIconName: function (resource: Resource<ILibraryDataset>): string {
+    return "library-dataset";
+  },
+
+  getName(resource: Resource<ILibraryDataset>): string {
+    return resource.attributes.dsname;
+  }
+};

--- a/packages/vsce/src/doc/meta/localFile.meta.ts
+++ b/packages/vsce/src/doc/meta/localFile.meta.ts
@@ -1,0 +1,62 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IResourceMeta } from "./IResourceMeta";
+import { ILocalFile } from "../resources";
+
+export const LocalFileMeta: IResourceMeta<ILocalFile> = {
+  resourceName: CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
+  humanReadableName: "Local Files",
+
+  getDefaultFilter: function (): string {
+    return "file=*";
+  },
+
+  getLabel: function (localFile: Resource<ILocalFile>): string {
+    let label = `${localFile.attributes.file}`;
+
+    if (localFile.attributes.enablestatus.trim().toLowerCase() === "disabled") {
+      label += " (Disabled)";
+    } else if (localFile.attributes.enablestatus.trim().toLowerCase() === "unenabled") {
+      label += " (Unenabled)";
+    }
+
+    if (localFile.attributes.openstatus.trim().toLowerCase() === "closed") {
+      label += " (Closed)";
+    }
+
+    return label;
+  },
+
+  getContext: function (localFile: Resource<ILocalFile>): string {
+    return `${CicsCmciConstants.CICS_CMCI_LOCAL_FILE
+      }.${localFile.attributes.enablestatus
+      }.${localFile.attributes.openstatus
+      }.${localFile.attributes.file}`;
+  },
+
+  getIconName: function (localFile: Resource<ILocalFile>): string {
+    let iconName = `local-file`;
+    if (localFile.attributes.enablestatus.trim().toLowerCase() === "disabled") {
+      iconName += `-disabled`;
+    }
+    if (localFile.attributes.openstatus.trim().toLowerCase() === "closed") {
+      iconName += `-closed`;
+    }
+    return iconName;
+  },
+
+  getName(localFile: Resource<ILocalFile>): string {
+    return localFile.attributes.file;
+  }
+};

--- a/packages/vsce/src/doc/meta/pipeline.meta.ts
+++ b/packages/vsce/src/doc/meta/pipeline.meta.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IResourceMeta } from "./IResourceMeta";
+import { IPipeline } from "../resources";
+
+export const PipelineMeta: IResourceMeta<IPipeline> = {
+  resourceName: CicsCmciConstants.CICS_PIPELINE_RESOURCE,
+  humanReadableName: "Pipelines",
+
+  getDefaultFilter: function (): string {
+    return "name=*";
+  },
+
+  getLabel: function (resource: Resource<IPipeline>): string {
+    return `${resource.attributes.name}`;
+  },
+
+  getContext: function (resource: Resource<IPipeline>): string {
+    return `${CicsCmciConstants.CICS_PIPELINE_RESOURCE}.${resource.attributes.name}`;
+  },
+
+  getIconName: function (resource: Resource<IPipeline>): string {
+    return "pipeline";
+  },
+
+  getName(resource: Resource<IPipeline>): string {
+    return resource.attributes.name;
+  }
+};

--- a/packages/vsce/src/doc/meta/program.meta.ts
+++ b/packages/vsce/src/doc/meta/program.meta.ts
@@ -1,0 +1,56 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IProgram } from "../resources";
+import { IResourceMeta } from "./IResourceMeta";
+
+export const ProgramMeta: IResourceMeta<IProgram> = {
+  resourceName: CicsCmciConstants.CICS_PROGRAM_RESOURCE,
+  humanReadableName: "Programs",
+
+  getDefaultFilter: function (): string {
+    return "NOT (PROGRAM=CEE* OR PROGRAM=DFH* OR PROGRAM=CJ* OR PROGRAM=EYU* OR PROGRAM=CSQ* OR PROGRAM=CEL* OR PROGRAM=IGZ*)";
+  },
+
+  getLabel: function (program: Resource<IProgram>): string {
+    let label = `${program.attributes.program}`;
+    if (program.attributes.newcopycnt && parseInt(program.attributes.newcopycnt) > 0) {
+      label += ` (New copy count: ${program.attributes.newcopycnt})`;
+    }
+    if (program.attributes.status.trim().toLowerCase() === "disabled") {
+      label += " (Disabled)";
+    }
+
+    return label;
+  },
+
+  getContext: function (program: Resource<IProgram>): string {
+    let context = `${CicsCmciConstants.CICS_PROGRAM_RESOURCE}.${program.attributes.program}`;
+    if (program.attributes.status.trim().toUpperCase() === "DISABLED") {
+      context += `.disabled`;
+    }
+    return context;
+  },
+
+  getIconName: function (program: Resource<IProgram>): string {
+    let iconName = `program`;
+    if (program.attributes.status.trim().toUpperCase() === "DISABLED") {
+      iconName += `-disabled`;
+    }
+    return iconName;
+  },
+
+  getName(program: Resource<IProgram>): string {
+    return program.attributes.program;
+  }
+};

--- a/packages/vsce/src/doc/meta/task.meta.ts
+++ b/packages/vsce/src/doc/meta/task.meta.ts
@@ -1,0 +1,58 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IResourceMeta } from "./IResourceMeta";
+import { ITask } from "../resources";
+
+export const TaskMeta: IResourceMeta<ITask> = {
+  resourceName: CicsCmciConstants.CICS_CMCI_TASK,
+  humanReadableName: "Tasks",
+
+  getDefaultFilter: function (): string {
+    return "TRANID=*";
+  },
+
+  getLabel: function (resource: Resource<ITask>): string {
+    let label = `${resource.attributes.task} - ${resource.attributes.tranid}`;
+
+    if (resource.attributes.runstatus.trim().toLowerCase() !== "suspended") {
+      label += ` (${resource.attributes.runstatus})`;
+    }
+
+    return label;
+  },
+
+  getContext: function (resource: Resource<ITask>): string {
+    return `${CicsCmciConstants.CICS_CMCI_TASK}.${resource.attributes.task}`;
+  },
+
+  getIconName: function (resource: Resource<ITask>): string {
+    let iconName = "task";
+    switch (resource.attributes.runstatus.trim().toLowerCase()) {
+      case "running":
+        iconName += `-running`;
+        break;
+      case "suspended":
+        iconName += `-suspended`;
+        break;
+      case "dispatched":
+        iconName += `-dispatched`;
+        break;
+    }
+    return iconName;
+  },
+
+  getName(resource: Resource<ITask>): string {
+    return resource.attributes.task;
+  }
+};

--- a/packages/vsce/src/doc/meta/tcpip.meta.ts
+++ b/packages/vsce/src/doc/meta/tcpip.meta.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IResourceMeta } from "./IResourceMeta";
+import { ITCPIP } from "../resources";
+
+export const TCPIPMeta: IResourceMeta<ITCPIP> = {
+  resourceName: CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE,
+  humanReadableName: "TCPIP Services",
+
+  getDefaultFilter: function (): string {
+    return "name=*";
+  },
+
+  getLabel: function (resource: Resource<ITCPIP>): string {
+    let label = `${resource.attributes.name}`;
+
+    if (resource.attributes.port) {
+      label += ` [Port #${resource.attributes.port}]`;
+    }
+
+    return label;
+  },
+
+  getContext: function (resource: Resource<ITCPIP>): string {
+    return `${CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE}.${resource.attributes.name}`;
+  },
+
+  getIconName: function (resource: Resource<ITCPIP>): string {
+    return "tcp-ip-service";
+  },
+
+  getName(resource: Resource<ITCPIP>): string {
+    return resource.attributes.name;
+  }
+};

--- a/packages/vsce/src/doc/meta/transaction.meta.ts
+++ b/packages/vsce/src/doc/meta/transaction.meta.ts
@@ -1,0 +1,54 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { ITransaction } from "../resources";
+import { IResourceMeta } from "./IResourceMeta";
+
+export const TransactionMeta: IResourceMeta<ITransaction> = {
+  resourceName: CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
+  humanReadableName: "Transactions",
+
+  getDefaultFilter: function (): string {
+    return "NOT (program=DFH* OR program=EYU*)";
+  },
+
+  getLabel: function (transaction: Resource<ITransaction>): string {
+    let label = `${transaction.attributes.tranid}`;
+
+    if (transaction.attributes.status.trim().toLowerCase() === "disabled") {
+      label += " (Disabled)";
+    }
+
+    return label;
+  },
+
+  getContext: function (transaction: Resource<ITransaction>): string {
+    let context = `${CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION}.${transaction.attributes.tranid}`;
+    if (transaction.attributes.status.trim().toUpperCase() === "DISABLED") {
+      context += `.disabled`;
+    }
+    return context;
+  },
+
+  getIconName: function (transaction: Resource<ITransaction>): string {
+    let iconName = `local-transaction`;
+    if (transaction.attributes.status.trim().toUpperCase() === "DISABLED") {
+      iconName += `-disabled`;
+    }
+    return iconName;
+  },
+
+  getName(transaction: Resource<ITransaction>): string {
+    return transaction.attributes.tranid;
+  }
+};

--- a/packages/vsce/src/doc/meta/urimap.meta.ts
+++ b/packages/vsce/src/doc/meta/urimap.meta.ts
@@ -1,0 +1,49 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IResourceMeta } from "./IResourceMeta";
+import { IURIMap } from "../resources";
+
+export const URIMapMeta: IResourceMeta<IURIMap> = {
+  resourceName: CicsCmciConstants.CICS_URIMAP,
+  humanReadableName: "URI Maps",
+
+  getDefaultFilter: function (): string {
+    return "name=*";
+  },
+
+  getLabel: function (resource: Resource<IURIMap>): string {
+    let label = `${resource.attributes.name}`;
+
+    if (resource.attributes.scheme) {
+      label += ` [${resource.attributes.scheme}]`;
+    }
+    if (resource.attributes.path) {
+      label += ` (${resource.attributes.path})`;
+    }
+
+    return label;
+  },
+
+  getContext: function (resource: Resource<IURIMap>): string {
+    return `${CicsCmciConstants.CICS_URIMAP}.${resource.attributes.name}`;
+  },
+
+  getIconName: function (resource: Resource<IURIMap>): string {
+    return "uri-map";
+  },
+
+  getName(resource: Resource<IURIMap>): string {
+    return resource.attributes.name;
+  }
+};

--- a/packages/vsce/src/doc/meta/webservice.meta.ts
+++ b/packages/vsce/src/doc/meta/webservice.meta.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { Resource } from "../../resources/Resource";
+import { IResourceMeta } from "./IResourceMeta";
+import { IWebService } from "../resources";
+
+export const WebServiceMeta: IResourceMeta<IWebService> = {
+  resourceName: CicsCmciConstants.CICS_WEBSERVICE_RESOURCE,
+  humanReadableName: "Web Services",
+
+  getDefaultFilter: function (): string {
+    return "name=*";
+  },
+
+  getLabel: function (resource: Resource<IWebService>): string {
+    return `${resource.attributes.name}`;
+  },
+
+  getContext: function (resource: Resource<IWebService>): string {
+    return `${CicsCmciConstants.CICS_WEBSERVICE_RESOURCE}.${resource.attributes.name}`;
+  },
+
+  getIconName: function (resource: Resource<IWebService>): string {
+    return "web-services";
+  },
+
+  getName(resource: Resource<IWebService>): string {
+    return resource.attributes.name;
+  }
+};

--- a/packages/vsce/src/doc/resources/IBundle.ts
+++ b/packages/vsce/src/doc/resources/IBundle.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface IBundle extends IResource {
+  bundledir: string;
+  bundleid: string;
+  enablestatus: string;
+  eyu_cicsname: string;
+  name: string;
+  partcount: string;
+}

--- a/packages/vsce/src/doc/resources/IBundlePart.ts
+++ b/packages/vsce/src/doc/resources/IBundlePart.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+// /CICSSystemManagement/CICSBundlePart/VSCDSMSJ?CRITERIA=BUNDLE='WRITE2Q'
+export interface IBundlePart extends IResource {
+  bundle: string;
+  bundlepart: string;
+  enablestatus: string;
+  eyu_cicsname: string;
+  partclass: string;
+}

--- a/packages/vsce/src/doc/resources/ICICSplex.ts
+++ b/packages/vsce/src/doc/resources/ICICSplex.ts
@@ -1,0 +1,21 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface ICICSplex extends IResource {
+  accesstype: string;
+  cmasname: string;
+  mpstatus: string;
+  plexname: string;
+  status: string;
+  sysid: string;
+}

--- a/packages/vsce/src/doc/resources/ILibrary.ts
+++ b/packages/vsce/src/doc/resources/ILibrary.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface ILibrary extends IResource {
+  name: string;
+  dsname: string;
+}

--- a/packages/vsce/src/doc/resources/ILibraryDataset.ts
+++ b/packages/vsce/src/doc/resources/ILibraryDataset.ts
@@ -1,0 +1,16 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface ILibraryDataset extends IResource {
+  dsname: string;
+}

--- a/packages/vsce/src/doc/resources/ILocalFile.ts
+++ b/packages/vsce/src/doc/resources/ILocalFile.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface ILocalFile extends IResource {
+  file: string;
+  enablestatus: string;
+  openstatus: string;
+  eyu_cicsname: string;
+}

--- a/packages/vsce/src/doc/resources/IPipeline.ts
+++ b/packages/vsce/src/doc/resources/IPipeline.ts
@@ -1,0 +1,16 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface IPipeline extends IResource {
+  name: string;
+}

--- a/packages/vsce/src/doc/resources/IProgram.ts
+++ b/packages/vsce/src/doc/resources/IProgram.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface IProgram extends IResource {
+  program: string;
+  status: string;
+  newcopycnt: string;
+  eyu_cicsname: string;
+}

--- a/packages/vsce/src/doc/resources/IRegion.ts
+++ b/packages/vsce/src/doc/resources/IRegion.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface IRegion extends IResource {
+  applid: string;
+  startup: string;
+  cicsstate: string;
+  cicsstatus: string;
+  cicsname: string;
+}

--- a/packages/vsce/src/doc/resources/IResource.ts
+++ b/packages/vsce/src/doc/resources/IResource.ts
@@ -1,0 +1,12 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export interface IResource {}

--- a/packages/vsce/src/doc/resources/ITCPIP.ts
+++ b/packages/vsce/src/doc/resources/ITCPIP.ts
@@ -1,0 +1,17 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface ITCPIP extends IResource {
+  name: string;
+  port: string;
+}

--- a/packages/vsce/src/doc/resources/ITask.ts
+++ b/packages/vsce/src/doc/resources/ITask.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface ITask extends IResource {
+  task: string;
+  runstatus: string;
+  tranid: string;
+}

--- a/packages/vsce/src/doc/resources/ITransaction.ts
+++ b/packages/vsce/src/doc/resources/ITransaction.ts
@@ -1,0 +1,19 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface ITransaction extends IResource {
+  tranid: string;
+  program: string;
+  status: string;
+  eyu_cicsname: string;
+}

--- a/packages/vsce/src/doc/resources/IURIMap.ts
+++ b/packages/vsce/src/doc/resources/IURIMap.ts
@@ -1,0 +1,18 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface IURIMap extends IResource {
+  name: string;
+  scheme: string;
+  path: string;
+}

--- a/packages/vsce/src/doc/resources/IWebService.ts
+++ b/packages/vsce/src/doc/resources/IWebService.ts
@@ -1,0 +1,16 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "./IResource";
+
+export interface IWebService extends IResource {
+  name: string;
+}

--- a/packages/vsce/src/doc/resources/index.ts
+++ b/packages/vsce/src/doc/resources/index.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export * from "./IBundle";
+export * from "./IBundlePart";
+export * from "./ICICSplex";
+export * from "./ILibrary";
+export * from "./ILibraryDataset";
+export * from "./ILocalFile";
+export * from "./IPipeline";
+export * from "./IProgram";
+export * from "./IRegion";
+export * from "./IResource";
+export * from "./ITask";
+export * from "./ITCPIP";
+export * from "./ITransaction";
+export * from "./IURIMap";
+export * from "./IWebService";

--- a/packages/vsce/src/resources/Resource.ts
+++ b/packages/vsce/src/resources/Resource.ts
@@ -1,0 +1,20 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResource } from "../doc";
+
+export class Resource<T extends IResource> {
+  attributes: T;
+
+  constructor(resource: T) {
+    this.attributes = resource;
+  }
+}


### PR DESCRIPTION
**What It Does**
Refactor CICS TreeItems to share behaviour and tidy up how they perform actions / commands. 

This takes inspiration from ZE regarding TreeItem interfaces and parent classes.

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
