### PR TITLE
Fix inconsistent optional chaining and update dependencies (v2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
         "@zowe/cli-test-utils": "^7.27.0",
-        "@zowe/imperative": "^5.27.9",
+        "@zowe/imperative": "^5.27.8",
         "@zowe/zowe-explorer-api": "^2.18.1",
         "chalk": "^4.1.2",
         "eslint": "^8.37.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
         "@zowe/cli-test-utils": "^7.27.0",
-        "@zowe/imperative": "^5.27.8",
+        "@zowe/imperative": "^5.27.9",
         "@zowe/zowe-explorer-api": "^2.18.1",
         "chalk": "^4.1.2",
         "eslint": "^8.37.0",
@@ -1334,9 +1334,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1384,9 +1384,9 @@
       }
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1844,9 +1844,9 @@
       }
     },
     "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3716,9 +3716,9 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3806,23 +3806,23 @@
       "link": true
     },
     "node_modules/@zowe/cli": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/cli/-/@zowe/cli-7.29.10.tgz",
-      "integrity": "sha512-NvQXyPYDRAKDjhYnTRKp6KeVyM1Ag4o01t0h0DJFMAtlxHhZsmnsxiw7KKImaKtiwJpLwd3vFxvyDIqHvRvSGg==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/cli/-/@zowe/cli-7.29.14.tgz",
+      "integrity": "sha512-/Qo+rtfq9CrIYQD+tGlkIA4nqMbGs6nYzoGH4KiW8QfV/Reph2t4sKk+qI6RlaSDgfGk4W84mPfz/DulG4Uyzg==",
       "hasInstallScript": true,
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/core-for-zowe-sdk": "7.29.10",
-        "@zowe/imperative": "5.27.7",
-        "@zowe/provisioning-for-zowe-sdk": "7.29.10",
-        "@zowe/zos-console-for-zowe-sdk": "7.29.10",
-        "@zowe/zos-files-for-zowe-sdk": "7.29.10",
-        "@zowe/zos-jobs-for-zowe-sdk": "7.29.10",
-        "@zowe/zos-logs-for-zowe-sdk": "7.29.10",
-        "@zowe/zos-tso-for-zowe-sdk": "7.29.10",
-        "@zowe/zos-uss-for-zowe-sdk": "7.29.10",
-        "@zowe/zos-workflows-for-zowe-sdk": "7.29.10",
-        "@zowe/zosmf-for-zowe-sdk": "7.29.10",
+        "@zowe/core-for-zowe-sdk": "7.29.14",
+        "@zowe/imperative": "5.27.9",
+        "@zowe/provisioning-for-zowe-sdk": "7.29.14",
+        "@zowe/zos-console-for-zowe-sdk": "7.29.14",
+        "@zowe/zos-files-for-zowe-sdk": "7.29.14",
+        "@zowe/zos-jobs-for-zowe-sdk": "7.29.14",
+        "@zowe/zos-logs-for-zowe-sdk": "7.29.14",
+        "@zowe/zos-tso-for-zowe-sdk": "7.29.14",
+        "@zowe/zos-uss-for-zowe-sdk": "7.29.14",
+        "@zowe/zos-workflows-for-zowe-sdk": "7.29.14",
+        "@zowe/zosmf-for-zowe-sdk": "7.29.14",
         "find-process": "1.4.7",
         "get-stream": "6.0.1",
         "lodash": "4.17.21",
@@ -3841,9 +3841,9 @@
       }
     },
     "node_modules/@zowe/cli-test-utils": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/cli-test-utils/-/@zowe/cli-test-utils-7.29.10.tgz",
-      "integrity": "sha512-7q+1VDpp1KBm/2SUBsURWMCJn5G/RX1p1Skp0w68kc/+M/Rxf/s1EclLDt8qNlPpdClKhmzuC5O5fiy53InXuw==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/cli-test-utils/-/@zowe/cli-test-utils-7.29.14.tgz",
+      "integrity": "sha512-l7W8ixZkFRqzE9XDecV5AI9M1qe226YslTq00ybdF43TLKmwq4hD4f7vaw1nQt6g/E+I88ckg8ndm7bj6JxerA==",
       "dev": true,
       "license": "EPL-2.0",
       "dependencies": {
@@ -3857,9 +3857,9 @@
       }
     },
     "node_modules/@zowe/cli-test-utils/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3929,224 +3929,10 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@zowe/cli/node_modules/@types/yargs": {
-      "version": "13.0.4",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.4.tgz",
-      "integrity": "sha512-Ke1WmBbIkVM8bpvsNEcGgQM70XcEh/nbpxQhW7FhrsbCsXSY9BmLB1+LHtD7r9zrsOcFlLiF+a/UeJsdfw3C5A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/@zowe/imperative": {
-      "version": "5.27.7",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-5.27.7.tgz",
-      "integrity": "sha512-WWtdvlMy3isk2EP/NNXC/7cZAQKPI4XtMWYszkIygud7wlH42VftZo07Vh9JoNXFaFfCYGwoGW7iPl8zhWprAA==",
-      "license": "EPL-2.0",
-      "dependencies": {
-        "@types/yargs": "13.0.4",
-        "chalk": "2.4.2",
-        "cli-table3": "0.6.2",
-        "comment-json": "4.1.1",
-        "cross-spawn": "7.0.6",
-        "dataobject-parser": "1.2.25",
-        "deepmerge": "4.2.2",
-        "diff": "5.1.0",
-        "diff2html": "3.4.20-usewontache.1.60e7a2e",
-        "fast-glob": "3.2.7",
-        "fastest-levenshtein": "1.0.12",
-        "find-up": "4.1.0",
-        "fs-extra": "9.1.0",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.4",
-        "jest-diff": "27.0.6",
-        "js-yaml": "4.1.0",
-        "jsonfile": "6.1.0",
-        "jsonschema": "1.4.1",
-        "lodash": "4.17.21",
-        "lodash-deep": "2.0.0",
-        "log4js": "6.4.6",
-        "markdown-it": "14.1.0",
-        "mustache": "4.2.0",
-        "npm-package-arg": "9.1.0",
-        "opener": "1.5.2",
-        "pacote": "17.0.6",
-        "prettyjson": "1.2.2",
-        "progress": "2.0.3",
-        "read": "1.0.7",
-        "readline-sync": "1.4.10",
-        "semver": "7.5.4",
-        "stack-trace": "0.0.10",
-        "strip-ansi": "6.0.1",
-        "which": "4.0.0",
-        "wrap-ansi": "7.0.0",
-        "yamljs": "0.3.0",
-        "yargs": "15.3.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "license": "MIT"
-    },
-    "node_modules/@zowe/cli/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@zowe/cli/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
     "node_modules/@zowe/core-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/core-for-zowe-sdk/-/@zowe/core-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-9IwgCQ5AY4rX4lrP1dDaBGmd++vyVJ9T5zZ3QvxpZAAzJQ9vGHubu653m09A8I2DJsoEPSH5/88oIHGu+oK5IQ==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/core-for-zowe-sdk/-/@zowe/core-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-/gSNM3HnEP8lGwFB642oalCnUb91DoN3O9DYehxkS79wc8O65P0wQEyH66ov3SCszUG2SWvTeqpWdHXTiskbqQ==",
       "license": "EPL-2.0",
       "dependencies": {
         "comment-json": "4.1.1",
@@ -4157,9 +3943,9 @@
       }
     },
     "node_modules/@zowe/imperative": {
-      "version": "5.27.8",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-5.27.8.tgz",
-      "integrity": "sha512-C0fCysi/yBNDI7PeeXv7Cu/PqNEjHZISyuzm5wW546fWTwVr3A7VISBjsOXJh/8APMDRHXoC0JnCB8Gqu4PhtA==",
+      "version": "5.27.9",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-5.27.9.tgz",
+      "integrity": "sha512-/1dHnEINoW0Ej6ttmWFOQKHuSse8qsEUtHcbrD40RGrSOSTFuK1NtlZ+E/EICKxDQzEyX34SUcRBkI/g2XvYxg==",
       "license": "EPL-2.0",
       "dependencies": {
         "@types/yargs": "13.0.4",
@@ -4371,9 +4157,9 @@
       "license": "ISC"
     },
     "node_modules/@zowe/provisioning-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/provisioning-for-zowe-sdk/-/@zowe/provisioning-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-lbgjTIIUD3eDSVPrlWkbFWOTfYhbsR7JfhP34QRa7tOIpeRfU8WLyrUFN57gE/quKtzweBey5Ftr3XoHwANGRA==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/provisioning-for-zowe-sdk/-/@zowe/provisioning-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-26rKukgYW2MSV/7IE5x44xagCW76Q9R2qYgVSXO7IX/HhwX4nlAJRbi2CylXenyuIC1MIfXNm9MJzkx9hwTkUg==",
       "license": "EPL-2.0",
       "dependencies": {
         "js-yaml": "4.1.0"
@@ -4394,9 +4180,9 @@
       }
     },
     "node_modules/@zowe/zos-console-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-5KGRm0Qtl47g5oZLI7BsIb1n6KI3MneNdXhN0T5F/Q19Hdwiu18B0o2AFrSbhGR+GqUfkeRgeP/wroo9N0OHRQ==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-NiLK8A2/1iey8AMNIS8uEfT2Q56r9XZxEbmOQ/GavFc+nNC5m0E9avzM88mj5ONVgqkl9uEeOu/vdcLmvZ5pNA==",
       "license": "EPL-2.0",
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": "^7.0.0",
@@ -4404,9 +4190,9 @@
       }
     },
     "node_modules/@zowe/zos-files-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-files-for-zowe-sdk/-/@zowe/zos-files-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-Q/T7/cNNGOyXFrpIHw34fJHad7aXmz+KlFrUdnMl3AdyD48adYfao66Z9O96YgaEVvmiN0cqB3f1JkBU3wVDjg==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-files-for-zowe-sdk/-/@zowe/zos-files-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-VePCwgIyTaZBaamJPRPubhucYNtu7xKLwYlnEyiLAJCokbRpWkuyqyAC0TIKJWEG++4HeUj2ofzcHJg2HRhrXA==",
       "license": "EPL-2.0",
       "dependencies": {
         "minimatch": "5.0.1"
@@ -4417,12 +4203,12 @@
       }
     },
     "node_modules/@zowe/zos-jobs-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-jobs-for-zowe-sdk/-/@zowe/zos-jobs-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-GC8o9+LDqDXoVt4JIqhs44laJJp8Zo6Id3g624HzeBBkCN34pvmN7XU5+o9UpGJ3tJRkLJYWIyOCzCR5DfJidg==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-jobs-for-zowe-sdk/-/@zowe/zos-jobs-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-9Hfsfi41YJ0r/rBWjPvwwt96stSOfmc1ceY6aePbGS0zj55hoVuldD+0kn6aVFko1gpjbFmOe499ZCpzcSwh1w==",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "7.29.10"
+        "@zowe/zos-files-for-zowe-sdk": "7.29.14"
       },
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": "^7.0.0",
@@ -4430,9 +4216,9 @@
       }
     },
     "node_modules/@zowe/zos-logs-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-logs-for-zowe-sdk/-/@zowe/zos-logs-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-lOIcAJBt1L3oIgICwzCWXc8FE5Cyu3sRic2fnraBSgXBGdFX5HZe2jfWG8lQ/BmVl6vuQB9MinQuEXRai2VAQw==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-logs-for-zowe-sdk/-/@zowe/zos-logs-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-g5eHOiEGhHsBFhG+PdwOOqo4bDqDa1TQAKhyMpuwKXchaRo+E/ENfDNMIrs8hsyRtAJLfFJYNfPs6a9/+TpJvg==",
       "license": "EPL-2.0",
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": "^7.0.0",
@@ -4440,12 +4226,12 @@
       }
     },
     "node_modules/@zowe/zos-tso-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-tso-for-zowe-sdk/-/@zowe/zos-tso-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-4TFek+IAmIH9m0lHjqdonzX5mosCDcOzyYsuFy3p9YZeEoQ8rbcMxjewOi2T93ahsXz4BRoae16mNpgYi8E6Vw==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-tso-for-zowe-sdk/-/@zowe/zos-tso-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-eyINvvLP3yN1WcQ/kpJgSNUD1M6gu7BsGfqykCT3AL9vUnG+X4s16GnRnNfgVMjPzghKsnGTsPtECFEgiudzCw==",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zosmf-for-zowe-sdk": "7.29.10"
+        "@zowe/zosmf-for-zowe-sdk": "7.29.14"
       },
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": "^7.0.0",
@@ -4453,9 +4239,9 @@
       }
     },
     "node_modules/@zowe/zos-uss-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-uss-for-zowe-sdk/-/@zowe/zos-uss-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-xJHA0KZYAIMkDIFMk/tzYsTTMKCdxlSmszTu2J9LkBQpXdUtgVwupGuAIKWnSbtxeXSS3MFFJPfmIAHcFgFSMQ==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-uss-for-zowe-sdk/-/@zowe/zos-uss-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-VEx+78p8AbP17/XbaYrlLcX6+aMY2qZLua2eQzYUYsdPd6PceKAQcV5q+cYS+TJi3QDdygam2xytRpdvQNQOwQ==",
       "license": "EPL-2.0",
       "dependencies": {
         "ssh2": "1.15.0"
@@ -4465,12 +4251,12 @@
       }
     },
     "node_modules/@zowe/zos-workflows-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-workflows-for-zowe-sdk/-/@zowe/zos-workflows-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-zsAcmk7EWxuev67P14DDzAUJPnpfBlBw43KlKw3NryTdrzwLD+i4xhmxntCWG3Wd7JzjGL6slnJ1um3maN98/g==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-workflows-for-zowe-sdk/-/@zowe/zos-workflows-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-ZfUhUSkXie1a4c4ktthGmAA6AgWU4HEAUkcSDh9KHhQ9kyL5Qj+KnbaVYq2bgyyTP9xjU2pD9U5wzVQQDg2sWw==",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/zos-files-for-zowe-sdk": "7.29.10"
+        "@zowe/zos-files-for-zowe-sdk": "7.29.14"
       },
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": "^7.0.0",
@@ -4478,9 +4264,9 @@
       }
     },
     "node_modules/@zowe/zosmf-for-zowe-sdk": {
-      "version": "7.29.10",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zosmf-for-zowe-sdk/-/@zowe/zosmf-for-zowe-sdk-7.29.10.tgz",
-      "integrity": "sha512-nyEI1r7vKyuvHLfXDateVddQYeHzmH2ODGY3L5ad4+H/xwBVFc4m8cXQXHsNaqBhcdA0DKW5ly1gXgQasQRQ0A==",
+      "version": "7.29.14",
+      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zosmf-for-zowe-sdk/-/@zowe/zosmf-for-zowe-sdk-7.29.14.tgz",
+      "integrity": "sha512-SEWMcD7AxOKBbubapfJNzGuL7CsPlzypKgyJDuCHVxr160zU+ljIii8kUP3hQuV8jQaxpBhYi++83H0VupOxZw==",
       "license": "EPL-2.0",
       "peerDependencies": {
         "@zowe/core-for-zowe-sdk": "^7.0.0",
@@ -4990,9 +4776,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -5638,6 +5424,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/consola": {
@@ -6901,9 +6688,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7383,9 +7170,9 @@
       }
     },
     "node_modules/flat-cache/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8203,6 +7990,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -8213,6 +8001,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -8573,9 +8362,9 @@
       }
     },
     "node_modules/jake/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8795,9 +8584,9 @@
       }
     },
     "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9257,9 +9046,9 @@
       }
     },
     "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10596,9 +10385,9 @@
       }
     },
     "node_modules/module-lookup-amd/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10691,9 +10480,9 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
-      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "version": "2.22.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.2.tgz",
+      "integrity": "sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==",
       "license": "MIT",
       "optional": true
     },
@@ -11153,6 +10942,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -11567,6 +11357,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -14243,9 +14034,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15293,6 +15084,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
@@ -15381,47 +15173,46 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/yamljs/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/yamljs/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/yamljs/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/yamljs/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yamljs/node_modules/sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "overrides": {
     "esbuild": "^0.25.0",
-    "@zowe/cli": "^7.29.14",
     "yamljs": {
       "glob": "^9.0.0"
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,11 @@
     "license": "node scripts/updateLicenses.js"
   },
   "overrides": {
-    "esbuild": "^0.25.0"
+    "esbuild": "^0.25.0",
+    "@zowe/cli": "^7.29.14",
+    "yamljs": {
+      "glob": "^9.0.0"
+    }
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",
@@ -35,7 +39,7 @@
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "@zowe/cli-test-utils": "^7.27.0",
-    "@zowe/imperative": "^5.27.8",
+    "@zowe/imperative": "^5.27.9",
     "@zowe/zowe-explorer-api": "^2.18.1",
     "chalk": "^4.1.2",
     "eslint": "^8.37.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "@zowe/cli-test-utils": "^7.27.0",
-    "@zowe/imperative": "^5.27.9",
+    "@zowe/imperative": "^5.27.8",
     "@zowe/zowe-explorer-api": "^2.18.1",
     "chalk": "^4.1.2",
     "eslint": "^8.37.0",

--- a/packages/vsce/src/utils/profileManagement.ts
+++ b/packages/vsce/src/utils/profileManagement.ts
@@ -145,7 +145,7 @@ export class ProfileManagement {
           name: "CICSRegion",
           regionName: profile.profile.regionName,
         });
-        if (singleRegionJson.response.records.cicsregion) {
+        if (singleRegionJson.response.records?.cicsregion) {
           infoLoaded.push({
             plexname: null,
             regions: [singleRegionJson.response.records?.cicsregion],


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
- Updates the `brace-expansion` dependency in package-lock
- Updates the `glob` dependency to not depend on vulnerable package `inflight` in `yamljs`
- Fixes inconsistent use of optional chaining identified by a SAST tool

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>Signed-off-by: Andrew W. Harn <andrew.harn@broadcom.com>