### PR TITLE
Use new Zowe extender API to trigger create profile (take 2)

### DIFF
--- a/packages/cli/__tests__/__snapshots__/imperative.test.ts.snap
+++ b/packages/cli/__tests__/__snapshots__/imperative.test.ts.snap
@@ -118,6 +118,7 @@ exports[`imperative config should match the snapshot 1`] = `
         "required": [],
         "title": "CICS Profile",
         "type": "object",
+        "version": "6.7.0",
       },
       "type": "cics",
     },

--- a/packages/sdk/src/constants/CICSProfileDefinition.ts
+++ b/packages/sdk/src/constants/CICSProfileDefinition.ts
@@ -17,6 +17,7 @@ export const getCICSProfileDefinition = (): imperative.ICommandProfileTypeConfig
     schema: {
       type: "object",
       title: "CICS Profile",
+      version: "6.7.0",
       description:
         "A cics profile is required to issue commands in the cics command group that interact with " +
         "CICS regions. The cics profile contains your host, port, user name, and password " +

--- a/packages/vsce/NOTICE
+++ b/packages/vsce/NOTICE
@@ -5442,7 +5442,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ------
 
-** @azure/identity; version 4.9.1 -- https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity/README.md
+** @azure/identity; version 4.10.0 -- https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/identity/identity/README.md
 Copyright (c) Microsoft Corporation
 
 Copyright (c) Microsoft Corporation.

--- a/packages/vsce/src/trees/CICSTree.ts
+++ b/packages/vsce/src/trees/CICSTree.ts
@@ -187,7 +187,7 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
           Gui.showMessage(debugMsg);
           return;
         } else if (choice === configPick) {
-          commands.executeCommand("zowe.all.config.init");
+          ZoweVsCodeExtension.createTeamConfiguration();
           return;
         } else if (choice === configEdit) {
           await this.editZoweConfigFile();


### PR DESCRIPTION
See conversation in https://github.com/zowe/cics-for-zowe-client/pull/288

**What It Does**
Updates to use the Zowe extender API provided with Zowe Explorer 3.2.0
No discernable change .... so can we avoid change-log and issue? 🤔 

Our end 2 end tests will cover the testing very well!

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
