### PR TITLE
Initial command to launching resource inspector by resource name and resource type

### DIFF
--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -247,8 +247,12 @@
           "when": "never"
         },
         {
-           "command": "cics-extension-for-zowe.setFocusRegion",
-           "when": "config.zowe.cics.resourceInspector"
+          "command": "cics-extension-for-zowe.setFocusRegion",
+          "when": "config.zowe.cics.resourceInspector"
+        },
+        {
+          "command": "cics-extension-for-zowe.inspectResource",
+          "when": "never"
         }
       ],
       "view/title": [

--- a/packages/vsce/src/commands/index.ts
+++ b/packages/vsce/src/commands/index.ts
@@ -34,6 +34,7 @@ import * as showLogsCommands from "./showLogsCommand";
 import { getShowRegionSITParametersCommand } from "./showParameterCommand";
 import { viewMoreCommand } from "./viewMoreCommand";
 import { setFocusRegionCommand } from "./setFocusRegionCommand";
+import { getInspectResourceCommand } from "./inspectResourceCommand";
 
 export const getCommands = (treeDataProv: CICSTree, treeview: TreeView<any>, context: ExtensionContext) => {
   return [
@@ -56,6 +57,8 @@ export const getCommands = (treeDataProv: CICSTree, treeview: TreeView<any>, con
     getOpenLocalFileCommand(treeDataProv, treeview),
 
     getPurgeTaskCommand(treeDataProv, treeview),
+
+    getInspectResourceCommand(context),
 
     showLogsCommands.getShowRegionLogs(treeview),
     showAttributesCommands.getShowResourceAttributesCommand(treeview),

--- a/packages/vsce/src/commands/inspectResourceCommand.ts
+++ b/packages/vsce/src/commands/inspectResourceCommand.ts
@@ -1,0 +1,58 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { commands, ExtensionContext } from "vscode";
+import { ResourceInspectorViewProvider } from "../trees/ResourceInspectorViewProvider";
+import { getFocusRegion } from "./setFocusRegionCommand";
+import { IFocusRegion } from "./IFocusRegion";
+import { Resource, ResourceContainer } from "../resources";
+import { IResource, IResourceMeta } from "../doc";
+import { SupportedResources } from "../model";
+
+export function getInspectResourceCommand(context: ExtensionContext) {
+  return commands.registerCommand("cics-extension-for-zowe.inspectResource", async (resourceName: string, resourceType: string) => {
+    const focusRegion: IFocusRegion = await getFocusRegion();
+
+    if (focusRegion) {
+      const type = getResourceType(resourceType);
+      let resourceContainer = new ResourceContainer<IResource>(type);
+      resourceContainer.setCriteria([resourceName]);
+      const resources:[Resource<IResource>[], boolean] = await resourceContainer.loadResources(
+        focusRegion.session,
+        focusRegion.focusSelectedRegion,
+        focusRegion.cicsPlex,
+      );
+
+      const resourceViewProvider = ResourceInspectorViewProvider.getInstance(context.extensionUri);
+      const enbededWebview = resourceViewProvider?._manager?._view;
+
+      // Will only have one resource
+      const resource:Resource<IResource>[] = resources[0];
+      resourceViewProvider.reloadData( {
+            resource: resource[0],
+            meta: resourceContainer.getMeta(),
+          }, enbededWebview);
+
+      // Not sure why its vscode-extension-for-zowe
+      commands.executeCommand("setContext", "zowe.vscode-extension-for-zowe.showResourceInspector", true);
+      commands.executeCommand("workbench.view.extension.inspector-panel");
+    }
+  });
+
+  function getResourceType(resourceName: string): IResourceMeta<IResource> {
+    const types: IResourceMeta<IResource>[] = SupportedResources.metaResources.filter((value) => value.resourceName == resourceName);
+
+    // Should only have one
+    if (types.length > 0) {
+      return types[0];
+    }
+  }
+}

--- a/packages/vsce/src/commands/inspectResourceCommand.ts
+++ b/packages/vsce/src/commands/inspectResourceCommand.ts
@@ -23,7 +23,7 @@ export function getInspectResourceCommand(context: ExtensionContext) {
 
     if (focusRegion) {
       const type = getResourceType(resourceType);
-      let resourceContainer = new ResourceContainer<IResource>(type);
+      const resourceContainer = new ResourceContainer<IResource>(type);
       resourceContainer.setCriteria([resourceName]);
       const resources:[Resource<IResource>[], boolean] = await resourceContainer.loadResources(
         focusRegion.session,

--- a/packages/vsce/src/commands/inspectResourceCommand.ts
+++ b/packages/vsce/src/commands/inspectResourceCommand.ts
@@ -23,7 +23,7 @@ export function getInspectResourceCommand(context: ExtensionContext) {
   return commands.registerCommand("cics-extension-for-zowe.inspectResource", async (resourceName: string, resourceType: string) => {
     if (!await workspace.getConfiguration().get('zowe.cics.resourceInspector')) {
       return;
-    };
+    }
 
     const focusRegion: IFocusRegion = await getFocusRegion();
 

--- a/packages/vsce/src/commands/inspectResourceCommand.ts
+++ b/packages/vsce/src/commands/inspectResourceCommand.ts
@@ -65,7 +65,7 @@ export function getInspectResourceCommand(context: ExtensionContext) {
     const types: IResourceMeta<IResource>[] = SupportedResources.metaResources.filter((value) => value.resourceName == resourceName);
 
     // Should only have one
-    if (types && types.length > 0) {
+    if (types?.length > 0) {
       return types[0];
     }
     return undefined;

--- a/packages/vsce/src/commands/inspectResourceCommand.ts
+++ b/packages/vsce/src/commands/inspectResourceCommand.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { commands, ExtensionContext, window } from "vscode";
+import { commands, ExtensionContext, window, workspace } from "vscode";
 import { ResourceInspectorViewProvider } from "../trees/ResourceInspectorViewProvider";
 import { getFocusRegion } from "./setFocusRegionCommand";
 import { IFocusRegion } from "./IFocusRegion";
@@ -21,6 +21,10 @@ import { CICSMessages } from "../constants/CICS.messages";
 
 export function getInspectResourceCommand(context: ExtensionContext) {
   return commands.registerCommand("cics-extension-for-zowe.inspectResource", async (resourceName: string, resourceType: string) => {
+    if (!await workspace.getConfiguration().get('zowe.cics.resourceInspector')) {
+      return;
+    };
+
     const focusRegion: IFocusRegion = await getFocusRegion();
 
     if (focusRegion) {

--- a/packages/vsce/src/commands/resourceInspectorViewCommand.ts
+++ b/packages/vsce/src/commands/resourceInspectorViewCommand.ts
@@ -22,13 +22,13 @@ export function getResourceInspectorCommand(context: ExtensionContext, treeview:
       await window.showErrorMessage("No CICS resource selected");
       return;
     }
-    getResourceViewProvider(nodes, context.extensionUri, treeview);
+    getResourceViewProvider(nodes, context.extensionUri);
   });
 }
 
-function getResourceViewProvider(selectedNodes: CICSResourceContainerNode<IResource>[], extensionUri: Uri, treeview: TreeView<any>) {
+function getResourceViewProvider(selectedNodes: CICSResourceContainerNode<IResource>[], extensionUri: Uri) {
   for (const item of selectedNodes) {
-    const resourceViewProvider = ResourceInspectorViewProvider.getInstance(extensionUri, treeview);
+    const resourceViewProvider = ResourceInspectorViewProvider.getInstance(extensionUri);
     const enbededWebview = resourceViewProvider?._manager?._view;
     resourceViewProvider.reloadData(item.getContainedResource(), enbededWebview);
   }

--- a/packages/vsce/src/constants/CICS.messages.ts
+++ b/packages/vsce/src/constants/CICS.messages.ts
@@ -32,4 +32,8 @@ export const CICSMessages: { [key: string]: IMessageDefinition; } = {
   loadingResources: {
     message: "Loading resources...",
   },
+
+  CICSResourceTypeNotFound: {
+    message: "CICS resource type not found or unsupported.",
+  },
 };

--- a/packages/vsce/src/extending/CICSExtenderApiConfig.ts
+++ b/packages/vsce/src/extending/CICSExtenderApiConfig.ts
@@ -10,6 +10,7 @@
  */
 
 import { CicsCmciConstants, ICICSExtenderConfig } from "@zowe/cics-for-zowe-sdk";
+import { SupportedResources } from "../model";
 
 export class CICSExtenderApiConfig {
   private static api: CICSExtenderApiConfig = new CICSExtenderApiConfig();
@@ -22,17 +23,7 @@ export class CICSExtenderApiConfig {
   private constructor() {
     this.config = {
       configuration: {
-        supportedResources: [
-            CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
-            CicsCmciConstants.CICS_PROGRAM_RESOURCE,
-            CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
-            CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE,
-            CicsCmciConstants.CICS_LIBRARY_RESOURCE,
-            CicsCmciConstants.CICS_URIMAP,
-            CicsCmciConstants.CICS_CMCI_TASK,
-            CicsCmciConstants.CICS_CMCI_PIPELINE,
-            CicsCmciConstants.CICS_CMCI_WEB_SERVICE,
-        ],
+        supportedResources: SupportedResources.resources,
         resourceInspector: {
           enabled: false
         }

--- a/packages/vsce/src/extension.ts
+++ b/packages/vsce/src/extension.ts
@@ -121,7 +121,7 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(
     window.registerWebviewViewProvider(
       ResourceInspectorViewProvider.viewType,
-      ResourceInspectorViewProvider.getInstance(context.extensionUri, treeview)
+      ResourceInspectorViewProvider.getInstance(context.extensionUri)
     )
   );
 

--- a/packages/vsce/src/model/SupportedResources.ts
+++ b/packages/vsce/src/model/SupportedResources.ts
@@ -1,0 +1,40 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
+import *  as ResourceTypes from "../doc/meta";
+
+export const SupportedResources = {
+    resources: [
+      CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
+      CicsCmciConstants.CICS_PROGRAM_RESOURCE,
+      CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
+      CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE,
+      CicsCmciConstants.CICS_LIBRARY_RESOURCE,
+      CicsCmciConstants.CICS_URIMAP,
+      CicsCmciConstants.CICS_CMCI_TASK,
+      CicsCmciConstants.CICS_CMCI_PIPELINE,
+      CicsCmciConstants.CICS_CMCI_WEB_SERVICE,
+    ],
+
+    metaResources: [
+      ResourceTypes.LocalFileMeta,
+      ResourceTypes.ProgramMeta,
+      ResourceTypes.TransactionMeta,
+      ResourceTypes.TCPIPMeta,
+      ResourceTypes.LibraryMeta,
+      ResourceTypes.URIMapMeta,
+      ResourceTypes.TaskMeta,
+      ResourceTypes.PipelineMeta,
+      ResourceTypes.WebServiceMeta
+    ],
+
+}

--- a/packages/vsce/src/model/index.ts
+++ b/packages/vsce/src/model/index.ts
@@ -1,0 +1,12 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export * from "./SupportedResources";

--- a/packages/vsce/src/trees/ResourceInspectorViewProvider.ts
+++ b/packages/vsce/src/trees/ResourceInspectorViewProvider.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { WebviewViewProvider, Uri, TreeView, WebviewView } from "vscode";
+import { WebviewViewProvider, Uri, WebviewView } from "vscode";
 import { ResourceInspectorView } from "./ResourceInspectorView";
 import { IContainedResource, IResource } from "../doc";
 
@@ -20,13 +20,12 @@ export class ResourceInspectorViewProvider implements WebviewViewProvider {
   private static refreshed = false;
 
   constructor(
-    private readonly extensionUri: Uri,
-    private readonly treeview: TreeView<any>
+    private readonly extensionUri: Uri
   ) { }
 
-  public static getInstance(extensionUri: Uri, treeview: TreeView<any>): ResourceInspectorViewProvider {
+  public static getInstance(extensionUri: Uri): ResourceInspectorViewProvider {
     if (!this.instance) {
-      this.instance = new ResourceInspectorViewProvider(extensionUri, treeview);
+      this.instance = new ResourceInspectorViewProvider(extensionUri);
     }
 
     return this.instance;


### PR DESCRIPTION
**What It Does**
This is a command to launch resource inspector by just providing the name of the resource and the type, although currently this is set to hidden.

**How to Test**
Manually tested to make sure this integration point works.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
