### PR TITLE
Adds resourceExtender to allow actions registered on resources

### DIFF
--- a/packages/vsce-api/__tests__/__unit__/interfaces.test.ts
+++ b/packages/vsce-api/__tests__/__unit__/interfaces.test.ts
@@ -9,11 +9,40 @@
  *
  */
 
+import { CICSSession } from "@zowe/cics-for-zowe-sdk";
+import { imperative } from "@zowe/zowe-explorer-api";
 import { IExtensionAPI } from "../../src/interfaces/IExtensionAPI";
 import { IResource } from "../../src/interfaces/IResource";
-import { SupportedResourceTypes } from "../../src/resources";
+import { IResourceContext } from "../../src/interfaces/IResourceContext";
+import { IResourceExtender } from "../../src/interfaces/IResourceExtender";
+import { ResourceTypes, SupportedResourceTypes } from "../../src/resources";
+import { IResourceAction } from "../../src/interfaces/IResourceAction";
 
 describe("Interfaces", () => {
+  const action: IResourceAction = {
+    id: "CICS.CICSProgram.NEWCOPY",
+    name: "New Copy Program",
+    resourceType: ResourceTypes.CICSProgram,
+    action: async (_resource: IResource, _resourceContext: IResourceContext) => { },
+    enabledWhen(_resource, _resourceContext) {
+      return true;
+    },
+    visibleWhen(_resource, _resourceContext) {
+      return true;
+    },
+  };
+
+  const extender: IResourceExtender = {
+    registeredActions: [],
+    deregisterAction(_id) { },
+    registerAction(_action) { },
+    getAction(_id) {
+      return action;
+    },
+    getActions() {
+      return [];
+    },
+  };
 
   const api: IExtensionAPI = {
     resources: {
@@ -26,6 +55,42 @@ describe("Interfaces", () => {
     status: "ENABLED",
   };
 
+  const profile: imperative.IProfileLoaded = {
+    failNotFound: false,
+    message: "",
+    type: "cics",
+    name: "MYPROF",
+    profile: {
+      host: "MYHOST",
+      port: 1234,
+    },
+  };
+
+  // @ts-ignore - profile will not be undefined
+  const session: CICSSession = new CICSSession(profile.profile);
+
+  const cx: IResourceContext = {
+    profile,
+    cicsplexName: "myplex",
+    regionName: "REGION1",
+    session,
+  };
+
+  it("should assert IResourceAction", () => {
+    expect(action).toHaveProperty("id");
+    expect(action).toHaveProperty("name");
+    expect(action).toHaveProperty("resourceType");
+    expect(action).toHaveProperty("action");
+    expect(action).toHaveProperty("enabledWhen");
+    expect(action).toHaveProperty("visibleWhen");
+  });
+  it("should assert IResourceExtender", () => {
+    expect(extender).toHaveProperty("registeredActions");
+    expect(extender).toHaveProperty("deregisterAction");
+    expect(extender).toHaveProperty("registerAction");
+    expect(extender).toHaveProperty("getAction");
+    expect(extender).toHaveProperty("getActions");
+  });
   it("should assert IExtensionAPI", () => {
     expect(api).toHaveProperty("resources");
     expect(api.resources).toHaveProperty("supportedResources");
@@ -33,5 +98,11 @@ describe("Interfaces", () => {
   it("should assert IResource", () => {
     expect(res).toHaveProperty("eyu_cicsname");
     expect(res).toHaveProperty("status");
+  });
+  it("should assert IResourceContext", () => {
+    expect(cx).toHaveProperty("session");
+    expect(cx).toHaveProperty("profile");
+    expect(cx).toHaveProperty("cicsplexName");
+    expect(cx).toHaveProperty("regionName");
   });
 });

--- a/packages/vsce-api/src/getAPI.ts
+++ b/packages/vsce-api/src/getAPI.ts
@@ -13,7 +13,7 @@ import { compare } from 'compare-versions';
 import { extensions } from "vscode";
 import { IExtensionAPI } from './interfaces';
 
-export async function getCICSForZoweExplorerAPI(minimumVersion?: string): Promise<IExtensionAPI> {
+export async function getCICSForZoweExplorerAPI(minimumVersion?: string): Promise<IExtensionAPI | undefined> {
 
     const cicsExtension = extensions.getExtension("Zowe.cics-extension-for-zowe");
 

--- a/packages/vsce-api/src/interfaces/IResourceAction.ts
+++ b/packages/vsce-api/src/interfaces/IResourceAction.ts
@@ -1,0 +1,23 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { ResourceTypes } from "../resources";
+import { IResource } from "./IResource";
+import { IResourceContext } from "./IResourceContext";
+
+export interface IResourceAction {
+  id: string;
+  name: string;
+  resourceType: ResourceTypes;
+  visibleWhen?: (resource: IResource, resourceContext: IResourceContext) => boolean | Promise<boolean>;
+  enabledWhen?: (resource: IResource, resourceContext: IResourceContext) => boolean | Promise<boolean>;
+  action: string | ((resource: IResource, resourceContext: IResourceContext) => void | Promise<void>);
+}

--- a/packages/vsce-api/src/interfaces/IResourceContext.ts
+++ b/packages/vsce-api/src/interfaces/IResourceContext.ts
@@ -9,8 +9,12 @@
  *
  */
 
-export * from "./IExtensionAPI";
-export * from "./IResource";
-export * from "./IResourceContext";
-export * from "./IResourceExtender";
-export * from "./IResourceAction";
+import { CICSSession } from "@zowe/cics-for-zowe-sdk";
+import { imperative } from "@zowe/zowe-explorer-api";
+
+export interface IResourceContext {
+  regionName: string;
+  cicsplexName: string;
+  profile: imperative.IProfileLoaded;
+  session: CICSSession;
+}

--- a/packages/vsce-api/src/interfaces/IResourceExtender.ts
+++ b/packages/vsce-api/src/interfaces/IResourceExtender.ts
@@ -9,8 +9,13 @@
  *
  */
 
-export * from "./IExtensionAPI";
-export * from "./IResource";
-export * from "./IResourceContext";
-export * from "./IResourceExtender";
-export * from "./IResourceAction";
+import { IResourceAction } from "./IResourceAction";
+
+export interface IResourceExtender {
+  registeredActions: IResourceAction[];
+
+  registerAction: (action: IResourceAction) => void;
+  deregisterAction: (id: string) => void;
+  getActions: () => IResourceAction[];
+  getAction: (id: string) => IResourceAction;
+}

--- a/packages/vsce/src/commands/openLocalFileCommand.ts
+++ b/packages/vsce/src/commands/openLocalFileCommand.ts
@@ -82,7 +82,7 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
   });
 }
 
-function openLocalFile(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
+export function openLocalFile(session: imperative.AbstractSession, parms: ICommandParams): Promise<ICMCIApiResponse> {
   return runPutResource(
     {
       session: session,

--- a/packages/vsce/src/extending/CICSResourceExtender.ts
+++ b/packages/vsce/src/extending/CICSResourceExtender.ts
@@ -1,0 +1,44 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResourceAction, IResourceExtender } from "@zowe/cics-for-zowe-explorer-api";
+import { getBuiltInResourceActions } from "../resources/actions";
+
+class SCICSResourceExtender implements IResourceExtender {
+  private static _instance: SCICSResourceExtender;
+  public static get Instance() {
+    return this._instance || (this._instance = new this());
+  }
+  registeredActions: IResourceAction[];
+
+  private constructor() {
+    this.registeredActions = getBuiltInResourceActions();
+  }
+
+  registerAction(action: IResourceAction) {
+    this.registeredActions.push(action);
+  }
+  deregisterAction(id: string) {
+    this.registeredActions = this.registeredActions.filter((action) => action.id.toUpperCase() !== id.toUpperCase());
+  }
+  getActions() {
+    return this.registeredActions;
+  }
+  getAction(id: string) {
+    return this.registeredActions.filter((action) => action.id.toUpperCase() === id.toUpperCase())[0] ?? undefined;
+  }
+  getActionsForResourceType(resType: string[]): IResourceAction[] {
+    return this.registeredActions.filter((action) => resType.includes(action.resourceType));
+  }
+}
+
+const CICSResourceExtender = SCICSResourceExtender.Instance;
+export default CICSResourceExtender;

--- a/packages/vsce/src/resources/actions/LocalFileActions.ts
+++ b/packages/vsce/src/resources/actions/LocalFileActions.ts
@@ -1,0 +1,46 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResourceAction, IResourceContext, ResourceTypes } from "@zowe/cics-for-zowe-explorer-api";
+import { ILocalFile } from "../../doc";
+
+export function getLocalFileActions(): IResourceAction[] {
+  return [
+    {
+      id: "CICS.CICSLocalFile.OPEN",
+      name: "Open Local File",
+      resourceType: ResourceTypes.CICSLocalFile,
+      visibleWhen: (localFile: ILocalFile, _cx: IResourceContext) => localFile.openstatus !== "OPEN",
+      action: "cics-extension-for-zowe.openLocalFile",
+    },
+    {
+      id: "CICS.CICSLocalFile.CLOSE",
+      name: "Close Local File",
+      resourceType: ResourceTypes.CICSLocalFile,
+      visibleWhen: (localFile: ILocalFile, _cx: IResourceContext) => localFile.openstatus !== "CLOSED",
+      action: "cics-extension-for-zowe.closeLocalFile",
+    },
+    {
+      id: "CICS.CICSLocalFile.ENABLE",
+      name: "Enable Local File",
+      resourceType: ResourceTypes.CICSLocalFile,
+      visibleWhen: (localFile: ILocalFile, _cx: IResourceContext) => localFile.openstatus !== "ENABLED",
+      action: "cics-extension-for-zowe.enableLocalFile",
+    },
+    {
+      id: "CICS.CICSLocalFile.DISABLE",
+      name: "Disable Local File",
+      resourceType: ResourceTypes.CICSLocalFile,
+      visibleWhen: (localFile: ILocalFile, _cx: IResourceContext) => localFile.openstatus !== "DISABLED",
+      action: "cics-extension-for-zowe.disableLocalFile",
+    },
+  ];
+}

--- a/packages/vsce/src/resources/actions/ProgramActions.ts
+++ b/packages/vsce/src/resources/actions/ProgramActions.ts
@@ -1,0 +1,50 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResourceAction, IResourceContext, ResourceTypes } from "@zowe/cics-for-zowe-explorer-api";
+import { IProgram } from "../../doc";
+
+export function getProgramActions(): IResourceAction[] {
+  return [
+    {
+      id: "CICS.CICSProgram.NEWCOPY",
+      name: "New Copy",
+      resourceType: ResourceTypes.CICSProgram,
+      action: "cics-extension-for-zowe.newCopyProgram",
+    },
+    {
+      id: "CICS.CICSProgram.PHASEIN",
+      name: "Phase In",
+      resourceType: ResourceTypes.CICSProgram,
+      action: "cics-extension-for-zowe.phaseInCommand",
+    },
+    {
+      id: "CICS.CICSProgram.DISABLE",
+      name: "Disable",
+      resourceType: ResourceTypes.CICSProgram,
+      visibleWhen: (program: IProgram, _cx: IResourceContext) => program.enablestatus !== "DISABLED",
+      action: "cics-extension-for-zowe.disableProgram",
+    },
+    {
+      id: "CICS.CICSProgram.ENABLE",
+      name: "Enable",
+      resourceType: ResourceTypes.CICSProgram,
+      visibleWhen: (program: IProgram, _cx: IResourceContext) => program.enablestatus !== "ENABLED",
+      action: "cics-extension-for-zowe.enableProgram",
+    },
+    {
+      id: "CICS.CICSProgram.SHOWLIBRARY",
+      name: "Show Library",
+      resourceType: ResourceTypes.CICSProgram,
+      action: "cics-extension-for-zowe.showLibrary",
+    },
+  ];
+}

--- a/packages/vsce/src/resources/actions/index.ts
+++ b/packages/vsce/src/resources/actions/index.ts
@@ -1,0 +1,24 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IResourceAction } from "@zowe/cics-for-zowe-explorer-api";
+import { getLocalFileActions } from "./LocalFileActions";
+import { getProgramActions } from "./ProgramActions";
+
+export function getBuiltInResourceActions(): IResourceAction[] {
+  return [
+    ...getProgramActions(),
+    ...getLocalFileActions(),
+  ];
+}
+
+export * from "./LocalFileActions";
+export * from "./ProgramActions";

--- a/packages/vsce/src/webviews/common/vscode.ts
+++ b/packages/vsce/src/webviews/common/vscode.ts
@@ -9,13 +9,26 @@
  *
  */
 
+import { IResource } from "@zowe/cics-for-zowe-explorer-api";
+
 // @ts-ignore
 const vscode = acquireVsCodeApi();
 
 export interface TransformWebviewMessage {
   command: string;
-  data?: any;
-  payload?: unknown;
+  data?: {
+    name: string;
+    resourceName: string;
+    humanReadableNameSingular: string;
+    highlights: { key: string; value: string; }[];
+    resource: IResource;
+    profileHandler: { key: string; value: string; }[];
+  };
+  actions?: {
+    id: string;
+    name: string;
+  }[];
+  actionId?: string;
 }
 
 export function postVscMessage(

--- a/packages/vsce/src/webviews/resource-inspector-panel/ResourceInspector.tsx
+++ b/packages/vsce/src/webviews/resource-inspector-panel/ResourceInspector.tsx
@@ -14,7 +14,7 @@ import { VscodeTextfield } from "@vscode-elements/react-elements";
 import * as React from "react";
 import * as vscode from "../common/vscode";
 
-import { IResource } from "../../doc";
+import { IResource } from "@zowe/cics-for-zowe-explorer-api";
 import "../css/style.css";
 import Breadcrumb from "./Breadcrumb";
 
@@ -26,12 +26,21 @@ const ResourceInspector = () => {
     humanReadableNameSingular: string;
     highlights: { key: string; value: string; }[];
     resource: IResource;
-    profileHandler: { key: string; value: string }[];
+    profileHandler: { key: string; value: string; }[];
   }>();
+  const [resourceActions, setResourceActions] = React.useState<{
+    id: string;
+    name: string;
+  }[]>([]);
+
+  const handleActionClick = (actionId: string) => {
+    vscode.postVscMessage({ command: "action", actionId });
+  };
 
   React.useEffect(() => {
     const listener = (event: MessageEvent<vscode.TransformWebviewMessage>): void => {
       setResourceInfo(event.data.data);
+      setResourceActions(event.data.actions);
     };
     vscode.addVscMessageListener(listener);
     const handleScroll = () => {
@@ -69,7 +78,9 @@ const ResourceInspector = () => {
           <th id="th-1" className="header-cell-1 padding-left-10">
             <div className="div-display-1">{resourceInfo?.name ?? "..."}</div>
             <div className="div-display-1 div-display-2">
-              {resourceInfo?.humanReadableNameSingular ?? "..."}: {resourceInfo ? (resourceInfo?.resource.status || resourceInfo?.resource.enablestatus) : "..."}
+              {resourceInfo?.humanReadableNameSingular ?? "..."}: {
+                // @ts-ignore
+                resourceInfo ? (resourceInfo?.resource.status || resourceInfo?.resource.enablestatus) : "..."}
             </div>
           </th>
         </thead>


### PR DESCRIPTION
**What It Does**
Adds a resourceExtender class to our API (not yet exposed) to allow actions to be registered against resource types. This will allow us to offer a set of available actions to perform on views like Resource Inspector.

An example would be registering a NewCopy action against CICSPrograms.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
