### PR TITLE
Store maximum resource length in meta files for validation

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
+## Recent Changes
+
+- Validate input using maximum resource length when inspecting resource. [#402](https://github.com/zowe/cics-for-zowe-client/issues/402)
+
 ## `3.11.0`
 
 - Enhancement: Added JVM server to the tree node. [#391](https://github.com/zowe/cics-for-zowe-client/issues/391)

--- a/packages/vsce/__tests__/__unit__/doc/meta.library.test.ts
+++ b/packages/vsce/__tests__/__unit__/doc/meta.library.test.ts
@@ -54,6 +54,11 @@ describe("Library Meta", () => {
     const iconName = LibraryMeta.getIconName(libraryMock);
     expect(iconName).toEqual(`library`);
   });
+  it("should return icon name when disabled", () => {
+    libraryMock.attributes.enablestatus = "DISABLED";
+    const iconName = LibraryMeta.getIconName(libraryMock);
+    expect(iconName).toEqual(`library-disabled`);
+  });
   it("should get name", () => {
     const name = LibraryMeta.getName(libraryMock);
     expect(name).toEqual("LIB1");

--- a/packages/vsce/__tests__/__unit__/doc/meta.librarydataset.test.ts
+++ b/packages/vsce/__tests__/__unit__/doc/meta.librarydataset.test.ts
@@ -38,7 +38,7 @@ describe("Library Dataset Meta", () => {
 
   it("should build criteria", () => {
     const crit = LibraryDatasetMeta.buildCriteria(["a", "b"], parentLibraryMock.attributes);
-    expect(crit).toEqual(`(LIBRARY='LIB1') AND (DSNAME='a' OR DSNAME='b')`);
+    expect(crit).toEqual(`(DSNAME='a' OR DSNAME='b') AND (LIBRARY='LIB1')`);
   });
   it("should get default criteria", async () => {
     const crit = await LibraryDatasetMeta.getDefaultCriteria(parentLibraryMock.attributes);

--- a/packages/vsce/src/commands/inspectResourceCommandUtils.ts
+++ b/packages/vsce/src/commands/inspectResourceCommandUtils.ts
@@ -223,14 +223,12 @@ async function getChoiceFromQuickPick(
 async function getEntryFromInputBox(resourceType: IResourceMeta<IResource>): Promise<string | undefined> {
   const options: InputBoxOptions = {
     prompt: CICSMessages.CICSEnterResourceName.message.replace("%resource-human-readable%", resourceType.humanReadableNameSingular),
-    value: "",
-    validateInput: function (value: string): string {
-      if (resourceType === TransactionMeta && value.length > constants.MAX_TRANS_RESOURCE_NAME_LENGTH) {
-        return CICSMessages.CICSInvalidResourceNameLength.message.replace("%length%", String(constants.MAX_TRANS_RESOURCE_NAME_LENGTH));
-      } else if (resourceType !== TransactionMeta && value.length > constants.MAX_RESOURCE_NAME_LENGTH) {
-        return CICSMessages.CICSInvalidResourceNameLength.message.replace("%length%", String(constants.MAX_RESOURCE_NAME_LENGTH));
-      }
-      return undefined;
+
+    validateInput: (value: string): string | undefined => {
+      const maxLength = resourceType.maximumPrimaryKeyLength ?? constants.MAX_RESOURCE_NAME_LENGTH;
+      const tooLongErrorMessage = CICSMessages.CICSInvalidResourceNameLength.message.replace("%length%", `${maxLength}`);
+
+      return value.length > maxLength ? tooLongErrorMessage : undefined;
     }
   };
 

--- a/packages/vsce/src/doc/meta/IResourceMeta.ts
+++ b/packages/vsce/src/doc/meta/IResourceMeta.ts
@@ -28,6 +28,7 @@ export interface IResourceMeta<T extends IResource> {
   getCriteriaHistory(): string[];
   appendCriteriaHistory(criteria: string): Promise<void>;
 
+  maximumPrimaryKeyLength?: number;
   childType?: IResourceMeta<IResource>;
   filterCaseSensitive?: boolean;
 }

--- a/packages/vsce/src/doc/meta/bundlePart.meta.ts
+++ b/packages/vsce/src/doc/meta/bundlePart.meta.ts
@@ -23,7 +23,11 @@ export const BundlePartMeta: IResourceMeta<IBundlePart> = {
   humanReadableNameSingular: "Bundle Part",
 
   buildCriteria(criteria: string[], parentResource?: IBundle) {
-    return `(${criteria.map((n) => `BUNDLEPART='${n}'`).join(" OR ")}) AND (BUNDLE='${parentResource.name}')`;
+    let criteriaString = `(${criteria.map((n) => `BUNDLEPART='${n}'`).join(" OR ")})`;
+    if (parentResource) {
+      criteriaString += ` AND (BUNDLE='${parentResource.name}')`;
+    }
+    return criteriaString;
   },
 
   getDefaultCriteria: function (parentResource: IBundle) {
@@ -35,9 +39,8 @@ export const BundlePartMeta: IResourceMeta<IBundlePart> = {
   },
 
   getContext: function (bundlePart: Resource<IBundlePart>): string {
-    return `${
-      CicsCmciConstants.CICS_CMCI_BUNDLE_PART
-    }.${bundlePart.attributes.enablestatus.trim().toUpperCase()}.${bundlePart.attributes.bundlepart}`;
+    return `${CicsCmciConstants.CICS_CMCI_BUNDLE_PART
+      }.${bundlePart.attributes.enablestatus.trim().toUpperCase()}.${bundlePart.attributes.bundlepart}`;
   },
 
   getIconName: function (_bundlePart: Resource<IBundlePart>): string {
@@ -66,4 +69,5 @@ export const BundlePartMeta: IResourceMeta<IBundlePart> = {
   },
 
   filterCaseSensitive: true,
+  maximumPrimaryKeyLength: 255,
 };

--- a/packages/vsce/src/doc/meta/libraryDataset.meta.ts
+++ b/packages/vsce/src/doc/meta/libraryDataset.meta.ts
@@ -38,7 +38,11 @@ export const LibraryDatasetMeta: IResourceMeta<ILibraryDataset> = {
   humanReadableNameSingular: "Library Dataset",
 
   buildCriteria(criteria: string[], parentResource: ILibrary) {
-    return `(LIBRARY='${parentResource.name}') AND (${criteria.map((n) => `DSNAME='${n}'`).join(" OR ")})`;
+    let criteriaString = `(${criteria.map((n) => `DSNAME='${n}'`).join(" OR ")})`;
+    if (parentResource) {
+      criteriaString += ` AND (LIBRARY='${parentResource.name}')`;
+    }
+    return criteriaString;
   },
 
   getDefaultCriteria: function (parentResource: ILibrary) {
@@ -79,4 +83,5 @@ export const LibraryDatasetMeta: IResourceMeta<ILibraryDataset> = {
   },
 
   childType: customProgramMeta,
+  maximumPrimaryKeyLength: 44,
 };

--- a/packages/vsce/src/doc/meta/task.meta.ts
+++ b/packages/vsce/src/doc/meta/task.meta.ts
@@ -80,4 +80,6 @@ export const TaskMeta: IResourceMeta<ITask> = {
   getCriteriaHistory() {
     return persistentStorage.getTransactionSearchHistory();
   },
+
+  maximumPrimaryKeyLength: 4,
 };

--- a/packages/vsce/src/doc/meta/transaction.meta.ts
+++ b/packages/vsce/src/doc/meta/transaction.meta.ts
@@ -72,4 +72,6 @@ export const TransactionMeta: IResourceMeta<ITransaction> = {
   getCriteriaHistory() {
     return persistentStorage.getTransactionSearchHistory();
   },
+
+  maximumPrimaryKeyLength: 4,
 };

--- a/packages/vsce/src/doc/meta/webservice.meta.ts
+++ b/packages/vsce/src/doc/meta/webservice.meta.ts
@@ -57,4 +57,6 @@ export const WebServiceMeta: IResourceMeta<IWebService> = {
   getCriteriaHistory() {
     return persistentStorage.getWebServiceSearchHistory();
   },
+
+  maximumPrimaryKeyLength: 32,
 };


### PR DESCRIPTION
**What It Does**
Stores the maxium primary key length in the meta file for each resource, if it's not the default value of 8, to be used to validate users' inputs when inspecting resources in the command palette.

This will allow new resources to have custom lengths rather than being restricted to 8

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**

https://github.com/user-attachments/assets/ca5094ef-f21d-4d09-a463-bb2e8ff53e66
