### PR TITLE
Don't require notices for release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,6 @@ jobs:
     needs:
       - test
       - e2e-test
-      - notices
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Now that we're building the notices on PRs and not on release, we don't want to predicate the release on the notices having happened (because they won't have done...!)