### PR TITLE
use human readable names for resource types

### DIFF
--- a/packages/vsce/__tests__/__unit__/commands/inspectResourceCommandUtils.test.ts
+++ b/packages/vsce/__tests__/__unit__/commands/inspectResourceCommandUtils.test.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { getInspectableResourceTypes } from "../../../src/commands/inspectResourceCommandUtils";
+
+jest.mock("@zowe/cics-for-zowe-sdk");
+jest.mock("../../../src/utils/CICSLogger");
+jest.mock("../../../src/utils/profileManagement", () => ({
+  ProfileManagement: {
+    getProfilesCache: false,
+  },
+}));
+
+describe("getInspectableResourceTypes", () => {
+  test("Not all meta types are visible", () => {
+    const result = getInspectableResourceTypes();
+    expect(Array.from(result.keys()).includes("Local File")).toBe(true);
+    // We do not want to show LIBDSN in the list of inspectable resources because it doesn't currently work
+    expect(Array.from(result.keys()).includes("Library Dataset")).toBe(false);
+  });
+});

--- a/packages/vsce/src/commands/filterResourceCommands.ts
+++ b/packages/vsce/src/commands/filterResourceCommands.ts
@@ -17,7 +17,7 @@ import { getPatternFromFilter } from "../utils/filterUtils";
 
 export function getFilterResourcesCommand(tree: CICSTree, treeview: TreeView<ICICSTreeNode>) {
   return commands.registerCommand("cics-extension-for-zowe.filterResources", async (node: CICSResourceContainerNode<IResource>) => {
-    const pattern = await getPatternFromFilter(node.getChildResource().meta.humanReadableName, node.getChildResource().meta.getCriteriaHistory());
+    const pattern = await getPatternFromFilter(node.getChildResource().meta.humanReadableNamePlural, node.getChildResource().meta.getCriteriaHistory());
 
     if (!pattern) {
       return;

--- a/packages/vsce/src/commands/inspectResourceCommandUtils.ts
+++ b/packages/vsce/src/commands/inspectResourceCommandUtils.ts
@@ -125,7 +125,7 @@ async function loadResources(
   const resources: [Resource<IResource>[], boolean] = await resourceContainer.loadResources(session, regionName, cicsplex);
 
   if (resources[0].length === 0 ) {
-    const hrn = resourceType.humanReadableName.endsWith("s") ? resourceType.humanReadableName.slice(0, resourceType.humanReadableName.length-1): resourceType.humanReadableName;
+    const hrn = resourceType.humanReadableNameSingular;
     const message = CICSMessages.CICSResourceNotFound.message.replace("%resource-type%", hrn).replace("%resource-name%", resourceName).replace("%region-name%", regionName);
     CICSLogger.error(message);
     window.showErrorMessage(message);
@@ -146,10 +146,18 @@ function getResourceType(resourceName: string): IResourceMeta<IResource> {
 }
 
 async function selectResourceType(): Promise<IResourceMeta<IResource> | undefined> {
-  const choice = await getChoiceFromQuickPick(CICSMessages.CICSSelectResourceType.message, SupportedResourceTypes);
+  // map with the nice name of the resource type "Local File" etc mapping onto the resource meta type
+  const resourceTypeMap = getMetas().reduce((acc, item) => {
+    if (SupportedResourceTypes.filter((res) => res == item.resourceName).length > 0) {
+      acc.set(item.humanReadableNameSingular, item);
+    }
+    return acc;
+  }, new Map());
+
+  const choice = await getChoiceFromQuickPick(CICSMessages.CICSSelectResourceType.message, Array.from(resourceTypeMap.keys()));
 
   if (choice) {
-    return getResourceType(choice.label);
+    return resourceTypeMap.get(choice.label);
   }
 
   return undefined;

--- a/packages/vsce/src/commands/inspectResourceCommandUtils.ts
+++ b/packages/vsce/src/commands/inspectResourceCommandUtils.ts
@@ -185,7 +185,7 @@ async function getChoiceFromQuickPick(
 
 async function getEntryFromInputBox(resourceType: IResourceMeta<IResource>): Promise<string | undefined> {
   const options: InputBoxOptions = {
-    prompt: CICSMessages.CICSEnterResourceName.message,
+    prompt: CICSMessages.CICSEnterResourceName.message.replace("%resource-human-readable%", resourceType.humanReadableNameSingular),
     value: "",
     validateInput: function(value: string): string {
       if (resourceType === TransactionMeta && value.length > constants.MAX_TRANS_RESOURCE_NAME_LENGTH) {

--- a/packages/vsce/src/commands/inspectResourceCommandUtils.ts
+++ b/packages/vsce/src/commands/inspectResourceCommandUtils.ts
@@ -145,14 +145,20 @@ function getResourceType(resourceName: string): IResourceMeta<IResource> {
   return undefined;
 }
 
-async function selectResourceType(): Promise<IResourceMeta<IResource> | undefined> {
-  // map with the nice name of the resource type "Local File" etc mapping onto the resource meta type
+export function getInspectableResourceTypes(): Map<string, IResourceMeta<IResource>> {
   const resourceTypeMap = getMetas().reduce((acc, item) => {
+    // for now we only show our externally visible types (so not LIBDSN)
     if (SupportedResourceTypes.filter((res) => res == item.resourceName).length > 0) {
       acc.set(item.humanReadableNameSingular, item);
     }
     return acc;
   }, new Map());
+  return resourceTypeMap;
+}
+
+async function selectResourceType(): Promise<IResourceMeta<IResource> | undefined> {
+  // map with the nice name of the resource type "Local File" etc mapping onto the resource meta type
+  const resourceTypeMap = getInspectableResourceTypes();
 
   const choice = await getChoiceFromQuickPick(CICSMessages.CICSSelectResourceType.message, Array.from(resourceTypeMap.keys()));
 

--- a/packages/vsce/src/constants/CICS.messages.ts
+++ b/packages/vsce/src/constants/CICS.messages.ts
@@ -42,7 +42,7 @@ export const CICSMessages: { [key: string]: IMessageDefinition; } = {
   },
 
   CICSEnterResourceName: {
-    message: "Enter the name of a CICS Resource",
+    message: "Enter the name of a CICS %resource-human-readable% resource.",
   },
 
   CICSInvalidResourceNameLength: {

--- a/packages/vsce/src/doc/meta/IResourceMeta.ts
+++ b/packages/vsce/src/doc/meta/IResourceMeta.ts
@@ -15,6 +15,7 @@ import { IResource } from "../resources/IResource";
 export interface IResourceMeta<T extends IResource> {
   resourceName: string;
   humanReadableName: string;
+  humanReadableNameSingular: string;
 
   buildCriteria(criteria: string[], parentResource?: IResource): string;
   getDefaultCriteria(parentResource?: IResource): Promise<string>;

--- a/packages/vsce/src/doc/meta/IResourceMeta.ts
+++ b/packages/vsce/src/doc/meta/IResourceMeta.ts
@@ -14,7 +14,7 @@ import { IResource } from "../resources/IResource";
 
 export interface IResourceMeta<T extends IResource> {
   resourceName: string;
-  humanReadableName: string;
+  humanReadableNamePlural: string;
   humanReadableNameSingular: string;
 
   buildCriteria(criteria: string[], parentResource?: IResource): string;

--- a/packages/vsce/src/doc/meta/bundle.meta.ts
+++ b/packages/vsce/src/doc/meta/bundle.meta.ts
@@ -21,6 +21,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const BundleMeta: IResourceMeta<IBundle> = {
   resourceName: CicsCmciConstants.CICS_CMCI_BUNDLE,
   humanReadableName: "Bundles",
+  humanReadableNameSingular: "Bundle",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `name=${n}`).join(" OR ");

--- a/packages/vsce/src/doc/meta/bundle.meta.ts
+++ b/packages/vsce/src/doc/meta/bundle.meta.ts
@@ -20,7 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const BundleMeta: IResourceMeta<IBundle> = {
   resourceName: CicsCmciConstants.CICS_CMCI_BUNDLE,
-  humanReadableName: "Bundles",
+  humanReadableNamePlural: "Bundles",
   humanReadableNameSingular: "Bundle",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/bundlePart.meta.ts
+++ b/packages/vsce/src/doc/meta/bundlePart.meta.ts
@@ -20,6 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const BundlePartMeta: IResourceMeta<IBundlePart> = {
   resourceName: CicsCmciConstants.CICS_CMCI_BUNDLE_PART,
   humanReadableName: "Bundle Parts",
+  humanReadableNameSingular: "Bundle Part",
 
   buildCriteria(criteria: string[], parentResource?: IBundle) {
     return `BUNDLE=${parentResource.name} AND (${criteria.map((n) => `BUNDLEPART=${n}`).join(" OR ")})`;

--- a/packages/vsce/src/doc/meta/bundlePart.meta.ts
+++ b/packages/vsce/src/doc/meta/bundlePart.meta.ts
@@ -19,7 +19,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const BundlePartMeta: IResourceMeta<IBundlePart> = {
   resourceName: CicsCmciConstants.CICS_CMCI_BUNDLE_PART,
-  humanReadableName: "Bundle Parts",
+  humanReadableNamePlural: "Bundle Parts",
   humanReadableNameSingular: "Bundle Part",
 
   buildCriteria(criteria: string[], parentResource?: IBundle) {

--- a/packages/vsce/src/doc/meta/library.meta.ts
+++ b/packages/vsce/src/doc/meta/library.meta.ts
@@ -20,7 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const LibraryMeta: IResourceMeta<ILibrary> = {
   resourceName: CicsCmciConstants.CICS_LIBRARY_RESOURCE,
-  humanReadableName: "Libraries",
+  humanReadableNamePlural: "Libraries",
   humanReadableNameSingular: "Library",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/library.meta.ts
+++ b/packages/vsce/src/doc/meta/library.meta.ts
@@ -21,6 +21,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const LibraryMeta: IResourceMeta<ILibrary> = {
   resourceName: CicsCmciConstants.CICS_LIBRARY_RESOURCE,
   humanReadableName: "Libraries",
+  humanReadableNameSingular: "Library",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `name=${n}`).join(" OR ");

--- a/packages/vsce/src/doc/meta/libraryDataset.meta.ts
+++ b/packages/vsce/src/doc/meta/libraryDataset.meta.ts
@@ -34,7 +34,7 @@ customProgramMeta.buildCriteria = (criteria: string[], parentResource: ILibraryD
 
 export const LibraryDatasetMeta: IResourceMeta<ILibraryDataset> = {
   resourceName: CicsCmciConstants.CICS_LIBRARY_DATASET_RESOURCE,
-  humanReadableName: "Library Datasets",
+  humanReadableNamePlural: "Library Datasets",
   humanReadableNameSingular: "Library Dataset",
 
   buildCriteria(criteria: string[], parentResource: ILibrary) {

--- a/packages/vsce/src/doc/meta/libraryDataset.meta.ts
+++ b/packages/vsce/src/doc/meta/libraryDataset.meta.ts
@@ -35,6 +35,7 @@ customProgramMeta.buildCriteria = (criteria: string[], parentResource: ILibraryD
 export const LibraryDatasetMeta: IResourceMeta<ILibraryDataset> = {
   resourceName: CicsCmciConstants.CICS_LIBRARY_DATASET_RESOURCE,
   humanReadableName: "Library Datasets",
+  humanReadableNameSingular: "Library Dataset",
 
   buildCriteria(criteria: string[], parentResource: ILibrary) {
     return `(LIBRARY='${parentResource.name}') AND (${criteria.map((n) => `DSNAME='${n}'`).join(" OR ")})`;

--- a/packages/vsce/src/doc/meta/localFile.meta.ts
+++ b/packages/vsce/src/doc/meta/localFile.meta.ts
@@ -20,6 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const LocalFileMeta: IResourceMeta<ILocalFile> = {
   resourceName: CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
   humanReadableName: "Local Files",
+  humanReadableNameSingular: "Local File",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `file=${n}`).join(" OR ");

--- a/packages/vsce/src/doc/meta/localFile.meta.ts
+++ b/packages/vsce/src/doc/meta/localFile.meta.ts
@@ -19,7 +19,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const LocalFileMeta: IResourceMeta<ILocalFile> = {
   resourceName: CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
-  humanReadableName: "Local Files",
+  humanReadableNamePlural: "Local Files",
   humanReadableNameSingular: "Local File",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/pipeline.meta.ts
+++ b/packages/vsce/src/doc/meta/pipeline.meta.ts
@@ -20,6 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const PipelineMeta: IResourceMeta<IPipeline> = {
   resourceName: CicsCmciConstants.CICS_PIPELINE_RESOURCE,
   humanReadableName: "Pipelines",
+  humanReadableNameSingular: "Pipeline",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `name=${n}`).join(" OR ");

--- a/packages/vsce/src/doc/meta/pipeline.meta.ts
+++ b/packages/vsce/src/doc/meta/pipeline.meta.ts
@@ -19,7 +19,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const PipelineMeta: IResourceMeta<IPipeline> = {
   resourceName: CicsCmciConstants.CICS_PIPELINE_RESOURCE,
-  humanReadableName: "Pipelines",
+  humanReadableNamePlural: "Pipelines",
   humanReadableNameSingular: "Pipeline",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/program.meta.ts
+++ b/packages/vsce/src/doc/meta/program.meta.ts
@@ -19,7 +19,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const ProgramMeta: IResourceMeta<IProgram> = {
   resourceName: CicsCmciConstants.CICS_PROGRAM_RESOURCE,
-  humanReadableName: "Programs",
+  humanReadableNamePlural: "Programs",
   humanReadableNameSingular: "Program",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/program.meta.ts
+++ b/packages/vsce/src/doc/meta/program.meta.ts
@@ -20,6 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const ProgramMeta: IResourceMeta<IProgram> = {
   resourceName: CicsCmciConstants.CICS_PROGRAM_RESOURCE,
   humanReadableName: "Programs",
+  humanReadableNameSingular: "Program",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `PROGRAM=${n}`).join(" OR ");

--- a/packages/vsce/src/doc/meta/task.meta.ts
+++ b/packages/vsce/src/doc/meta/task.meta.ts
@@ -19,7 +19,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const TaskMeta: IResourceMeta<ITask> = {
   resourceName: CicsCmciConstants.CICS_CMCI_TASK,
-  humanReadableName: "Tasks",
+  humanReadableNamePlural: "Tasks",
   humanReadableNameSingular: "Task",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/task.meta.ts
+++ b/packages/vsce/src/doc/meta/task.meta.ts
@@ -20,6 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const TaskMeta: IResourceMeta<ITask> = {
   resourceName: CicsCmciConstants.CICS_CMCI_TASK,
   humanReadableName: "Tasks",
+  humanReadableNameSingular: "Task",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `TRANID=${n}`).join(" OR ");

--- a/packages/vsce/src/doc/meta/tcpip.meta.ts
+++ b/packages/vsce/src/doc/meta/tcpip.meta.ts
@@ -20,6 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const TCPIPMeta: IResourceMeta<ITCPIP> = {
   resourceName: CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE,
   humanReadableName: "TCP/IP Services",
+  humanReadableNameSingular: "TCP/IP Service",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `name=${n}`).join(" OR ");

--- a/packages/vsce/src/doc/meta/tcpip.meta.ts
+++ b/packages/vsce/src/doc/meta/tcpip.meta.ts
@@ -19,7 +19,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const TCPIPMeta: IResourceMeta<ITCPIP> = {
   resourceName: CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE,
-  humanReadableName: "TCP/IP Services",
+  humanReadableNamePlural: "TCP/IP Services",
   humanReadableNameSingular: "TCP/IP Service",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/transaction.meta.ts
+++ b/packages/vsce/src/doc/meta/transaction.meta.ts
@@ -20,6 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const TransactionMeta: IResourceMeta<ITransaction> = {
   resourceName: CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
   humanReadableName: "Transactions",
+  humanReadableNameSingular: "Transaction",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `TRANID=${n}`).join(" OR ");

--- a/packages/vsce/src/doc/meta/transaction.meta.ts
+++ b/packages/vsce/src/doc/meta/transaction.meta.ts
@@ -19,7 +19,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const TransactionMeta: IResourceMeta<ITransaction> = {
   resourceName: CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
-  humanReadableName: "Transactions",
+  humanReadableNamePlural: "Transactions",
   humanReadableNameSingular: "Transaction",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/urimap.meta.ts
+++ b/packages/vsce/src/doc/meta/urimap.meta.ts
@@ -20,6 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const URIMapMeta: IResourceMeta<IURIMap> = {
   resourceName: CicsCmciConstants.CICS_URIMAP,
   humanReadableName: "URI Maps",
+  humanReadableNameSingular: "URI Map",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `name=${n}`).join(" OR ");

--- a/packages/vsce/src/doc/meta/urimap.meta.ts
+++ b/packages/vsce/src/doc/meta/urimap.meta.ts
@@ -19,7 +19,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const URIMapMeta: IResourceMeta<IURIMap> = {
   resourceName: CicsCmciConstants.CICS_URIMAP,
-  humanReadableName: "URI Maps",
+  humanReadableNamePlural: "URI Maps",
   humanReadableNameSingular: "URI Map",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/webservice.meta.ts
+++ b/packages/vsce/src/doc/meta/webservice.meta.ts
@@ -19,7 +19,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const WebServiceMeta: IResourceMeta<IWebService> = {
   resourceName: CicsCmciConstants.CICS_WEBSERVICE_RESOURCE,
-  humanReadableName: "Web Services",
+  humanReadableNamePlural: "Web Services",
   humanReadableNameSingular: "Web Service",
 
   buildCriteria(criteria: string[]) {

--- a/packages/vsce/src/doc/meta/webservice.meta.ts
+++ b/packages/vsce/src/doc/meta/webservice.meta.ts
@@ -20,6 +20,7 @@ const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 export const WebServiceMeta: IResourceMeta<IWebService> = {
   resourceName: CicsCmciConstants.CICS_WEBSERVICE_RESOURCE,
   humanReadableName: "Web Services",
+  humanReadableNameSingular: "Web Service",
 
   buildCriteria(criteria: string[]) {
     return criteria.map((n) => `name=${n}`).join(" OR ");

--- a/packages/vsce/src/trees/CICSRegionTree.ts
+++ b/packages/vsce/src/trees/CICSRegionTree.ts
@@ -102,7 +102,7 @@ export class CICSRegionTree extends CICSTreeNode implements ICICSTreeNode {
 
   private buildResourceContainerNode(meta: IResourceMeta<IResource>) {
     return new CICSResourceContainerNode(
-      meta.humanReadableName,
+      meta.humanReadableNamePlural,
       {
         parentNode: this,
         profile: this.parentSession.profile,

--- a/packages/vsce/src/trees/ResourceInspectorViewProvider.ts
+++ b/packages/vsce/src/trees/ResourceInspectorViewProvider.ts
@@ -99,7 +99,7 @@ export class ResourceInspectorViewProvider implements WebviewViewProvider {
     await this.webviewView.webview.postMessage({
       data: {
         name: this.resource.meta.getName(this.resource.resource),
-        resourceName: this.resource.meta.resourceName,
+        humanReadableNameSingular: this.resource.meta.humanReadableNameSingular,
         highlights: this.resource.meta.getHighlights(this.resource.resource),
         resource: this.resource.resource.attributes,
         profileHandler: this.resourceHandlerMap,

--- a/packages/vsce/src/webviews/resource-inspector-panel/ResourceInspector.tsx
+++ b/packages/vsce/src/webviews/resource-inspector-panel/ResourceInspector.tsx
@@ -23,7 +23,7 @@ const ResourceInspector = () => {
 
   const [resourceInfo, setResourceInfo] = React.useState<{
     name: string;
-    resourceName: string;
+    humanReadableNameSingular: string;
     highlights: { key: string; value: string; }[];
     resource: IResource;
     profileHandler: { key: string; value: string }[];
@@ -69,7 +69,7 @@ const ResourceInspector = () => {
           <th id="th-1" className="header-cell-1 padding-left-10">
             <div className="div-display-1">{resourceInfo?.name ?? "..."}</div>
             <div className="div-display-1 div-display-2">
-              {resourceInfo?.resourceName ?? "..."}: {resourceInfo ? (resourceInfo?.resource.status || resourceInfo?.resource.enablestatus) : "..."}
+              {resourceInfo?.humanReadableNameSingular ?? "..."}: {resourceInfo ? (resourceInfo?.resource.status || resourceInfo?.resource.enablestatus) : "..."}
             </div>
           </th>
         </thead>


### PR DESCRIPTION
**What It Does**
The new (but unreleased!) Resource Inspector uses the CMCI names for resources (CICSLocalFile etc) in the view itself and also in the command palette to open the view.

It's a nicer UX to call them "Local File" etc.

Resolves https://github.com/zowe/cics-for-zowe-client/issues/387

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
