### PR TITLE
e2e will run now on mac with wiremock standalone jar

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,6 +182,7 @@ jobs:
     if: github.event_name == 'push' && github.ref_protected
     needs:
       - test
+      - e2e-test-mac
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,28 +92,36 @@ jobs:
     #     name: zowe-cics-client
     #     path: dist/*
 
-  e2e-test:
-    runs-on: ubuntu-latest
-
-    services:
-      wiremock:
-        image: wiremock/wiremock
-        ports:
-          - 8080:8080
-        volumes:
-          - ${{ github.workspace }}/packages/vsce/__tests__/__e2e__/resources/wiremock:/home/wiremock
-        options: --name wiremock
+  e2e-test-mac: 
+    runs-on: macos-latest
 
     steps:
-      - name: Change workspace folder so wiremock service can write
-        run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-
-      - name: Checkout
+      - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Restart Wiremock with new mappings
-        run: docker restart wiremock
+      - name: Set up Java 17
+        uses: actions/setup-java@v3.14.1
+        with:
+          distribution: 'oracle'
+          java-version: '17'
 
+      - name: Download WireMock Standalone JAR
+        run: |
+          curl -L https://repo1.maven.org/maven2/org/wiremock/wiremock-standalone/3.0.1/wiremock-standalone-3.0.1.jar -o wiremock-standalone.jar
+      
+      - name: Wait for WireMock to be ready
+        run: |
+          sleep 2
+      
+      - name: Start WireMock Standalone JAR
+        run: |
+          # Start WireMock in the background
+          nohup java -jar wiremock-standalone.jar --port 8080 --root-dir ${{ github.workspace }}/packages/vsce/__tests__/__e2e__/resources/wiremock/ &
+      
+      - name: Wait for WireMock to be ready
+        run: |
+          sleep 5
+      
       - name: Use Node.js 22.x
         uses: actions/setup-node@v4
         with:
@@ -132,13 +140,11 @@ jobs:
 
       - name: Test Wiremock route
         if: ${{ always() && steps.build.outcome == 'success' }}
-        run: curl localhost:8080/CICSSystemManagement/CICSResultCache/E06EB1264D925C60
+        run: curl localhost:8080/CICSSystemManagement/CICSResultCache/E07F03C0E3C3A462
 
       - name: E2E Tests
         if: ${{ always() && steps.build.outcome == 'success' }}
-        uses: coactions/setup-xvfb@v1
-        with:
-          run: npm run test:e2e
+        run: npm run test:e2e
 
   notices:
     if: github.event.pull_request.merged != true && github.ref != 'refs/heads/main'
@@ -176,7 +182,6 @@ jobs:
     if: github.event_name == 'push' && github.ref_protected
     needs:
       - test
-      - e2e-test
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/packages/vsce/NOTICE
+++ b/packages/vsce/NOTICE
@@ -1380,8 +1380,6 @@ Copyright 2019 Coveo Solutions Inc.
 ** @bazel/runfiles; version 6.3.1 -- https://github.com/bazel-contrib/rules_nodejs#readme
 ** @sigstore/verify; version 1.2.1 -- https://github.com/sigstore/sigstore-js/tree/main/packages/verify#readme
 Copyright 2023 The Sigstore Authors
-** detect-libc; version 2.0.3 -- https://github.com/lovell/detect-libc#readme
-Copyright 2017 Lovell Fuller and others.
 ** spdx-correct; version 3.2.0 -- https://github.com/jslicense/spdx-correct.js#readme
 ** validate-npm-package-license; version 3.0.4 -- https://github.com/kemitchell/validate-npm-package-license.js#readme
 
@@ -4395,8 +4393,6 @@ SOFTWARE.
 
 ------
 
-** parse5; version 7.2.1 -- https://parse5.js.org
-Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 ** parse5-htmlparser2-tree-adapter; version 7.1.0 -- https://parse5.js.org
 Copyright (c) 2013-2019 Ivan Nikulin (ifaaan@gmail.com, https://github.com/inikulin)
 ** parse5-parser-stream; version 7.1.2 -- https://github.com/inikulin/parse5
@@ -5546,6 +5542,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ** @azure/core-client; version 1.9.3 -- https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-client/
 Copyright (c) Microsoft Corporation
 ** @azure/core-rest-pipeline; version 1.19.1 -- https://github.com/Azure/azure-sdk-for-js/blob/main/sdk/core/core-rest-pipeline/
+Copyright (c) Microsoft Corporation
+** @azure/identity; version 4.9.1 -- https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity/README.md
 Copyright (c) Microsoft Corporation
 
 Copyright (c) Microsoft Corporation.
@@ -6809,6 +6807,9 @@ Copyright (c) Microsoft Corporation
 ** @types/istanbul-lib-coverage; version 2.0.6 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/istanbul-lib-coverage
 Copyright (c) Microsoft Corporation
 ** @types/mocha; version 10.0.10 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mocha
+Copyright (c) Microsoft Corporation
+** @types/node; version 22.14.1 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
+Copyright Node.js contributors
 Copyright (c) Microsoft Corporation
 ** @types/selenium-webdriver; version 4.1.28 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/selenium-webdriver
 ** @types/vscode; version 1.53.0 -- 


### PR DESCRIPTION
**What It Does**
E2E test cases will now run on mac os with Standalone jar. 

**How to Test**
To execute it in local `npm run test:e2e` 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
