### PR TITLE
release on manual workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,7 +179,7 @@ jobs:
         commit_user_email: zowe.robot@gmail.com
 
   release:
-    if: github.event_name == 'push' && github.ref_protected
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_protected
     needs:
       - test
       - e2e-test-mac

--- a/packages/vsce/NOTICE
+++ b/packages/vsce/NOTICE
@@ -6687,6 +6687,9 @@ Copyright (c) Microsoft Corporation
 Copyright (c) Microsoft Corporation
 ** @types/mocha; version 10.0.10 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/mocha
 Copyright (c) Microsoft Corporation
+** @types/node; version 22.15.18 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
+Copyright Node.js contributors
+Copyright (c) Microsoft Corporation
 ** @types/selenium-webdriver; version 4.1.28 -- https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/selenium-webdriver
 ** @types/vscode; version 1.53.0 -- 
 Copyright (c) Microsoft Corporation.


### PR DESCRIPTION
**What It Does**
We've had an issue with PRs not running the release step of the workflow. We're hoping adding in this manual trigger will allow it to be rerun if necessary. 