### PR TITLE
Add extender API that return select config

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented 
 
 ## Recent Changes
 
-- Enhancement: Added a some missing resource constants. [#299](https://github.com/zowe/cics-for-zowe-client/pull/299)
+- Enhancement: Added pipeline and webservice resource constants. [#299](https://github.com/zowe/cics-for-zowe-client/pull/299)
 
 ## `6.6.1`
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented 
 
 ## Recent Changes
 
-- Enhancement: Added a some missing resource constants. [#294](https://github.com/zowe/cics-for-zowe-client/pull/294)
+- Enhancement: Added a some missing resource constants. [#299](https://github.com/zowe/cics-for-zowe-client/pull/299)
 
 ## `6.6.1`
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented 
 
 ## Recent Changes
 
-- Enhancement: Added pipeline and webservice resource constants. [#299](https://github.com/zowe/cics-for-zowe-client/pull/299)
+- Enhancement: Added extender API interface and resource constants for pipeline and webservice resource. [#299](https://github.com/zowe/cics-for-zowe-client/pull/299)
 
 ## `6.6.1`
 

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Added a some missing resource constants. [#294](https://github.com/zowe/cics-for-zowe-client/pull/294)
+
 ## `6.6.1`
 
 - Add notices file into package [#267](https://github.com/zowe/cics-for-zowe-client/issues/267)

--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -165,6 +165,16 @@ export const CicsCmciConstants = {
   CICS_CMCI_TASK: "CICSTask",
 
   /**
+   * The CICS CMCI pipeline
+   */
+   CICS_CMCI_PIPELINE: "CICSPipeline",
+
+  /**
+   * The CICS CMCI web service
+   */
+  CICS_CMCI_WEB_SERVICE: "CICSWebService",
+
+  /**
    * CICS CMCI Response 1 Codes
    */
   RESPONSE_1_CODES: {

--- a/packages/sdk/src/doc/ICICSExtenderConfig.ts
+++ b/packages/sdk/src/doc/ICICSExtenderConfig.ts
@@ -14,10 +14,6 @@ export interface ICICSExtenderConfig {
    * Extension configuration as returned by the extender API
    */
   configuration: {
-    /**
-     * The name of the CSD Group
-     * Up to eight characters long
-     */
     supportedResources: string[];
     resourceInspector: {
       enabled: boolean;

--- a/packages/sdk/src/doc/ICICSExtenderConfig.ts
+++ b/packages/sdk/src/doc/ICICSExtenderConfig.ts
@@ -1,0 +1,26 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export interface ICICSExtenderConfig {
+  /**
+   * Extension configuration as returned by the extender API
+   */
+  configuration: {
+    /**
+     * The name of the CSD Group
+     * Up to eight characters long
+     */
+    supportedResources: string[];
+    resourceInspector: {
+      enabled: boolean;
+    };
+  };
+}

--- a/packages/sdk/src/doc/index.ts
+++ b/packages/sdk/src/doc/index.ts
@@ -22,3 +22,4 @@ export * from "./IResultCacheParms";
 export * from "./ITransactionParms";
 export * from "./IURIMapParms";
 export * from "./IWebServiceParms";
+export * from "./ICICSExtenderConfig";

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 
 ## Recent Changes
 
-- Enhancement: Added a supportedResources API for extenders. [#294](https://github.com/zowe/cics-for-zowe-client/pull/294)
+- Enhancement: Added an API for extenders. [#299](https://github.com/zowe/cics-for-zowe-client/pull/299)
 
 ## `3.7.0`
 

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Added a supportedResources API for extenders. [#294](https://github.com/zowe/cics-for-zowe-client/pull/294)
+
 ## `3.7.0`
 
 - BugFix: Allow credentials to be used by the current session only with `autoStore: false` [#224](https://github.com/zowe/cics-for-zowe-client/issues/224)

--- a/packages/vsce/__tests__/__unit__/extending/CICSExtenderApiConfig.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/extending/CICSExtenderApiConfig.unit.test.ts
@@ -11,15 +11,16 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk/lib/constants/CicsCmci.constants";
 import { CICSExtenderApiConfig } from "../../../src/extending/CICSExtenderApiConfig";
+import { ICICSExtenderConfig } from "@zowe/cics-for-zowe-sdk";
 
 describe("CICS Extender Api Tests", () => {
   it("should return resource inspector configuration", () => {
-    const config = CICSExtenderApiConfig.getInstance().getConfig();
+    const config:ICICSExtenderConfig = CICSExtenderApiConfig.getInstance().getConfig();
     expect(config).toHaveProperty('configuration.resourceInspector.enabled', false);
   });
 
   it("should return supported resources configuration", () => {
-    const config = CICSExtenderApiConfig.getInstance().getConfig();
+    const config:ICICSExtenderConfig  = CICSExtenderApiConfig.getInstance().getConfig();
     expect(config).toHaveProperty('configuration.supportedResources', [
         CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
         CicsCmciConstants.CICS_PROGRAM_RESOURCE,

--- a/packages/vsce/__tests__/__unit__/extending/CICSExtenderApiConfig.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/extending/CICSExtenderApiConfig.unit.test.ts
@@ -1,0 +1,34 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk/lib/constants/CicsCmci.constants";
+import { CICSExtenderApiConfig } from "../../../src/extending/CICSExtenderApiConfig";
+
+describe("CICS Extender Api Tests", () => {
+  it("should return resource inspector configuration", () => {
+    const config = CICSExtenderApiConfig.getInstance().getConfig();
+    expect(config).toHaveProperty('configuration.resourceInspector.enabled', false);
+  });
+
+  it("should return supported resources configuration", () => {
+    const config = CICSExtenderApiConfig.getInstance().getConfig();
+    expect(config).toHaveProperty('configuration.supportedResources', [
+        CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
+        CicsCmciConstants.CICS_PROGRAM_RESOURCE,
+        CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
+        CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE,
+        CicsCmciConstants.CICS_LIBRARY_RESOURCE,
+        CicsCmciConstants.CICS_URIMAP,
+        CicsCmciConstants.CICS_CMCI_TASK,
+        CicsCmciConstants.CICS_CMCI_PIPELINE,
+        CicsCmciConstants.CICS_CMCI_WEB_SERVICE ]);
+  });
+});

--- a/packages/vsce/src/extending/CICSExtenderApiConfig.ts
+++ b/packages/vsce/src/extending/CICSExtenderApiConfig.ts
@@ -21,8 +21,8 @@ export class CICSExtenderApiConfig {
 
   private constructor() {
     this.config = {
-      "configuration": {
-        "supportedResources": [
+      configuration: {
+        supportedResources: [
             CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
             CicsCmciConstants.CICS_PROGRAM_RESOURCE,
             CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
@@ -33,8 +33,8 @@ export class CICSExtenderApiConfig {
             CicsCmciConstants.CICS_CMCI_PIPELINE,
             CicsCmciConstants.CICS_CMCI_WEB_SERVICE,
         ],
-        "resourceInspector": {
-          "enabled": false
+        resourceInspector: {
+          enabled: false
         }
       }
     };

--- a/packages/vsce/src/extending/CICSExtenderApiConfig.ts
+++ b/packages/vsce/src/extending/CICSExtenderApiConfig.ts
@@ -1,0 +1,50 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+
+export class CICSExtenderApiConfig {
+  private static api: CICSExtenderApiConfig = new CICSExtenderApiConfig();
+  private config: any = { "configuration": {} };
+
+  public static getInstance(): CICSExtenderApiConfig {
+    return this.api;
+  }
+
+  private constructor() {
+    this.registerResourceTypes();
+    this.registerResourceInspector();
+  }
+
+  private registerResourceTypes(): void {
+    this.config["configuration"]["supportedResources"] = [
+            CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
+            CicsCmciConstants.CICS_PROGRAM_RESOURCE,
+            CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
+            CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE,
+            CicsCmciConstants.CICS_LIBRARY_RESOURCE,
+            CicsCmciConstants.CICS_URIMAP,
+            CicsCmciConstants.CICS_CMCI_TASK,
+            CicsCmciConstants.CICS_CMCI_PIPELINE,
+            CicsCmciConstants.CICS_CMCI_WEB_SERVICE,
+          ];
+  }
+
+  private registerResourceInspector(): void {
+    this.config["configuration"]["resourceInspector"] = {
+      "enabled": false
+    };
+  }
+
+  public getConfig(): any {
+    return this.config;
+  }
+}

--- a/packages/vsce/src/extending/CICSExtenderApiConfig.ts
+++ b/packages/vsce/src/extending/CICSExtenderApiConfig.ts
@@ -9,23 +9,20 @@
  *
  */
 
-import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import { CicsCmciConstants, ICICSExtenderConfig } from "@zowe/cics-for-zowe-sdk";
 
 export class CICSExtenderApiConfig {
   private static api: CICSExtenderApiConfig = new CICSExtenderApiConfig();
-  private config: any = { "configuration": {} };
+  private config: ICICSExtenderConfig;
 
   public static getInstance(): CICSExtenderApiConfig {
     return this.api;
   }
 
   private constructor() {
-    this.registerResourceTypes();
-    this.registerResourceInspector();
-  }
-
-  private registerResourceTypes(): void {
-    this.config["configuration"]["supportedResources"] = [
+    this.config = {
+      "configuration": {
+        "supportedResources": [
             CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
             CicsCmciConstants.CICS_PROGRAM_RESOURCE,
             CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
@@ -35,16 +32,15 @@ export class CICSExtenderApiConfig {
             CicsCmciConstants.CICS_CMCI_TASK,
             CicsCmciConstants.CICS_CMCI_PIPELINE,
             CicsCmciConstants.CICS_CMCI_WEB_SERVICE,
-          ];
-  }
-
-  private registerResourceInspector(): void {
-    this.config["configuration"]["resourceInspector"] = {
-      "enabled": false
+        ],
+        "resourceInspector": {
+          "enabled": false
+        }
+      }
     };
   }
 
-  public getConfig(): any {
+  public getConfig(): ICICSExtenderConfig {
     return this.config;
   }
 }

--- a/packages/vsce/src/extension.ts
+++ b/packages/vsce/src/extension.ts
@@ -19,6 +19,7 @@ import { getZoweExplorerVersion } from "./utils/workspaceUtils";
 import { getCommands } from "./commands";
 import { CICSLogger } from "./utils/CICSLogger";
 import { CICSMessages } from "./constants/CICS.messages";
+import { CICSExtenderApiConfig } from "./extending/CICSExtenderApiConfig";
 import { ResourceInspectorViewProvider } from "./trees/ResourceInspectorViewProvider";
 
 /**
@@ -184,6 +185,8 @@ export async function activate(context: ExtensionContext) {
       ResourceInspectorViewProvider.getInstance(context.extensionUri, treeview)
     )
   );
+
+  return CICSExtenderApiConfig.getInstance().getConfig();
 }
 
 export async function deactivate(): Promise<void> {

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedPipelineTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedPipelineTree.ts
@@ -20,6 +20,7 @@ import { CICSTree } from "../CICSTree";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { ViewMore } from "../treeItems/utils/ViewMore";
 import { CICSPipelineTreeItem } from "../treeItems/CICSPipelineTreeItem";
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk/lib/constants/CicsCmci.constants";
 
 export class CICSCombinedPipelineTree extends TreeItem {
   children: (CICSPipelineTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -40,7 +41,7 @@ export class CICSCombinedPipelineTree extends TreeItem {
     this.activeFilter = undefined;
     this.currentCount = 0;
     this.incrementCount = +`${workspace.getConfiguration().get("zowe.cics.allPipelines.recordCountIncrement")}`;
-    this.constant = "CICSPipeline";
+    this.constant = CicsCmciConstants.CICS_CMCI_PIPELINE;
   }
 
   public async loadContents(tree: CICSTree) {

--- a/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedWebServiceTree.ts
+++ b/packages/vsce/src/trees/CICSCombinedTrees/CICSCombinedWebServiceTree.ts
@@ -20,6 +20,7 @@ import { CICSTree } from "../CICSTree";
 import { TextTreeItem } from "../treeItems/utils/TextTreeItem";
 import { ViewMore } from "../treeItems/utils/ViewMore";
 import { CICSWebServiceTreeItem } from "../treeItems/CICSWebServiceTreeItem";
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 
 export class CICSCombinedWebServiceTree extends TreeItem {
   children: (CICSWebServiceTreeItem | ViewMore)[] | [TextTreeItem] | null;
@@ -40,7 +41,7 @@ export class CICSCombinedWebServiceTree extends TreeItem {
     this.activeFilter = undefined;
     this.currentCount = 0;
     this.incrementCount = +`${workspace.getConfiguration().get("zowe.cics.allWebServices.recordCountIncrement")}`;
-    this.constant = "CICSWebService";
+    this.constant = CicsCmciConstants.CICS_CMCI_WEB_SERVICE;
   }
 
   public async loadContents(tree: CICSTree) {

--- a/packages/vsce/src/trees/CICSPipelineTree.ts
+++ b/packages/vsce/src/trees/CICSPipelineTree.ts
@@ -17,6 +17,7 @@ import { runGetResource } from "../utils/resourceUtils";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { CICSPipelineTreeItem } from "./treeItems/CICSPipelineTreeItem";
 import { CICSLogger } from "../utils/CICSLogger";
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 
 export class CICSPipelineTree extends TreeItem {
   children: CICSPipelineTreeItem[] = [];
@@ -48,7 +49,7 @@ export class CICSPipelineTree extends TreeItem {
     try {
       const pipelineResponse = await runGetResource({
         session: this.parentRegion.parentSession.session,
-        resourceName: "CICSPipeline",
+        resourceName: CicsCmciConstants.CICS_CMCI_PIPELINE,
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         params: { criteria: criteria },

--- a/packages/vsce/src/trees/CICSWebServiceTree.ts
+++ b/packages/vsce/src/trees/CICSWebServiceTree.ts
@@ -17,6 +17,7 @@ import { runGetResource } from "../utils/resourceUtils";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { CICSWebServiceTreeItem } from "./treeItems/CICSWebServiceTreeItem";
 import { CICSLogger } from "../utils/CICSLogger";
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 
 export class CICSWebServiceTree extends TreeItem {
   children: CICSWebServiceTreeItem[] = [];
@@ -48,7 +49,7 @@ export class CICSWebServiceTree extends TreeItem {
     try {
       const webserviceResponse = await runGetResource({
         session: this.parentRegion.parentSession.session,
-        resourceName: "CICSWebService",
+        resourceName: CicsCmciConstants.CICS_CMCI_WEB_SERVICE,
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         regionName: this.parentRegion.getRegionName(),
         params: { criteria: criteria },


### PR DESCRIPTION
**What It Does**
Add an extender API that can return some configuration for the extension.

**How to Test**
Performed manual testing + added a unit test. 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [ ] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
