### PR TITLE
Only 1 region node allowed for showRegionLogs

### DIFF
--- a/packages/vsce/src/commands/showLogsCommand.ts
+++ b/packages/vsce/src/commands/showLogsCommand.ts
@@ -109,7 +109,7 @@ export async function getJobIdForRegion(selectedRegion: CICSRegionTree): Promise
         session: selectedRegion.parentSession.getSession(),
         resourceName: CicsCmciConstants.CICS_CMCI_REGION,
         regionName: selectedRegion.region.cicsname,
-        cicsPlex: selectedRegion.parentPlex.plexName,
+        cicsPlex: selectedRegion.parentPlex?.plexName,
       });
       if (response.records?.cicsregion) {
         jobid = toArray(response.records.cicsregion)[0].jobid;
@@ -132,10 +132,13 @@ export function doesConnectionSupportJes(profile: IProfileLoaded) {
 }
 
 export function getShowRegionLogs(treeview: TreeView<any>) {
-  return commands.registerCommand("cics-extension-for-zowe.showRegionLogs", async (node) => {
-    const allSelectedRegions = findSelectedNodes(treeview, CICSRegionTree, node);
-    const selectedRegion: CICSRegionTree = allSelectedRegions[0];
-    CICSLogger.debug(`Showing region logs for region ${selectedRegion?.getRegionName()}`);
+  return commands.registerCommand("cics-extension-for-zowe.showRegionLogs", async (node: CICSRegionTree) => {
+    const selectedRegion = node ?? treeview.selection[0];
+    if (!selectedRegion) {
+      window.showErrorMessage(`No region selected`);
+      return;
+    }
+    CICSLogger.debug(`Showing region logs for region ${selectedRegion.getRegionName()}`);
 
     const jobid = await getJobIdForRegion(selectedRegion);
     CICSLogger.debug(`Job ID for region: ${jobid}`);


### PR DESCRIPTION
**What It Does**
Tidies code for showRegionLogs to only deal with the selected node - we have `listMultiSelection` in package.json anyway so this can only ever be run on 1 node.

This also fixes running from the command pallete while that is still an option.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
