### PR TITLE
Fix All tree command bugs, show library across regions

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 
 ## Recent Changes
 
-- Enhancement: Removed most of the existing command palette entries for CICS where they're unhelpful  [#285] (https://github.com/zowe/cics-for-zowe-client/issues/285)
+- Enhancement: Removed most of the existing command palette entries for CICS where they're unhelpful  [#285](https://github.com/zowe/cics-for-zowe-client/issues/285)
 - Enhancement: Navigate from a program to the library from which it was loaded. [#292](https://github.com/zowe/cics-for-zowe-client/issues/292)
 - Enhancement: Added pagination to all resource trees. [#302](https://github.com/zowe/cics-for-zowe-client/issues/302)
-- Reduce default number of records returned in combined trees from 500 to 100. [#302](https://github.com/zowe/cics-for-zowe-client/issues/302)
+- Reduce default number of records returned in combined trees from 500 to 250. [#302](https://github.com/zowe/cics-for-zowe-client/issues/302)
 - Enhancement: Arranged resource context menu items into groups. [#307](https://github.com/zowe/cics-for-zowe-client/issues/307)
-- Enhancement: Added Enable/Disable Library feature to all library resources [#43] (https://github.com/zowe/cics-for-zowe-client/issues/43)
+- Enhancement: Added Enable/Disable Library feature to all library resources [#43](https://github.com/zowe/cics-for-zowe-client/issues/43)
 
 ## `3.8.0`
 

--- a/packages/vsce/__tests__/__e2e__/05_ShowLibraryFromSingleProgramHavingNoDataSet.test.ts
+++ b/packages/vsce/__tests__/__e2e__/05_ShowLibraryFromSingleProgramHavingNoDataSet.test.ts
@@ -76,7 +76,7 @@ describe("Show Library Action on Program without LIBDSNAME", () => {
 
   it("Check the attributes of PLIB2NONE", async () => {
     await PLIB2NONEPROGRAM?.click();
-    await runCommandFromCommandPalette(">IBM CICS for Zowe Explorer: Show Attributes cics-extension-for-zowe.showPrgramAttributes");
+    await runCommandFromCommandPalette(">IBM CICS for Zowe Explorer: Show Attributes cics-extension-for-zowe.showResourceAttributes");
     await verifyProgramAttributes(PLIB2NONE, {
       Program: PLIB2NONE,
       Library: LIB2,

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -251,7 +251,7 @@
       },
       {
         "command": "cics-extension-for-zowe.inspectResource",
-        "title": "Inspect Resource",
+        "title": "Inspect CICS Resource",
         "category": "IBM CICS for Zowe Explorer"
       }
     ],
@@ -267,7 +267,7 @@
         },
         {
           "command": "cics-extension-for-zowe.inspectResource",
-          "when": "config.zowe.cics.resourceInspector"
+          "when": "config.zowe.cics.resourceInspector && !config.zowe.cics.showAllCommandsInPalette"
         },
         {
           "command": "cics-extension-for-zowe.purgeTask",
@@ -352,7 +352,6 @@
         {
           "command": "cics-extension-for-zowe.enableLibrary",
           "when": "config.zowe.cics.showAllCommandsInPalette"
-
         },
         {
           "command": "cics-extension-for-zowe.manageSession",

--- a/packages/vsce/src/commands/closeLocalFileCommand.ts
+++ b/packages/vsce/src/commands/closeLocalFileCommand.ts
@@ -57,7 +57,7 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
               node.getSession(),
               {
                 name: node.getContainedResourceName(),
-                regionName: node.regionName,
+                regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
                 cicsPlex: node.cicsplexName,
               },
               busyDecision

--- a/packages/vsce/src/commands/disableCommands/disableLibraryCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableLibraryCommand.ts
@@ -40,7 +40,7 @@ export function getDisableLibraryCommand(tree: CICSTree, treeview: TreeView<any>
         cancellable: false,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {});
+        token.onCancellationRequested(() => { });
 
         for (const node of nodes) {
           progress.report({
@@ -52,7 +52,7 @@ export function getDisableLibraryCommand(tree: CICSTree, treeview: TreeView<any>
             await disableLibrary(node.getSession(), {
               name: node.getContainedResourceName(),
               cicsPlex: node.cicsplexName,
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
             });
           } catch (error) {
             const message = `Something went wrong while disabling library ${node.getContainedResourceName()}\n\n${JSON.stringify(

--- a/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
@@ -60,7 +60,7 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<CI
               {
                 name: node.getContainedResourceName(),
                 cicsPlex: node.cicsplexName,
-                regionName: node.regionName,
+                regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
               },
               busyDecision
             );

--- a/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
@@ -51,7 +51,7 @@ export function getDisableProgramCommand(tree: CICSTree, treeview: TreeView<any>
             await disableProgram(node.getSession(), {
               name: node.getContainedResourceName(),
               cicsPlex: node.cicsplexName,
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
             });
           } catch (error) {
             window.showErrorMessage(

--- a/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
@@ -46,7 +46,7 @@ export function getDisableTransactionCommand(tree: CICSTree, treeview: TreeView<
             await disableTransaction(node.getSession(), {
               name: node.getContainedResourceName(),
               cicsPlex: node.cicsplexName,
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
             });
           } catch (error) {
             if (error.mMessage) {

--- a/packages/vsce/src/commands/enableCommands/enableLibraryCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableLibraryCommand.ts
@@ -40,7 +40,7 @@ export function getEnableLibraryCommand(tree: CICSTree, treeview: TreeView<any>)
         cancellable: true,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {});
+        token.onCancellationRequested(() => { });
 
         for (const node of nodes) {
           progress.report({
@@ -51,7 +51,7 @@ export function getEnableLibraryCommand(tree: CICSTree, treeview: TreeView<any>)
           try {
             await enableLibrary(node.getSession(), {
               name: node.getContainedResourceName(),
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
               cicsPlex: node.cicsplexName,
             });
           } catch (error) {

--- a/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
@@ -36,7 +36,7 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<CIC
         cancellable: false,
       },
       async (progress, token) => {
-        token.onCancellationRequested(() => {});
+        token.onCancellationRequested(() => { });
 
         for (const node of nodes) {
           progress.report({
@@ -48,7 +48,7 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<CIC
             await enableLocalFile(node.getSession(), {
               name: node.getContainedResourceName(),
               cicsPlex: node.cicsplexName,
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
             });
           } catch (error) {
             window.showErrorMessage(

--- a/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
@@ -50,7 +50,7 @@ export function getEnableProgramCommand(tree: CICSTree, treeview: TreeView<any>)
           try {
             await enableProgram(node.getSession(), {
               name: node.getContainedResourceName(),
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
               cicsPlex: node.cicsplexName,
             });
           } catch (error) {

--- a/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
@@ -46,7 +46,7 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
             await enableTransaction(node.getSession(), {
               name: node.getContainedResourceName(),
               cicsPlex: node.cicsplexName,
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
             });
           } catch (error) {
             window.showErrorMessage(

--- a/packages/vsce/src/commands/index.ts
+++ b/packages/vsce/src/commands/index.ts
@@ -61,7 +61,7 @@ export const getCommands = (treeDataProv: CICSTree, treeview: TreeView<any>, con
 
     getPurgeTaskCommand(treeDataProv, treeview),
 
-    getInspectResourceCommand(context, treeview),
+    getInspectResourceCommand(context),
 
     showLogsCommands.getShowRegionLogs(treeview),
     showAttributesCommands.getShowResourceAttributesCommand(treeview),

--- a/packages/vsce/src/commands/inspectResourceCommand.ts
+++ b/packages/vsce/src/commands/inspectResourceCommand.ts
@@ -9,11 +9,11 @@
  *
  */
 
-import { commands, ExtensionContext, TreeView, workspace } from "vscode";
+import { commands, ExtensionContext } from "vscode";
 
 import { inspectResourceByName, inspectResource } from "./inspectResourceCommandUtils";
 
-export function getInspectResourceCommand(context: ExtensionContext, treeview: TreeView<any>) {
+export function getInspectResourceCommand(context: ExtensionContext) {
   return commands.registerCommand("cics-extension-for-zowe.inspectResource", async (resourceName?: string, resourceType?: string) => {
     if (resourceName && resourceType) {
       await inspectResourceByName(context, resourceName, resourceType);

--- a/packages/vsce/src/commands/newCopyCommand.ts
+++ b/packages/vsce/src/commands/newCopyCommand.ts
@@ -48,7 +48,7 @@ export function getNewCopyCommand(tree: CICSTree, treeview: TreeView<any>) {
           try {
             await programNewcopy(node.getSession(), {
               name: node.getContainedResourceName(),
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
               cicsPlex: node.cicsplexName,
             });
           } catch (error) {

--- a/packages/vsce/src/commands/openLocalFileCommand.ts
+++ b/packages/vsce/src/commands/openLocalFileCommand.ts
@@ -47,7 +47,7 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
           try {
             await openLocalFile(node.getSession(), {
               name: resName,
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
               cicsPlex: node.cicsplexName,
             });
           } catch (error) {

--- a/packages/vsce/src/commands/phaseInCommand.ts
+++ b/packages/vsce/src/commands/phaseInCommand.ts
@@ -50,7 +50,7 @@ export function getPhaseInCommand(tree: CICSTree, treeview: TreeView<any>) {
           try {
             await performPhaseIn(node.getSession(), {
               name: node.getContainedResourceName(),
-              regionName: node.regionName,
+              regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
               cicsPlex: node.cicsplexName,
             });
           } catch (error) {

--- a/packages/vsce/src/commands/purgeTaskCommand.ts
+++ b/packages/vsce/src/commands/purgeTaskCommand.ts
@@ -61,7 +61,7 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
               node.getSession(),
               {
                 name: resName,
-                regionName: node.regionName,
+                regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
                 cicsPlex: node.cicsplexName,
               },
               purgeType

--- a/packages/vsce/src/commands/showLibraryCommand.ts
+++ b/packages/vsce/src/commands/showLibraryCommand.ts
@@ -1,97 +1,116 @@
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { TreeView, commands, window } from "vscode";
-import { ILibrary, IProgram, IResource, ProgramMeta } from "../doc";
-import { CICSResourceContainerNode } from "../trees";
+import { ILibrary, ILibraryDataset, IProgram, IResource, LibraryMeta, ProgramMeta } from "../doc";
+import { CICSRegionsContainer, CICSRegionTree, CICSResourceContainerNode } from "../trees";
 import { CICSTree } from "../trees/CICSTree";
-import { findSelectedNodes, getResourceTree } from "../utils/commandUtils";
+import { findSelectedNodes } from "../utils/commandUtils";
 import { openSettingsForHiddenResourceType } from "../utils/workspaceUtils";
+
+
+const getLibrariesToReveal = (nodes: CICSResourceContainerNode<IProgram>[]): Map<string, Map<string, Set<string>>> => {
+  const librariesToReveal: Map<string, Map<string, Set<string>>> = new Map();
+  for (const childNode of nodes) {
+    const region = childNode.regionName ?? childNode.getContainedResource().resource.attributes.eyu_cicsname;
+    const library = childNode.getContainedResource().resource.attributes.library;
+    const libraryDsn = childNode.getContainedResource().resource.attributes.librarydsn;
+
+    if (library && libraryDsn) {
+      if (!librariesToReveal.has(region)) {
+        librariesToReveal.set(region, new Map());
+      }
+      if (!librariesToReveal.get(region)!.has(library)) {
+        librariesToReveal.get(region)!.set(library, new Set<string>());
+      }
+      librariesToReveal.get(region)!.get(library)!.add(libraryDsn);
+    }
+  }
+
+  return librariesToReveal;
+};
+
+const getListOfAvailableRegions = async (node: CICSResourceContainerNode<IProgram>, treeview: TreeView<any>): Promise<CICSRegionTree[]> => {
+  if (node.getParent().label === "Programs") {
+    const parent = node.getParent().getParent();
+    if (parent.getParent() instanceof CICSRegionsContainer) {
+      await treeview.reveal(parent.getParent(), { expand: true });
+      return parent.getParent().children as CICSRegionTree[];
+    } else {
+      return [parent as CICSRegionTree];
+    }
+  } else {
+    const regionsContainer = node.getParent().getParent().children.filter(
+      (child) => child instanceof CICSRegionsContainer)[0] as CICSRegionsContainer;
+    await treeview.reveal(regionsContainer, { expand: true });
+    return regionsContainer.children;
+  }
+};
 
 export function showLibraryCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.showLibrary", async (node) => {
-    const msg = "CICS Library resources are not visible. Enable them from your VS Code settings.";
-    if (!openSettingsForHiddenResourceType(msg, "Library")) {
+
+    if (!openSettingsForHiddenResourceType("CICS Library resources are not visible. Enable them from your VS Code settings.", "Library")) {
       return;
     }
 
     const nodes = findSelectedNodes(treeview, ProgramMeta, node) as CICSResourceContainerNode<IProgram>[];
-    if (!nodes || !nodes.length) {
+    if (!nodes || nodes.length === 0) {
       window.showErrorMessage("No CICS Program selected");
       return;
     }
 
-    const labels = nodes.map((n) => (typeof n.label === "string" ? n.label : (n.label?.label ?? "")));
-    const selectedNodesLabels = labels.join(",");
-
-    // Create a map: library name -> set of librarydsn (unique values)
-    const libraryDSNMap = new Map<string, Set<string>>();
-    for (const childNode of nodes) {
-      const lib = childNode.getContainedResource().resource.attributes.library;
-      const libDsn = childNode.getContainedResource().resource.attributes.librarydsn;
-      if (lib) {
-        if (!libraryDSNMap.has(lib)) {
-          libraryDSNMap.set(lib, new Set());
-        }
-        if (libDsn && libDsn.length > 0) {
-          libraryDSNMap.get(lib)!.add(libDsn);
-        }
-      }
-    }
-
-    if (!libraryDSNMap.size) {
-      await window.showInformationMessage(`${selectedNodesLabels} do not contain library`);
+    const librariesToReveal = getLibrariesToReveal(nodes);
+    if (librariesToReveal.size === 0) {
+      await window.showInformationMessage(`No libraries found in selected CICS programs`);
       return;
     }
-    let libraryTree: CICSResourceContainerNode<ILibrary> | undefined;
-    const label = nodes[0].getParent().label;
 
-    //if the label is "All Programs", we need to get the library tree from the regions node
-    if (label === "All Programs") {
-      libraryTree = await getResourceTree<ILibrary>(treeview, nodes, CicsCmciConstants.CICS_LIBRARY_RESOURCE);
-    } else {
-      libraryTree = nodes[0]
-        .getParent()
-        .getParent()
-        .children.filter(
-          (child: CICSResourceContainerNode<IResource>) => child.getChildResource().meta.resourceName === CicsCmciConstants.CICS_LIBRARY_RESOURCE
-        )[0] as CICSResourceContainerNode<ILibrary>;
-    }
-    //clearing the previous filter and description
-    libraryTree.clearFilter();
-    libraryTree.description = "";
-    libraryTree.children = [];
-    libraryTree.refreshingDescription = false;
-    libraryTree.getChildResource().resources.resetCriteria();
-    libraryTree.getChildResource().resources.resources = [];
+    const listOfRegions: CICSRegionTree[] = await getListOfAvailableRegions(nodes[0], treeview);
 
-    await treeview.reveal(libraryTree, { expand: true });
+    for (const [region, libraries] of librariesToReveal) {
 
-    //set the new filter and description
-    const libraryNames = Array.from(libraryDSNMap.keys());
-    libraryTree.setFilter(libraryNames);
-    libraryTree.description = libraryNames.join(" OR ");
-    libraryTree.refreshingDescription = false;
-    const libraryNodes = await libraryTree.getChildren();
-    let libNode;
-    const libArray: CICSResourceContainerNode<IResource>[] = [];
-    //setting the filter and description for each library node
-    for (const child of libraryNodes) {
-      libNode = child as CICSResourceContainerNode<IResource>;
-      const labelKey = typeof libNode.label === "string" ? libNode.label : (libNode.label?.label ?? "");
-      if (
-        libNode.getChildResource().meta.resourceName === CicsCmciConstants.CICS_LIBRARY_DATASET_RESOURCE &&
-        libraryDSNMap.has(labelKey) &&
-        libraryDSNMap.get(labelKey) &&
-        libraryDSNMap.get(labelKey)!.size > 0
-      ) {
-        const libDsns = Array.from(libraryDSNMap.get(labelKey)!);
-        libNode.setFilter(libDsns);
-        libNode.description = libDsns.join(" OR ");
-        libArray.push(libNode);
-        libNode.refreshingDescription = false;
+      const regionTree: CICSRegionTree = listOfRegions.filter(
+        (regTree) => regTree.getRegionName() === region)[0];
+
+      await treeview.reveal(regionTree, { expand: true });
+
+      const libraryTree: CICSResourceContainerNode<ILibrary> = regionTree.children.filter(
+        (resourceTree: CICSResourceContainerNode<IResource>) => resourceTree.getChildResource().meta === LibraryMeta
+      )[0] as CICSResourceContainerNode<ILibrary>;
+
+      //clearing the previous filter and description
+      libraryTree.clearFilter();
+      libraryTree.description = "";
+      libraryTree.children = [];
+      libraryTree.refreshingDescription = false;
+      libraryTree.getChildResource().resources.resetCriteria();
+      libraryTree.getChildResource().resources.resources = [];
+
+      await treeview.reveal(libraryTree, { expand: true });
+
+      libraryTree.setFilter([...libraries.keys()]);
+      libraryTree.description = [...libraries.keys()].join(" OR ");
+      libraryTree.refreshingDescription = false;
+      const libraryNodes = await libraryTree.getChildren();
+
+      const libArray: CICSResourceContainerNode<IResource>[] = [];
+      //setting the filter and description for each library node
+      for (const child of libraryNodes) {
+
+        const libNode = child as CICSResourceContainerNode<ILibraryDataset>;
+        if (
+          libNode.getChildResource().meta.resourceName === CicsCmciConstants.CICS_LIBRARY_DATASET_RESOURCE &&
+          libraries.has(libNode.getContainedResourceName()) &&
+          libraries.get(libNode.getContainedResourceName())!.size > 0
+        ) {
+          libNode.setFilter([...libraries.get(libNode.getContainedResourceName())]);
+          libNode.description = [...libraries.get(libNode.getContainedResourceName())].join(" OR ");
+          libArray.push(libNode);
+          libNode.refreshingDescription = false;
+        }
       }
-    }
-    for (const lib of libArray) {
-      await treeview.reveal(lib, { expand: true });
+      for (const lib of libArray) {
+        await treeview.reveal(lib, { expand: true });
+      }
     }
   });
 }

--- a/packages/vsce/src/trees/CICSRegionTree.ts
+++ b/packages/vsce/src/trees/CICSRegionTree.ts
@@ -65,17 +65,34 @@ export class CICSRegionTree extends CICSTreeNode implements ICICSTreeNode {
 
       const config = workspace.getConfiguration("zowe.cics.resources");
 
-      this.children = [
-        config.get<boolean>("Program", true) && this.buildResourceContainerNode(ProgramMeta),
-        config.get<boolean>("Transaction", true) && this.buildResourceContainerNode(TransactionMeta),
-        config.get<boolean>("LocalFile", true) && this.buildResourceContainerNode(LocalFileMeta),
-        config.get<boolean>("Task", true) && this.buildResourceContainerNode(TaskMeta),
-        config.get<boolean>("Library", true) && this.buildResourceContainerNode(LibraryMeta),
-        config.get<boolean>("Pipeline", true) && this.buildResourceContainerNode(PipelineMeta),
-        config.get<boolean>("TCP/IPService", true) && this.buildResourceContainerNode(TCPIPMeta),
-        config.get<boolean>("URIMap", true) && this.buildResourceContainerNode(URIMapMeta),
-        config.get<boolean>("WebService", true) && this.buildResourceContainerNode(WebServiceMeta),
-      ].filter((child) => child !== null);
+      this.children = [];
+      if (config.get<boolean>("Program", true)) {
+        this.children.push(this.buildResourceContainerNode(ProgramMeta));
+      }
+      if (config.get<boolean>("Transaction", true)) {
+        this.children.push(this.buildResourceContainerNode(TransactionMeta));
+      }
+      if (config.get<boolean>("LocalFile", true)) {
+        this.children.push(this.buildResourceContainerNode(LocalFileMeta));
+      }
+      if (config.get<boolean>("Task", true)) {
+        this.children.push(this.buildResourceContainerNode(TaskMeta));
+      }
+      if (config.get<boolean>("Library", true)) {
+        this.children.push(this.buildResourceContainerNode(LibraryMeta));
+      }
+      if (config.get<boolean>("Pipeline", true)) {
+        this.children.push(this.buildResourceContainerNode(PipelineMeta));
+      }
+      if (config.get<boolean>("TCP/IPService", true)) {
+        this.children.push(this.buildResourceContainerNode(TCPIPMeta));
+      }
+      if (config.get<boolean>("URIMap", true)) {
+        this.children.push(this.buildResourceContainerNode(URIMapMeta));
+      }
+      if (config.get<boolean>("WebService", true)) {
+        this.children.push(this.buildResourceContainerNode(WebServiceMeta));
+      }
     }
   }
 


### PR DESCRIPTION
**What It Does**
Fixes issues of performing actions on resources under `All xxx` trees. Allows Show Library to work when resources in multiple regions.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
