### PR TITLE
Command Palette support for RI

### DIFF
--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -238,13 +238,18 @@
           "light": "resources/imgs/toggle-resources-dark.svg",
           "dark": "resources/imgs/toggle-resources-light.svg"
         }
+      },
+      {
+        "command": "cics-extension-for-zowe.inspectResource",
+        "title": "Invoke Resource Inspector",
+        "category": "IBM CICS for Zowe Explorer"
       }
     ],
     "menus": {
       "commandPalette": [
         {
           "command": "cics-extension-for-zowe.inspectTreeResource",
-          "when": "never"
+          "when": "config.zowe.cics.resourceInspector"
         },
         {
           "command": "cics-extension-for-zowe.setFocusRegion",

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -241,7 +241,7 @@
       },
       {
         "command": "cics-extension-for-zowe.inspectResource",
-        "title": "Invoke Resource Inspector",
+        "title": "Inspect Resource",
         "category": "IBM CICS for Zowe Explorer"
       }
     ],

--- a/packages/vsce/src/commands/resourceInspectorViewCommand.ts
+++ b/packages/vsce/src/commands/resourceInspectorViewCommand.ts
@@ -17,7 +17,17 @@ import { findSelectedNodes } from "../utils/commandUtils";
 
 export function getResourceInspectorCommand(context: ExtensionContext, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.inspectTreeResource", async (node: CICSResourceContainerNode<IResource>) => {
-    const nodes = findSelectedNodes(treeview, node.getContainedResource().meta, node);
+    let meta;
+    if (node === undefined || node === null) {
+      for (const res of [...new Set([...treeview.selection, node])].filter(
+        (item) => item instanceof CICSResourceContainerNode && item.getContainedResource()?.resource
+      )) {
+        meta = res.getContainedResource().meta;
+      }
+    } else {
+      meta = node.getContainedResource().meta;
+    }
+    const nodes = findSelectedNodes(treeview, meta, node);
     if (!nodes || !nodes.length) {
       await window.showErrorMessage("No CICS resource selected");
       return;

--- a/packages/vsce/src/commands/resourceInspectorViewCommand.ts
+++ b/packages/vsce/src/commands/resourceInspectorViewCommand.ts
@@ -18,21 +18,27 @@ import { findSelectedNodes } from "../utils/commandUtils";
 export function getResourceInspectorCommand(context: ExtensionContext, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.inspectTreeResource", async (node: CICSResourceContainerNode<IResource>) => {
     let meta;
+    const treeSelectionArray = [...new Set([...treeview.selection])];
     if (!node) {
-      for (const res of [...new Set([...treeview.selection])].filter(
-        (item) => item instanceof CICSResourceContainerNode && item.getContainedResource()?.resource
-      )) {
+      for (const res of treeSelectionArray.filter((item) => item instanceof CICSResourceContainerNode && item.getContainedResource()?.resource)) {
         meta = res.getContainedResource().meta;
       }
     } else {
       meta = node.getContainedResource().meta;
     }
     const nodes = findSelectedNodes(treeview, meta, node);
-    if (!nodes || !nodes.length) {
+    if (!nodes || !nodes.length || treeSelectionArray.length === 0) {
       await window.showErrorMessage("No CICS resource selected");
       return;
     }
     getResourceViewProvider(nodes, context.extensionUri);
+    if (treeSelectionArray.length > 1) {
+      await window.showInformationMessage(
+        "Multiple CICS resources selected. Resource with label '" +
+          treeSelectionArray[treeSelectionArray.length - 1].getLabel() +
+          "' will be inspected."
+      );
+    }
   });
 }
 

--- a/packages/vsce/src/commands/resourceInspectorViewCommand.ts
+++ b/packages/vsce/src/commands/resourceInspectorViewCommand.ts
@@ -34,9 +34,7 @@ export function getResourceInspectorCommand(context: ExtensionContext, treeview:
     getResourceViewProvider(nodes, context.extensionUri);
     if (treeSelectionArray.length > 1) {
       await window.showInformationMessage(
-        "Multiple CICS resources selected. Resource with label '" +
-          treeSelectionArray[treeSelectionArray.length - 1].getLabel() +
-          "' will be inspected."
+        "Multiple CICS resources selected. Resource '" + treeSelectionArray[treeSelectionArray.length - 1].getLabel() + "' will be inspected."
       );
     }
   });

--- a/packages/vsce/src/commands/resourceInspectorViewCommand.ts
+++ b/packages/vsce/src/commands/resourceInspectorViewCommand.ts
@@ -19,7 +19,7 @@ export function getResourceInspectorCommand(context: ExtensionContext, treeview:
   return commands.registerCommand("cics-extension-for-zowe.inspectTreeResource", async (node: CICSResourceContainerNode<IResource>) => {
     let meta;
     if (!node) {
-      for (const res of [...new Set([...treeview.selection, node])].filter(
+      for (const res of [...new Set([...treeview.selection])].filter(
         (item) => item instanceof CICSResourceContainerNode && item.getContainedResource()?.resource
       )) {
         meta = res.getContainedResource().meta;

--- a/packages/vsce/src/commands/resourceInspectorViewCommand.ts
+++ b/packages/vsce/src/commands/resourceInspectorViewCommand.ts
@@ -18,7 +18,7 @@ import { findSelectedNodes } from "../utils/commandUtils";
 export function getResourceInspectorCommand(context: ExtensionContext, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.inspectTreeResource", async (node: CICSResourceContainerNode<IResource>) => {
     let meta;
-    if (node === undefined || node === null) {
+    if (!node) {
       for (const res of [...new Set([...treeview.selection, node])].filter(
         (item) => item instanceof CICSResourceContainerNode && item.getContainedResource()?.resource
       )) {


### PR DESCRIPTION
**What It Does**

- Instills Command palette support Resource Inspector
- Declares a command before using it : `cics-extension-for-zowe.inspectResource`
