### PR TITLE
Add Bundle as option of CLI Define

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Add ability to define bundles [#72](https://github.com/zowe/cics-for-zowe-client/issues/72)
+
 ## `6.6.1`
 
 - Add notices file into package [#267](https://github.com/zowe/cics-for-zowe-client/issues/267)

--- a/packages/cli/__tests__/__unit__/define/bundle/Bundle.definition.unit.test.ts
+++ b/packages/cli/__tests__/__unit__/define/bundle/Bundle.definition.unit.test.ts
@@ -11,14 +11,11 @@
 
 import { ICommandDefinition } from "@zowe/imperative";
 
-describe("cics define program", () => {
-  const DEFINE_RESOURCES = 7;
-
+describe("cics define bundle", () => {
   it("should not have changed", () => {
-    const definition: ICommandDefinition = require("../../../src/define/Define.definition");
+    const definition: ICommandDefinition = require("../../../../src/define/bundle/Bundle.definition").BundleDefinition;
     expect(definition).toBeDefined();
-    expect(definition.children?.length).toBe(DEFINE_RESOURCES);
-    delete definition.children;
+    delete definition.handler;
     expect(definition).toMatchSnapshot();
   });
 });

--- a/packages/cli/__tests__/__unit__/define/bundle/Bundle.handler.unit.test.ts
+++ b/packages/cli/__tests__/__unit__/define/bundle/Bundle.handler.unit.test.ts
@@ -1,0 +1,112 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { mockHandlerParameters } from "@zowe/cli-test-utils";
+import { IHandlerParameters, Session } from "@zowe/imperative";
+import { ICMCIApiResponse } from "../../../../src";
+import { BundleDefinition } from "../../../../src/define/bundle/Bundle.definition";
+import BundleHandler from "../../../../src/define/bundle/Bundle.handler";
+
+jest.mock("@zowe/cics-for-zowe-sdk");
+const Define = require("@zowe/cics-for-zowe-sdk");
+
+const host = "somewhere.com";
+const port = 43443;
+const user = "someone";
+const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
+
+const PROFILE_MAP = {
+  name: "cics",
+  type: "cics",
+  host,
+  port,
+  user,
+  password,
+};
+const DEFAULT_PARAMETERS: IHandlerParameters = mockHandlerParameters({
+  positionals: ["cics", "define", "bundle"],
+  definition: BundleDefinition,
+  arguments: PROFILE_MAP,
+});
+
+describe("DefineBundleHandler", () => {
+  const bundleName = "testBundle";
+  const bundleDir = "/my/user/bundle/";
+  const regionName = "testRegion";
+  const csdGroup = "testGroup";
+
+  const defaultReturn: ICMCIApiResponse = {
+    response: {
+      resultsummary: { api_response1: "1024", api_response2: "0", recordcount: "0", displayed_recordcount: "0" },
+      records: "testing",
+    },
+  };
+
+  const functionSpy = jest.spyOn(Define, "defineBundle");
+
+  beforeEach(() => {
+    functionSpy.mockClear();
+    functionSpy.mockImplementation(async () => defaultReturn);
+  });
+
+  it("should call the defineBundle api", async () => {
+    const handler = new BundleHandler();
+
+    const commandParameters = { ...DEFAULT_PARAMETERS };
+    commandParameters.arguments = {
+      ...commandParameters.arguments,
+      bundleName,
+      bundleDir,
+      regionName,
+      csdGroup,
+      host,
+      port,
+      user,
+      password,
+      rejectUnauthorized,
+      protocol,
+    };
+
+    await handler.process(commandParameters);
+
+    expect(functionSpy).toHaveBeenCalledTimes(1);
+
+    expect(functionSpy).toHaveBeenCalledWith(
+      new Session({
+        type: "basic",
+        hostname: PROFILE_MAP.host,
+        port: PROFILE_MAP.port,
+        user: PROFILE_MAP.user,
+        password: PROFILE_MAP.password,
+        rejectUnauthorized,
+        protocol,
+        _authCache: {
+          availableCreds: {
+            base64EncodedAuth: "c29tZW9uZTpzb21lc2VjcmV0",
+            password: "somesecret",
+            user: "someone",
+          },
+          didUserSetAuthOrder: false,
+          topDefaultAuth: "basic",
+        },
+        authTypeOrder: ["basic", "token", "bearer", "cert-pem"],
+      }),
+      {
+        name: bundleName,
+        bundleDir,
+        csdGroup,
+        regionName,
+      }
+    );
+  });
+});

--- a/packages/cli/__tests__/__unit__/define/bundle/__snapshots__/Bundle.definition.unit.test.ts.snap
+++ b/packages/cli/__tests__/__unit__/define/bundle/__snapshots__/Bundle.definition.unit.test.ts.snap
@@ -20,7 +20,7 @@ exports[`cics define bundle should not have changed 1`] = `
       "type": "string",
     },
     {
-      "description": "The name of the CICSPlex to which to define the new bundle",
+      "description": "The name of the CICSplex to which to define the new bundle",
       "name": "cics-plex",
       "type": "string",
     },
@@ -33,7 +33,7 @@ exports[`cics define bundle should not have changed 1`] = `
       "type": "string",
     },
     {
-      "description": "The fully qualified name of the root directory for the bundle on z/OS UNIX. The first character must be / and the end character /. The maximum length if 255 characters.",
+      "description": "The fully qualified name of the root directory for the bundle on z/OS UNIX. The first character must be / and the end character /. The maximum length is 255 characters.",
       "name": "bundleDir",
       "required": true,
       "type": "string",

--- a/packages/cli/__tests__/__unit__/define/bundle/__snapshots__/Bundle.definition.unit.test.ts.snap
+++ b/packages/cli/__tests__/__unit__/define/bundle/__snapshots__/Bundle.definition.unit.test.ts.snap
@@ -9,7 +9,7 @@ exports[`cics define bundle should not have changed 1`] = `
   "examples": [
     {
       "description": "Define a bundle named BND123 to the region name MYREGION in the CSD group MYGRP",
-      "options": "BND123 MYGRP /user/myname/bundle1/ --region-name MYREGION",
+      "options": "BND123 /user/myname/bundle1/ MYGRP --region-name MYREGION",
     },
   ],
   "name": "bundle",

--- a/packages/cli/__tests__/__unit__/define/bundle/__snapshots__/Bundle.definition.unit.test.ts.snap
+++ b/packages/cli/__tests__/__unit__/define/bundle/__snapshots__/Bundle.definition.unit.test.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cics define bundle should not have changed 1`] = `
+{
+  "aliases": [
+    "bund",
+  ],
+  "description": "Define a new bundle to CICS.",
+  "examples": [
+    {
+      "description": "Define a bundle named BND123 to the region name MYREGION in the CSD group MYGRP",
+      "options": "BND123 MYGRP /user/myname/bundle1/ --region-name MYREGION",
+    },
+  ],
+  "name": "bundle",
+  "options": [
+    {
+      "description": "The CICS region name to which to define the new bundle",
+      "name": "region-name",
+      "type": "string",
+    },
+    {
+      "description": "The name of the CICSPlex to which to define the new bundle",
+      "name": "cics-plex",
+      "type": "string",
+    },
+  ],
+  "positionals": [
+    {
+      "description": "The name of the new bundle to define. The maximum length of the bundle name is eight characters.",
+      "name": "bundleName",
+      "required": true,
+      "type": "string",
+    },
+    {
+      "description": "The fully qualified name of the root directory for the bundle on z/OS UNIX. The first character must be / and the end character /. The maximum length if 255 characters.",
+      "name": "bundleDir",
+      "required": true,
+      "type": "string",
+    },
+    {
+      "description": "The CICS system definition (CSD) Group for the new bundle that you want to define. The maximum length of the group name is eight characters.",
+      "name": "csdGroup",
+      "required": true,
+      "type": "string",
+    },
+  ],
+  "profile": {
+    "optional": [
+      "cics",
+    ],
+  },
+  "type": "command",
+}
+`;

--- a/packages/cli/__tests__/__unit__/define/bundle/__snapshots__/Bundle.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/__unit__/define/bundle/__snapshots__/Bundle.handler.unit.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DefineBundleHandler should call the defineBundle api 1`] = `"The bundle '%s' was defined successfully."`;
+
+exports[`DefineBundleHandler should call the defineBundle api 2`] = `
+{
+  "response": {
+    "records": "testing",
+    "resultsummary": {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;

--- a/packages/cli/src/-strings-/en.ts
+++ b/packages/cli/src/-strings-/en.ts
@@ -170,11 +170,11 @@ export default {
             "name is eight characters.",
           BUNDLEDIR:
             "The fully qualified name of the root directory for the bundle on z/OS UNIX. " +
-            "The first character must be / and the end character /. The maximum length if 255 characters.",
+            "The first character must be / and the end character /. The maximum length is 255 characters.",
         },
         OPTIONS: {
           REGIONNAME: "The CICS region name to which to define the new bundle",
-          CICSPLEX: "The name of the CICSPlex to which to define the new bundle",
+          CICSPLEX: "The name of the CICSplex to which to define the new bundle",
         },
         MESSAGES: {
           SUCCESS: "The bundle '%s' was defined successfully.",

--- a/packages/cli/src/-strings-/en.ts
+++ b/packages/cli/src/-strings-/en.ts
@@ -160,6 +160,29 @@ export default {
             "in the CSD group MYGRP where the binding file is /u/exampleapp/wsbind/example.log",
         },
       },
+      BUNDLE: {
+        DESCRIPTION: "Define a new bundle to CICS.",
+        POSITIONALS: {
+          BUNDLENAME: "The name of the new bundle to define. The maximum length of the bundle name is eight characters.",
+          CSDGROUP:
+            "The CICS system definition (CSD) Group for the new bundle that you want to define." +
+            " The maximum length of the group " +
+            "name is eight characters.",
+          BUNDLEDIR:
+            "The fully qualified name of the root directory for the bundle on z/OS UNIX. " +
+            "The first character must be / and the end character /. The maximum length if 255 characters.",
+        },
+        OPTIONS: {
+          REGIONNAME: "The CICS region name to which to define the new bundle",
+          CICSPLEX: "The name of the CICSPlex to which to define the new bundle",
+        },
+        MESSAGES: {
+          SUCCESS: "The bundle '%s' was defined successfully.",
+        },
+        EXAMPLES: {
+          EX1: "Define a bundle named BND123 to the region name MYREGION in the CSD group MYGRP",
+        },
+      },
     },
   },
   DELETE: {

--- a/packages/cli/src/define/Define.definition.ts
+++ b/packages/cli/src/define/Define.definition.ts
@@ -12,6 +12,7 @@
 import { ICommandDefinition } from "@zowe/imperative";
 import { CicsSession } from "../CicsSession";
 
+import { BundleDefinition } from "./bundle/Bundle.definition";
 import { ProgramDefinition } from "./program/Program.definition";
 import { TransactionDefinition } from "./transaction/Transaction.definition";
 import { UrimapClientDefinition } from "./urimap-client/UrimapClient.definition";
@@ -40,6 +41,7 @@ const definition: ICommandDefinition = {
     UrimapClientDefinition,
     UrimapPipelineDefinition,
     WebServiceDefinition,
+    BundleDefinition,
   ],
   passOn: [
     {

--- a/packages/cli/src/define/bundle/Bundle.definition.ts
+++ b/packages/cli/src/define/bundle/Bundle.definition.ts
@@ -1,0 +1,64 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { ICommandDefinition } from "@zowe/imperative";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.BUNDLE;
+
+export const BundleDefinition: ICommandDefinition = {
+  name: "bundle",
+  aliases: ["bund"],
+  description: strings.DESCRIPTION,
+  handler: __dirname + "/Bundle.handler",
+  type: "command",
+  positionals: [
+    {
+      name: "bundleName",
+      description: strings.POSITIONALS.BUNDLENAME,
+      type: "string",
+      required: true,
+    },
+    {
+      name: "bundleDir",
+      description: strings.POSITIONALS.BUNDLEDIR,
+      type: "string",
+      required: true,
+    },
+    {
+      name: "csdGroup",
+      description: strings.POSITIONALS.CSDGROUP,
+      type: "string",
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: "region-name",
+      description: strings.OPTIONS.REGIONNAME,
+      type: "string",
+    },
+    {
+      name: "cics-plex",
+      description: strings.OPTIONS.CICSPLEX,
+      type: "string",
+    },
+  ],
+  profile: { optional: ["cics"] },
+  examples: [
+    {
+      description: strings.EXAMPLES.EX1,
+      options: "BND123 MYGRP /user/myname/bundle1/ --region-name MYREGION",
+    },
+  ],
+};

--- a/packages/cli/src/define/bundle/Bundle.definition.ts
+++ b/packages/cli/src/define/bundle/Bundle.definition.ts
@@ -58,7 +58,7 @@ export const BundleDefinition: ICommandDefinition = {
   examples: [
     {
       description: strings.EXAMPLES.EX1,
-      options: "BND123 MYGRP /user/myname/bundle1/ --region-name MYREGION",
+      options: "BND123 /user/myname/bundle1/ MYGRP --region-name MYREGION",
     },
   ],
 };

--- a/packages/cli/src/define/bundle/Bundle.handler.ts
+++ b/packages/cli/src/define/bundle/Bundle.handler.ts
@@ -1,0 +1,47 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { ICMCIApiResponse, defineBundle } from "@zowe/cics-for-zowe-sdk";
+import { AbstractSession, IHandlerParameters, ITaskWithStatus, TaskStage } from "@zowe/imperative";
+import { CicsBaseHandler } from "../../CicsBaseHandler";
+
+import i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).DEFINE.RESOURCES.BUNDLE;
+
+/**
+ * Command handler for defining CICS bundles via CMCI
+ * @export
+ * @class BundleHandler
+ * @implements {ICommandHandler}
+ */
+export default class BundleHandler extends CicsBaseHandler {
+  public async processWithSession(params: IHandlerParameters, session: AbstractSession): Promise<ICMCIApiResponse> {
+    const status: ITaskWithStatus = {
+      statusMessage: "Defining bundle to CICS",
+      percentComplete: 0,
+      stageName: TaskStage.IN_PROGRESS,
+    };
+    params.response.progress.startBar({ task: status });
+
+    const response = await defineBundle(session, {
+      name: params.arguments.bundleName,
+      bundleDir: params.arguments.bundleDir,
+      csdGroup: params.arguments.csdGroup,
+      regionName: params.arguments.regionName,
+      cicsPlex: params.arguments.cicsPlex,
+    });
+
+    params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.bundleName);
+    return response;
+  }
+}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented 
 
 - Add missing CICS resource constants. [#249](https://github.com/zowe/cics-for-zowe-client/pull/249)
 - Enhancement: Add a version number to the profile schema [#291](https://github.com/zowe/cics-for-zowe-client/issues/291)
+- Add ability to define bundles [#72](https://github.com/zowe/cics-for-zowe-client/issues/72)
 
 ## `6.8.0`
 

--- a/packages/sdk/__tests__/__unit__/CicsCmciRestClient.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/CicsCmciRestClient.unit.test.ts
@@ -101,4 +101,29 @@ describe("CicsCmciRestClient tests", () => {
     expect(processedError.msg).toContain(shouldNotDeleteMessage);
     expect(processedError.msg.indexOf()).toEqual(-1);
   });
+
+  it("should convertObjectToXML", () => {
+    expect(CicsCmciRestClient.convertObjectToXML({})).toEqual("<root/>");
+    expect(
+      CicsCmciRestClient.convertObjectToXML({
+        attribute: {
+          key: "value",
+        },
+        listHeader: [
+          "value1",
+          {
+            object: "child",
+          },
+        ],
+      })
+    ).toEqual(`<root>
+  <attribute>
+    <key>value</key>
+  </attribute>
+  <listHeader>value1</listHeader>
+  <listHeader>
+    <object>child</object>
+  </listHeader>
+</root>`);
+  });
 });

--- a/packages/sdk/__tests__/__unit__/CicsProfileDefinition.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/CicsProfileDefinition.unit.test.ts
@@ -1,0 +1,22 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { getCICSProfileDefinition } from "../../src";
+
+describe("CICS Profile definition", () => {
+  it("Should return accurage cics profile definition", () => {
+    expect(getCICSProfileDefinition()).toHaveProperty("type");
+    expect(getCICSProfileDefinition()).toHaveProperty("schema");
+
+    expect(getCICSProfileDefinition().schema).toHaveProperty("required");
+    expect(getCICSProfileDefinition().type).toEqual("cics");
+  });
+});

--- a/packages/sdk/__tests__/__unit__/define/Define.bundle.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/define/Define.bundle.unit.test.ts
@@ -1,0 +1,263 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Session } from "@zowe/imperative";
+import { CicsCmciConstants, CicsCmciRestClient, IBundleParms, ICMCIApiResponse, defineBundle } from "../../../src";
+
+describe("CMCI - Define bundle", () => {
+  const bundle = "bundle";
+  const bundleDir = "/my/bundle/dir/";
+  const region = "region";
+  const group = "group";
+  const cicsPlex = "plex";
+  const content = "This\nis\r\na\ntest" as unknown as ICMCIApiResponse;
+
+  const defineParms: IBundleParms = {
+    regionName: region,
+    name: bundle,
+    bundleDir,
+    csdGroup: group,
+    cicsPlex: undefined,
+  };
+
+  const dummySession = new Session({
+    user: "fake",
+    password: "fake",
+    hostname: "fake",
+    port: 1490,
+  });
+
+  let error: any;
+  let response: any;
+  let endPoint: string;
+
+  describe("validation", () => {
+    beforeEach(() => {
+      response = undefined;
+      error = undefined;
+    });
+
+    it("should throw error if no parms are defined", async () => {
+      try {
+        // @ts-ignore - undefined is not a valid argument
+        response = await defineBundle(dummySession, undefined);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toMatch(/(Cannot read).*undefined/);
+    });
+
+    it("should throw error if bundle name is not defined", async () => {
+      try {
+        response = await defineBundle(dummySession, {
+          regionName: "fake",
+          // @ts-ignore - name is required
+          name: undefined,
+          csdGroup: "fake",
+          bundleDir: "fake",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("CICS bundle name is required");
+    });
+
+    it("should throw error if CSD group is not defined", async () => {
+      try {
+        response = await defineBundle(dummySession, {
+          regionName: "fake",
+          name: "fake",
+          // @ts-ignore - csdgroup is required
+          csdGroup: undefined,
+          bundleDir: "fake",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("CICS CSD group is required");
+    });
+
+    it("should throw error if CICS Region name is not defined", async () => {
+      try {
+        response = await defineBundle(dummySession, {
+          // @ts-ignore - regionName is required
+          regionName: undefined,
+          name: "fake",
+          csdGroup: "fake",
+          bundleDir: "fake",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("CICS region name is required");
+    });
+
+    it("should throw error if CICS Bundle Dir is not defined", async () => {
+      try {
+        response = await defineBundle(dummySession, {
+          regionName: "fake",
+          name: "fake",
+          csdGroup: "fake",
+          // @ts-ignore - bundleDir is required
+          bundleDir: undefined,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("Expect Error: CICS bundle directory is required");
+    });
+
+    it("should throw error if bundle name is missing", async () => {
+      try {
+        response = await defineBundle(dummySession, {
+          regionName: "fake",
+          name: "",
+          csdGroup: "fake",
+          bundleDir: "fake",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("Required parameter 'CICS Bundle name' must not be blank");
+    });
+
+    it("should throw error if CSD group is missing", async () => {
+      try {
+        response = await defineBundle(dummySession, {
+          regionName: "fake",
+          name: "fake",
+          csdGroup: "",
+          bundleDir: "fake",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("Required parameter 'CICS CSD Group' must not be blank");
+    });
+
+    it("should throw error if CICS Region name is missing", async () => {
+      try {
+        response = await defineBundle(dummySession, {
+          regionName: "",
+          name: "fake",
+          csdGroup: "fake",
+          bundleDir: "fake",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("Required parameter 'CICS Region name' must not be blank");
+    });
+
+    it("should throw error if CICS Bundle Dir is missing", async () => {
+      try {
+        response = await defineBundle(dummySession, {
+          regionName: "fake",
+          name: "fake",
+          csdGroup: "fake",
+          bundleDir: "",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("Expect Error: Required parameter 'CICS Bundle directory' must not be blank");
+    });
+  });
+
+  describe("success scenarios", () => {
+    const requestBody: any = {
+      request: {
+        create: {
+          parameter: {
+            $: {
+              name: "CSD",
+            },
+          },
+          attributes: {
+            $: {
+              name: bundle,
+              bundleDir,
+              csdgroup: group,
+            },
+          },
+        },
+      },
+    };
+
+    const defineSpy = jest.spyOn(CicsCmciRestClient, "postExpectParsedXml").mockResolvedValue(content);
+
+    beforeEach(() => {
+      response = undefined;
+      error = undefined;
+      defineSpy.mockClear();
+      defineSpy.mockResolvedValue(content);
+    });
+
+    it("should be able to define a bundle without cicsPlex specified", async () => {
+      endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" + CicsCmciConstants.CICS_DEFINITION_BUNDLE + "/" + region;
+
+      response = await defineBundle(dummySession, defineParms);
+
+      // expect(response.success).toBe(true);
+      expect(response).toContain(content);
+      expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+
+    it("should be able to define a bundle with cicsPlex specified but empty string", async () => {
+      defineParms.cicsPlex = "";
+      endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" + CicsCmciConstants.CICS_DEFINITION_BUNDLE + "//" + region;
+
+      response = await defineBundle(dummySession, defineParms);
+
+      // expect(response.success).toBe(true);
+      expect(response).toContain(content);
+      expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+
+    it("should be able to define a bundle with cicsPlex specified", async () => {
+      defineParms.cicsPlex = cicsPlex;
+      endPoint = "/" + CicsCmciConstants.CICS_SYSTEM_MANAGEMENT + "/" + CicsCmciConstants.CICS_DEFINITION_BUNDLE + "/" + cicsPlex + "/" + region;
+
+      response = await defineBundle(dummySession, defineParms);
+
+      // expect(response.success).toBe(true);
+      expect(response).toContain(content);
+      expect(defineSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+  });
+});

--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -64,6 +64,11 @@ export const CicsCmciConstants = {
   CICS_DEFINITION_WEBSERVICE: "CICSDefinitionWebService",
 
   /**
+   * Specifies the required part of the REST interface URI to access program definitions
+   */
+  CICS_DEFINITION_BUNDLE: "CICSDefinitionBundle",
+
+  /**
    * Specifies the required part of the REST interface URI to access tcp/ip service resources
    */
   CICS_TCPIPSERVICE_RESOURCE: "CICSTCPIPService",

--- a/packages/sdk/src/doc/IBundleParms.ts
+++ b/packages/sdk/src/doc/IBundleParms.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export interface IBundleParms {
+  /**
+   * The name of the bundle
+   * Up to eight characters long
+   */
+  name: string;
+
+  /**
+   * The bundle directory
+   * Up to 255 characters long, starting and ending with /
+   */
+  bundleDir: string;
+
+  /**
+   * CSD group for the bundle
+   * Up to eight characters long
+   */
+  csdGroup: string;
+
+  /**
+   * The name of the CICS region of the bundle
+   */
+  regionName: string;
+
+  /**
+   * CICS Plex of the bundle
+   */
+  cicsPlex?: string;
+}

--- a/packages/sdk/src/doc/index.ts
+++ b/packages/sdk/src/doc/index.ts
@@ -9,6 +9,8 @@
  *
  */
 
+export * from "./IBundleParms";
+export * from "./ICICSExtenderConfig";
 export * from "./ICMCIApiResponse";
 export * from "./ICMCIRequestOptions";
 export * from "./ICMCIResponseResultSummary";
@@ -22,4 +24,3 @@ export * from "./IResultCacheParms";
 export * from "./ITransactionParms";
 export * from "./IURIMapParms";
 export * from "./IWebServiceParms";
-export * from "./ICICSExtenderConfig";

--- a/packages/sdk/src/methods/define/Define.ts
+++ b/packages/sdk/src/methods/define/Define.ts
@@ -11,7 +11,7 @@
 
 import { AbstractSession, ImperativeExpect, Logger } from "@zowe/imperative";
 import { CicsCmciConstants } from "../../constants";
-import { ICMCIApiResponse, IGetResourceUriOptions, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms } from "../../doc";
+import { IBundleParms, ICMCIApiResponse, IGetResourceUriOptions, IProgramParms, ITransactionParms, IURIMapParms, IWebServiceParms } from "../../doc";
 import { CicsCmciRestClient } from "../../rest";
 import { Utils } from "../../utils";
 
@@ -325,5 +325,40 @@ export function defineWebservice(session: AbstractSession, parms: IWebServicePar
   };
 
   const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_WEBSERVICE, options);
+  return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
+}
+
+export function defineBundle(session: AbstractSession, parms: IBundleParms): Promise<ICMCIApiResponse> {
+  ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Bundle name", "CICS bundle name is required");
+  ImperativeExpect.toBeDefinedAndNonBlank(parms.bundleDir, "CICS Bundle directory", "CICS bundle directory is required");
+  ImperativeExpect.toBeDefinedAndNonBlank(parms.csdGroup, "CICS CSD Group", "CICS CSD group is required");
+  ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+  Logger.getAppLogger().debug("Attempting to define a bundle with the following parameters:\n%s", JSON.stringify(parms));
+  const requestBody: any = {
+    request: {
+      create: {
+        parameter: {
+          $: {
+            name: "CSD",
+          },
+        },
+        attributes: {
+          $: {
+            name: parms.name,
+            bundleDir: parms.bundleDir,
+            csdgroup: parms.csdGroup,
+          },
+        },
+      },
+    },
+  };
+
+  const options: IGetResourceUriOptions = {
+    cicsPlex: parms.cicsPlex,
+    regionName: parms.regionName,
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_DEFINITION_BUNDLE, options);
   return CicsCmciRestClient.postExpectParsedXml(session, cmciResource, [], requestBody) as any;
 }


### PR DESCRIPTION
**What It Does**
Resolves #72 
Adds `zowe cics define bundle` as CLI option with SDK method, as requested by the community.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)


