### PR TITLE
Refactor PersistentStorage to reduce repeated code

### DIFF
--- a/packages/vsce/__tests__/__unit__/trees/CICSPlexTree.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/trees/CICSPlexTree.unit.test.ts
@@ -23,7 +23,7 @@ import * as vscode from "vscode";
 import { CICSPlexTree } from "../../../src/trees/CICSPlexTree";
 import { CICSRegionTree } from "../../../src/trees/CICSRegionTree";
 import { CICSSessionTree } from "../../../src/trees/CICSSessionTree";
-import { PersistentStorage } from "../../../src/utils/PersistentStorage";
+import PersistentStorage from "../../../src/utils/PersistentStorage";
 import * as globalMocks from "../../__utils__/globalMocks";
 
 const defaultFilterMock = jest.fn();
@@ -31,7 +31,7 @@ defaultFilterMock.mockReturnValue("DEFAULT FITLER");
 const defaultResNumberMock = jest.fn();
 defaultResNumberMock.mockReturnValue(10);
 
-PersistentStorage.getDefaultFilter = defaultFilterMock;
+PersistentStorage.getDefaultResourceFilter = defaultFilterMock;
 PersistentStorage.getNumberOfResourcesToFetch = defaultResNumberMock;
 
 jest.mock("../../../src/trees/CICSRegionsContainer", () => ({

--- a/packages/vsce/__tests__/__unit__/trees/CICSRegionTree.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/trees/CICSRegionTree.unit.test.ts
@@ -34,7 +34,7 @@ jest.mock("../../../src/utils/profileManagement", () => ({
 import { CICSTree } from "../../../src/trees";
 import { CICSRegionTree } from "../../../src/trees/CICSRegionTree";
 import { CICSSessionTree } from "../../../src/trees/CICSSessionTree";
-import { PersistentStorage } from "../../../src/utils/PersistentStorage";
+import PersistentStorage from "../../../src/utils/PersistentStorage";
 import * as globalMocks from "../../__utils__/globalMocks";
 
 const defaultFilterMock = jest.fn();
@@ -42,7 +42,7 @@ defaultFilterMock.mockReturnValue("DEFAULT FITLER");
 const defaultResNumberMock = jest.fn();
 defaultResNumberMock.mockReturnValue(10);
 
-PersistentStorage.getDefaultFilter = defaultFilterMock;
+PersistentStorage.getDefaultResourceFilter = defaultFilterMock;
 PersistentStorage.getNumberOfResourcesToFetch = defaultResNumberMock;
 
 const region = {

--- a/packages/vsce/__tests__/__unit__/trees/CICSTree.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/trees/CICSTree.unit.test.ts
@@ -30,15 +30,11 @@ getProfilesCacheMock.mockReturnValue({
 import { CICSTree } from "../../../src/trees/CICSTree";
 
 jest.mock("../../../src/utils/CICSLogger");
-jest.mock("../../../src/utils/PersistentStorage", () => ({
-  get PersistentStorage() {
-    return jest.fn().mockImplementation(() => {
-      return {
-        getLoadedCICSProfile: profilesCacheRefreshMock,
-      };
-    });
-  },
-}));
+
+import PersistentStorage from "../../../src/utils/PersistentStorage";
+const profilesCacheRefreshSpy = jest.spyOn(PersistentStorage, "getLoadedCICSProfiles");
+profilesCacheRefreshSpy.mockReturnValue(["prof1", "prof2"]);
+
 jest.mock("../../../src/utils/profileManagement", () => ({
   ProfileManagement: {
     profilesCacheRefresh: profilesCacheRefreshMock,

--- a/packages/vsce/__tests__/__unit__/utils/PersistentStorage.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/utils/PersistentStorage.unit.test.ts
@@ -1,0 +1,159 @@
+const vscodeGetConfigurationMock = jest.fn();
+const vscodeGetMock = jest.fn();
+const vscodeUpdateMock = jest.fn();
+
+const mockedVSCodeConfig = {
+  get: vscodeGetMock,
+  update: vscodeUpdateMock,
+};
+
+jest.mock("vscode", () => ({
+  workspace: {
+    getConfiguration: vscodeGetConfigurationMock,
+  },
+  ConfigurationTarget: {
+    Global: "GLOBAL"
+  }
+}));
+
+import { ILastUsedRegion } from "../../../src/doc/commands/ILastUsedRegion";
+import PersistentStorage from "../../../src/utils/PersistentStorage";
+
+
+const lastUsedRegion: ILastUsedRegion = {
+  cicsPlexName: "MYPLEX",
+  profileName: "MYPROFILE",
+  regionName: "MYREG",
+};
+
+describe("PersistentStorage test suite", () => {
+
+  beforeEach(() => {
+    vscodeGetMock.mockReset();
+    vscodeUpdateMock.mockReset();
+    vscodeGetConfigurationMock.mockReset();
+    vscodeGetConfigurationMock.mockReturnValue(mockedVSCodeConfig);
+  });
+
+  it("should get lastUsedRegion", () => {
+    vscodeGetMock.mockReturnValue(lastUsedRegion);
+    const region = PersistentStorage.getLastUsedRegion();
+
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledWith("zowe.cics.persistent");
+    expect(region).toEqual(lastUsedRegion);
+  });
+
+  it("should set lastUsedRegion", async () => {
+    await PersistentStorage.setLastUsedRegion(lastUsedRegion);
+
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledTimes(2);
+    expect(vscodeUpdateMock).toHaveBeenCalledTimes(1);
+    expect(vscodeUpdateMock).toHaveBeenCalledWith("zowe.cics.persistent", { ...mockedVSCodeConfig, lastUsedRegion }, "GLOBAL");
+  });
+
+  it("should get search history", () => {
+    vscodeGetMock.mockReturnValue(["prog1", "prog2"]);
+    const history = PersistentStorage.getSearchHistory("CICSProgram");
+
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledWith("zowe.cics.persistent");
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith("programSearchHistory", []);
+    expect(history).toHaveLength(2);
+    expect(history[0]).toEqual("prog1");
+    expect(history[1]).toEqual("prog2");
+  });
+
+  it("should get search history for resource not in map", () => {
+    const history = PersistentStorage.getSearchHistory("MADEUPTHING");
+
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledWith("zowe.cics.persistent");
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith(undefined, []);
+    expect(history).toBeUndefined();
+  });
+
+  it("should append search history", async () => {
+    vscodeGetMock.mockReturnValue(["1", "2"]);
+    await PersistentStorage.appendSearchHistory("CICSLocalFile", "MYSRCH*");
+
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledTimes(3);
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith("localFileSearchHistory", []);
+    expect(vscodeUpdateMock).toHaveBeenCalledTimes(1);
+    expect(vscodeUpdateMock).toHaveBeenCalledWith("zowe.cics.persistent", { ...mockedVSCodeConfig, localFileSearchHistory: ["MYSRCH*", "1", "2"] }, "GLOBAL");
+  });
+
+  it("should append search history when 10 items are already there", async () => {
+    vscodeGetMock.mockReturnValue(["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]);
+    await PersistentStorage.appendSearchHistory("CICSLocalFile", "MYSRCH*");
+
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledTimes(3);
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith("localFileSearchHistory", []);
+    expect(vscodeUpdateMock).toHaveBeenCalledTimes(1);
+    expect(vscodeUpdateMock).toHaveBeenCalledWith("zowe.cics.persistent", { ...mockedVSCodeConfig, localFileSearchHistory: ["MYSRCH*", "1", "2", "3", "4", "5", "6", "7", "8", "9"] }, "GLOBAL");
+  });
+
+  it("should get loaded cics profiles", () => {
+    vscodeGetMock.mockReturnValue(["prof1", "prof2"]);
+    const profiles = PersistentStorage.getLoadedCICSProfiles();
+
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledWith("zowe.cics.persistent");
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith("loadedCICSProfile", []);
+    expect(profiles).toHaveLength(2);
+    expect(profiles[0]).toEqual("prof1");
+    expect(profiles[1]).toEqual("prof2");
+  });
+
+  it("should append to loaded cics profile", async () => {
+    vscodeGetMock.mockReturnValue(["prof1"]);
+    await PersistentStorage.appendLoadedCICSProfile("NEW PROF");
+
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledTimes(3);
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith("loadedCICSProfile", []);
+    expect(vscodeUpdateMock).toHaveBeenCalledTimes(1);
+    expect(vscodeUpdateMock).toHaveBeenCalledWith("zowe.cics.persistent", { ...mockedVSCodeConfig, loadedCICSProfile: ["NEW PROF", "prof1"] }, "GLOBAL");
+  });
+
+  it("should remove a loaded cics profile", async () => {
+    vscodeGetMock.mockReturnValue(["prof1", "prof2"]);
+    await PersistentStorage.removeLoadedCICSProfile("prof1");
+
+    expect(vscodeGetConfigurationMock).toHaveBeenCalledTimes(3);
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith("loadedCICSProfile", []);
+    expect(vscodeUpdateMock).toHaveBeenCalledTimes(1);
+    expect(vscodeUpdateMock).toHaveBeenCalledWith("zowe.cics.persistent", { ...mockedVSCodeConfig, loadedCICSProfile: ["prof2"] }, "GLOBAL");
+  });
+
+  it("should get default filter", () => {
+    vscodeGetMock.mockReturnValue("MY DEFAULT FILTER STORED IN SETTINGS");
+    const defFilter = PersistentStorage.getDefaultResourceFilter("CICSPipeline");
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith("zowe.cics.CICSPipeline.filter", "(NAME=*)");
+    expect(defFilter).toEqual("MY DEFAULT FILTER STORED IN SETTINGS");
+  });
+
+  it("should get default filter with custom key", () => {
+    vscodeGetMock.mockReturnValue("MY DEFAULT FILTER STORED IN SETTINGS");
+    const defFilter = PersistentStorage.getDefaultResourceFilter("CICSPipeline", "CUSTOMKEY");
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith("zowe.cics.CUSTOMKEY.filter", "(NAME=*)");
+    expect(defFilter).toEqual("MY DEFAULT FILTER STORED IN SETTINGS");
+  });
+
+  it("should get number of resources to fetch", () => {
+    vscodeGetMock.mockReturnValue(5);
+    const numToFetch = PersistentStorage.getNumberOfResourcesToFetch();
+
+    expect(vscodeGetMock).toHaveBeenCalledTimes(1);
+    expect(vscodeGetMock).toHaveBeenCalledWith("zowe.cics.resourcePageCount", 250);
+    expect(numToFetch).toEqual(5);
+  });
+});

--- a/packages/vsce/__tests__/__unit__/utils/lastUsedRegionUtils.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/utils/lastUsedRegionUtils.unit.test.ts
@@ -9,8 +9,6 @@
  *
  */
 
-const getLastUsedRegionMock = jest.fn();
-const setLastUsedRegionMock = jest.fn();
 const getLoadedProfilesMock = jest.fn();
 const getAllProfilesMock = jest.fn();
 const getPlexInfoMock = jest.fn();
@@ -35,12 +33,12 @@ jest.mock("@zowe/zowe-explorer-api", () => ({
   },
 }));
 jest.mock("../../../src/utils/CICSLogger");
-jest.mock("../../../src/utils/PersistentStorage", () => ({
-  PersistentStorage: jest.fn().mockImplementation(() => ({
-    getLastUsedRegion: getLastUsedRegionMock,
-    setLastUsedRegion: setLastUsedRegionMock,
-  })),
-}));
+
+import PersistentStorage from "../../../src/utils/PersistentStorage";
+
+const getLastUsedRegionSpy = jest.spyOn(PersistentStorage, 'getLastUsedRegion');
+const setLastUsedRegionSpy = jest.spyOn(PersistentStorage, 'setLastUsedRegion');
+
 jest.mock("../../../src/trees/CICSTree", () => ({
   CICSTree: jest.fn().mockImplementation(() => ({
     getLoadedProfiles: getLoadedProfilesMock,
@@ -80,7 +78,7 @@ describe("Test suite for lastUsedRegionUtils", () => {
       jest.clearAllMocks();
     });
     it("should return the last used region", () => {
-      getLastUsedRegionMock.mockReturnValueOnce(lastUsedRegion);
+      getLastUsedRegionSpy.mockReturnValueOnce(lastUsedRegion);
       const selectedRegion = {
         regionName: "IYK2ZXXX",
         cicsPlexName: "PLEXX",
@@ -89,7 +87,7 @@ describe("Test suite for lastUsedRegionUtils", () => {
       const result = getLastUsedRegion();
 
       expect(result).toEqual(selectedRegion);
-      expect(getLastUsedRegionMock).toHaveBeenCalled();
+      expect(getLastUsedRegionSpy).toHaveBeenCalled();
     });
   });
 
@@ -104,17 +102,17 @@ describe("Test suite for lastUsedRegionUtils", () => {
       const cicsPlexName = "NEWPLEX";
 
       setLastUsedRegion(regionName, profileName, cicsPlexName);
-      expect(setLastUsedRegionMock).toHaveBeenCalledWith({ regionName, cicsPlexName, profileName });
+      expect(setLastUsedRegionSpy).toHaveBeenCalledWith({ regionName, cicsPlexName, profileName });
     });
 
     it("should not set the region if region name is empty string", () => {
       setLastUsedRegion("", "PROFILE");
-      expect(setLastUsedRegionMock).not.toHaveBeenCalled();
+      expect(setLastUsedRegionSpy).not.toHaveBeenCalled();
     });
 
     it("should not set the region if profile name is empty string", () => {
       setLastUsedRegion("REGION", "");
-      expect(setLastUsedRegionMock).not.toHaveBeenCalled();
+      expect(setLastUsedRegionSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -159,30 +157,30 @@ describe("Test suite for lastUsedRegionUtils", () => {
 
     it("should return true if profile name and region name is present", async () => {
       getLoadedProfilesMock.mockReturnValueOnce(loadedProfiles);
-      getLastUsedRegionMock.mockReturnValueOnce(lastUsedRegion);
+      getLastUsedRegionSpy.mockReturnValueOnce(lastUsedRegion);
       const result = await isCICSProfileValidInSettings();
 
-      expect(getLastUsedRegionMock).toHaveBeenCalled();
+      expect(getLastUsedRegionSpy).toHaveBeenCalled();
       expect(getLoadedProfilesMock).toHaveBeenCalled();
       expect(result).toBe(true);
     });
 
     it("should return false if profile name is not present", async () => {
       getLoadedProfilesMock.mockReturnValueOnce(loadedProfiles);
-      getLastUsedRegionMock.mockReturnValueOnce({ regionName: "IYK2XXX", cicsPlexName: "PLEX", profileName: "" });
+      getLastUsedRegionSpy.mockReturnValueOnce({ regionName: "IYK2XXX", cicsPlexName: "PLEX", profileName: "" });
       const result = await isCICSProfileValidInSettings();
 
-      expect(getLastUsedRegionMock).toHaveBeenCalled();
+      expect(getLastUsedRegionSpy).toHaveBeenCalled();
       expect(getLoadedProfilesMock).toHaveBeenCalled();
       expect(result).toBe(false);
     });
 
     it("should return false if profile name is not in the list of profiles", async () => {
       getLoadedProfilesMock.mockReturnValueOnce(loadedProfiles);
-      getLastUsedRegionMock.mockReturnValue({ regionName: "IYK2XXX", profileName: "Profile2" });
+      getLastUsedRegionSpy.mockReturnValue({ regionName: "IYK2XXX", profileName: "Profile2", cicsPlexName: null });
       const result = await isCICSProfileValidInSettings();
 
-      expect(getLastUsedRegionMock).toHaveBeenCalled();
+      expect(getLastUsedRegionSpy).toHaveBeenCalled();
       expect(getLoadedProfilesMock).toHaveBeenCalled();
       expect(result).toBe(false);
     });

--- a/packages/vsce/src/commands/getFilterPlexResources.ts
+++ b/packages/vsce/src/commands/getFilterPlexResources.ts
@@ -14,7 +14,8 @@ import { CICSRegionsContainer } from "../trees";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
 import { getPatternFromFilter } from "../utils/filterUtils";
-import { PersistentStorage } from "../utils/PersistentStorage";
+import PersistentStorage from "../utils/PersistentStorage";
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 
 /**
  * Apply filter for a Regions Container (previously this was available on a plex)
@@ -43,20 +44,19 @@ export function getFilterPlexResources(tree: CICSTree, treeview: TreeView<any>) 
     } else {
       resourceToFilter = await window.showQuickPick(["Regions", "Programs", "Local Transactions", "Local Files", "Tasks", "Libraries"]);
     }
-    const persistentStorage = new PersistentStorage("zowe.cics.persistent");
     let resourceHistory;
     if (resourceToFilter === "Programs") {
-      resourceHistory = persistentStorage.getProgramSearchHistory();
+      resourceHistory = PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_PROGRAM_RESOURCE);
     } else if (resourceToFilter === "Local Transactions") {
-      resourceHistory = persistentStorage.getTransactionSearchHistory();
+      resourceHistory = PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_LOCAL_TRANSACTION);
     } else if (resourceToFilter === "Local Files") {
-      resourceHistory = persistentStorage.getLocalFileSearchHistory();
+      resourceHistory = PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_CMCI_LOCAL_FILE);
     } else if (resourceToFilter === "Tasks") {
-      resourceHistory = persistentStorage.getTransactionSearchHistory();
+      resourceHistory = PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_LOCAL_TRANSACTION);
     } else if (resourceToFilter === "Libraries") {
-      resourceHistory = persistentStorage.getLibrarySearchHistory();
+      resourceHistory = PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_LIBRARY_RESOURCE);
     } else if (resourceToFilter === "Regions") {
-      resourceHistory = persistentStorage.getRegionSearchHistory();
+      resourceHistory = PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_CMCI_REGION);
     } else {
       window.showInformationMessage("No Selection Made");
       return;
@@ -64,17 +64,17 @@ export function getFilterPlexResources(tree: CICSTree, treeview: TreeView<any>) 
     const pattern = await getPatternFromFilter(resourceToFilter.slice(0, -1), resourceHistory);
     if (pattern) {
       if (resourceToFilter === "Programs") {
-        await persistentStorage.addProgramSearchHistory(pattern);
+        await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_PROGRAM_RESOURCE, pattern);
       } else if (resourceToFilter === "Local Transactions") {
-        await persistentStorage.addTransactionSearchHistory(pattern);
+        await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_LOCAL_TRANSACTION, pattern);
       } else if (resourceToFilter === "Local Files") {
-        await persistentStorage.addLocalFileSearchHistory(pattern);
+        await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, pattern);
       } else if (resourceToFilter === "Regions") {
-        await persistentStorage.addRegionSearchHistory(pattern);
+        await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_CMCI_REGION, pattern);
       } else if (resourceToFilter === "Tasks") {
-        await persistentStorage.addTransactionSearchHistory(pattern);
+        await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_LOCAL_TRANSACTION, pattern);
       } else if (resourceToFilter === "Libraries") {
-        await persistentStorage.addLibrarySearchHistory(pattern);
+        await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_LIBRARY_RESOURCE, pattern);
       }
 
       if (resourceToFilter === "Regions") {
@@ -87,7 +87,7 @@ export function getFilterPlexResources(tree: CICSTree, treeview: TreeView<any>) 
             cancellable: true,
           },
           (_, token): Thenable<unknown> => {
-            token.onCancellationRequested(() => {});
+            token.onCancellationRequested(() => { });
             for (const region of chosenNode.children) {
               if (region instanceof CICSRegionTree) {
                 if (region.getIsActive()) {

--- a/packages/vsce/src/doc/meta/IResourceMeta.ts
+++ b/packages/vsce/src/doc/meta/IResourceMeta.ts
@@ -18,7 +18,7 @@ export interface IResourceMeta<T extends IResource> {
   humanReadableNameSingular: string;
 
   buildCriteria(criteria: string[], parentResource?: IResource): string;
-  getDefaultCriteria(parentResource?: IResource): Promise<string>;
+  getDefaultCriteria(parentResource?: IResource): string;
   getLabel(resource: Resource<T>): string;
   getContext(resource: Resource<T>): string;
   getIconName(resource: Resource<T>): string;

--- a/packages/vsce/src/doc/meta/JVMServer.meta.ts
+++ b/packages/vsce/src/doc/meta/JVMServer.meta.ts
@@ -1,10 +1,8 @@
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { IResourceMeta } from "./IResourceMeta";
 import { IJVMServer } from "../resources/IJVMServer";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const JVMServerMeta: IResourceMeta<IJVMServer> = {
   resourceName: CicsCmciConstants.CICS_JVMSERVER_RESOURCE,
@@ -15,8 +13,8 @@ export const JVMServerMeta: IResourceMeta<IJVMServer> = {
     return criteria.map((n) => `name=${n}`).join(" OR ");
   },
 
-  async getDefaultCriteria() {
-    return PersistentStorage.getDefaultFilter(
+  getDefaultCriteria() {
+    return PersistentStorage.getDefaultResourceFilter(
       CicsCmciConstants.CICS_JVMSERVER_RESOURCE,
       "jvmServer"
     );
@@ -56,10 +54,10 @@ export const JVMServerMeta: IResourceMeta<IJVMServer> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addJVMServerSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_JVMSERVER_RESOURCE, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getJVMServerSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_JVMSERVER_RESOURCE);
   },
 };

--- a/packages/vsce/src/doc/meta/bundle.meta.ts
+++ b/packages/vsce/src/doc/meta/bundle.meta.ts
@@ -11,12 +11,10 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { IBundle } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
 import { BundlePartMeta } from "./bundlePart.meta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const BundleMeta: IResourceMeta<IBundle> = {
   resourceName: CicsCmciConstants.CICS_CMCI_BUNDLE,
@@ -28,7 +26,7 @@ export const BundleMeta: IResourceMeta<IBundle> = {
   },
 
   getDefaultCriteria: function () {
-    return Promise.resolve("name=*");
+    return "name=*";
   },
 
   getLabel: function (bundle: Resource<IBundle>): string {
@@ -68,11 +66,11 @@ export const BundleMeta: IResourceMeta<IBundle> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addBundleSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_CMCI_BUNDLE, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getBundleSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_CMCI_BUNDLE);
   },
 
   childType: BundlePartMeta,

--- a/packages/vsce/src/doc/meta/bundlePart.meta.ts
+++ b/packages/vsce/src/doc/meta/bundlePart.meta.ts
@@ -11,11 +11,9 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { IBundle, IBundlePart } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const BundlePartMeta: IResourceMeta<IBundlePart> = {
   resourceName: CicsCmciConstants.CICS_CMCI_BUNDLE_PART,
@@ -31,7 +29,7 @@ export const BundlePartMeta: IResourceMeta<IBundlePart> = {
   },
 
   getDefaultCriteria: function (parentResource: IBundle) {
-    return Promise.resolve(`BUNDLE='${parentResource.name}'`);
+    return `BUNDLE='${parentResource.name}'`;
   },
 
   getLabel: function (bundlePart: Resource<IBundlePart>): string {
@@ -61,11 +59,11 @@ export const BundlePartMeta: IResourceMeta<IBundlePart> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addBundlePartSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_CMCI_BUNDLE_PART, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getBundlePartSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_CMCI_BUNDLE_PART);
   },
 
   filterCaseSensitive: true,

--- a/packages/vsce/src/doc/meta/library.meta.ts
+++ b/packages/vsce/src/doc/meta/library.meta.ts
@@ -11,12 +11,10 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { ILibrary } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
 import { LibraryDatasetMeta } from "./libraryDataset.meta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const LibraryMeta: IResourceMeta<ILibrary> = {
   resourceName: CicsCmciConstants.CICS_LIBRARY_RESOURCE,
@@ -27,8 +25,8 @@ export const LibraryMeta: IResourceMeta<ILibrary> = {
     return criteria.map((n) => `name=${n}`).join(" OR ");
   },
 
-  async getDefaultCriteria() {
-    return PersistentStorage.getDefaultFilter(CicsCmciConstants.CICS_LIBRARY_RESOURCE, "library");
+  getDefaultCriteria() {
+    return PersistentStorage.getDefaultResourceFilter(CicsCmciConstants.CICS_LIBRARY_RESOURCE, "library");
   },
 
   getLabel: function (resource: Resource<ILibrary>): string {
@@ -66,11 +64,11 @@ export const LibraryMeta: IResourceMeta<ILibrary> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addLibrarySearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_LIBRARY_RESOURCE, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getLibrarySearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_LIBRARY_RESOURCE);
   },
 
   childType: LibraryDatasetMeta,

--- a/packages/vsce/src/doc/meta/libraryDataset.meta.ts
+++ b/packages/vsce/src/doc/meta/libraryDataset.meta.ts
@@ -11,16 +11,14 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { ILibrary, ILibraryDataset, IProgram } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
 import { ProgramMeta } from "./program.meta";
 
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
-
 const customProgramMeta = { ...ProgramMeta };
 customProgramMeta.getDefaultCriteria = (parentResource: ILibraryDataset) => {
-  return Promise.resolve(`(LIBRARYDSN='${parentResource.dsname}')`);
+  return `(LIBRARYDSN='${parentResource.dsname}')`;
 };
 
 customProgramMeta.getContext = function (program: Resource<IProgram>): string {
@@ -46,7 +44,7 @@ export const LibraryDatasetMeta: IResourceMeta<ILibraryDataset> = {
   },
 
   getDefaultCriteria: function (parentResource: ILibrary) {
-    return Promise.resolve(`LIBRARY=${parentResource.name}`);
+    return `LIBRARY=${parentResource.name}`;
   },
 
   getLabel: function (resource: Resource<ILibraryDataset>): string {
@@ -75,11 +73,11 @@ export const LibraryDatasetMeta: IResourceMeta<ILibraryDataset> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addDatasetSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_LIBRARY_DATASET_RESOURCE, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getDatasetSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_LIBRARY_DATASET_RESOURCE);
   },
 
   childType: customProgramMeta,

--- a/packages/vsce/src/doc/meta/localFile.meta.ts
+++ b/packages/vsce/src/doc/meta/localFile.meta.ts
@@ -11,11 +11,9 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { ILocalFile } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const LocalFileMeta: IResourceMeta<ILocalFile> = {
   resourceName: CicsCmciConstants.CICS_CMCI_LOCAL_FILE,
@@ -26,8 +24,8 @@ export const LocalFileMeta: IResourceMeta<ILocalFile> = {
     return criteria.map((n) => `file=${n}`).join(" OR ");
   },
 
-  async getDefaultCriteria () {
-    return PersistentStorage.getDefaultFilter(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, "localFile");
+  getDefaultCriteria() {
+    return PersistentStorage.getDefaultResourceFilter(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, "localFile");
   },
 
   getLabel: function (localFile: Resource<ILocalFile>): string {
@@ -47,9 +45,8 @@ export const LocalFileMeta: IResourceMeta<ILocalFile> = {
   },
 
   getContext: function (localFile: Resource<ILocalFile>): string {
-    return `${
-      CicsCmciConstants.CICS_CMCI_LOCAL_FILE
-    }.${localFile.attributes.enablestatus.toUpperCase()}.${localFile.attributes.openstatus.toUpperCase()}.${localFile.attributes.file}`;
+    return `${CicsCmciConstants.CICS_CMCI_LOCAL_FILE
+      }.${localFile.attributes.enablestatus.toUpperCase()}.${localFile.attributes.openstatus.toUpperCase()}.${localFile.attributes.file}`;
   },
 
   getIconName: function (localFile: Resource<ILocalFile>): string {
@@ -101,10 +98,10 @@ export const LocalFileMeta: IResourceMeta<ILocalFile> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addLocalFileSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getLocalFileSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_CMCI_LOCAL_FILE);
   },
 };

--- a/packages/vsce/src/doc/meta/pipeline.meta.ts
+++ b/packages/vsce/src/doc/meta/pipeline.meta.ts
@@ -11,11 +11,9 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { IPipeline } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const PipelineMeta: IResourceMeta<IPipeline> = {
   resourceName: CicsCmciConstants.CICS_PIPELINE_RESOURCE,
@@ -26,8 +24,8 @@ export const PipelineMeta: IResourceMeta<IPipeline> = {
     return criteria.map((n) => `name=${n}`).join(" OR ");
   },
 
-  async getDefaultCriteria () {
-    return PersistentStorage.getDefaultFilter(CicsCmciConstants.CICS_PIPELINE_RESOURCE, "pipeline");
+  getDefaultCriteria() {
+    return PersistentStorage.getDefaultResourceFilter(CicsCmciConstants.CICS_PIPELINE_RESOURCE, "pipeline");
   },
 
   getLabel: function (resource: Resource<IPipeline>): string {
@@ -51,10 +49,10 @@ export const PipelineMeta: IResourceMeta<IPipeline> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addPipelineSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_PIPELINE_RESOURCE, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getPipelineSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_PIPELINE_RESOURCE);
   },
 };

--- a/packages/vsce/src/doc/meta/program.meta.ts
+++ b/packages/vsce/src/doc/meta/program.meta.ts
@@ -11,11 +11,9 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { IProgram } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const ProgramMeta: IResourceMeta<IProgram> = {
   resourceName: CicsCmciConstants.CICS_PROGRAM_RESOURCE,
@@ -26,8 +24,8 @@ export const ProgramMeta: IResourceMeta<IProgram> = {
     return criteria.map((n) => `PROGRAM=${n}`).join(" OR ");
   },
 
-  async getDefaultCriteria() {
-    return PersistentStorage.getDefaultFilter(CicsCmciConstants.CICS_PROGRAM_RESOURCE, "program");
+  getDefaultCriteria() {
+    return PersistentStorage.getDefaultResourceFilter(CicsCmciConstants.CICS_PROGRAM_RESOURCE, "program");
   },
 
   getLabel: function (program: Resource<IProgram>): string {
@@ -68,11 +66,11 @@ export const ProgramMeta: IResourceMeta<IProgram> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addProgramSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_PROGRAM_RESOURCE, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getProgramSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_PROGRAM_RESOURCE);
   },
 
   getName(program: Resource<IProgram>): string {

--- a/packages/vsce/src/doc/meta/task.meta.ts
+++ b/packages/vsce/src/doc/meta/task.meta.ts
@@ -11,11 +11,9 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { ITask } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const TaskMeta: IResourceMeta<ITask> = {
   resourceName: CicsCmciConstants.CICS_CMCI_TASK,
@@ -27,7 +25,7 @@ export const TaskMeta: IResourceMeta<ITask> = {
   },
 
   getDefaultCriteria: function () {
-    return PersistentStorage.getDefaultFilter(CicsCmciConstants.CICS_CMCI_TASK, "tasks");
+    return PersistentStorage.getDefaultResourceFilter(CicsCmciConstants.CICS_CMCI_TASK, "tasks");
   },
 
   getLabel: function (resource: Resource<ITask>): string {
@@ -74,11 +72,11 @@ export const TaskMeta: IResourceMeta<ITask> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addTransactionSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_LOCAL_TRANSACTION, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getTransactionSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_LOCAL_TRANSACTION);
   },
 
   maximumPrimaryKeyLength: 4,

--- a/packages/vsce/src/doc/meta/tcpip.meta.ts
+++ b/packages/vsce/src/doc/meta/tcpip.meta.ts
@@ -11,11 +11,9 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { ITCPIP } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const TCPIPMeta: IResourceMeta<ITCPIP> = {
   resourceName: CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE,
@@ -27,7 +25,7 @@ export const TCPIPMeta: IResourceMeta<ITCPIP> = {
   },
 
   getDefaultCriteria: function () {
-    return PersistentStorage.getDefaultFilter(CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE, "tcpipService");
+    return PersistentStorage.getDefaultResourceFilter(CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE, "tcpipService");
   },
 
   getLabel: function (resource: Resource<ITCPIP>): string {
@@ -62,10 +60,10 @@ export const TCPIPMeta: IResourceMeta<ITCPIP> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addTCPIPSSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getTCPIPSSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_TCPIPSERVICE_RESOURCE);
   },
 };

--- a/packages/vsce/src/doc/meta/transaction.meta.ts
+++ b/packages/vsce/src/doc/meta/transaction.meta.ts
@@ -11,11 +11,9 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { ITransaction } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const TransactionMeta: IResourceMeta<ITransaction> = {
   resourceName: CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION,
@@ -26,8 +24,8 @@ export const TransactionMeta: IResourceMeta<ITransaction> = {
     return criteria.map((n) => `TRANID=${n}`).join(" OR ");
   },
 
-  async getDefaultCriteria() {
-    return PersistentStorage.getDefaultFilter(CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION, "transaction");
+  getDefaultCriteria() {
+    return PersistentStorage.getDefaultResourceFilter(CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION, "transaction");
   },
 
   getLabel: function (transaction: Resource<ITransaction>): string {
@@ -66,11 +64,11 @@ export const TransactionMeta: IResourceMeta<ITransaction> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addTransactionSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getTransactionSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_CMCI_LOCAL_TRANSACTION);
   },
 
   maximumPrimaryKeyLength: 4,

--- a/packages/vsce/src/doc/meta/urimap.meta.ts
+++ b/packages/vsce/src/doc/meta/urimap.meta.ts
@@ -11,11 +11,9 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { IURIMap } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const URIMapMeta: IResourceMeta<IURIMap> = {
   resourceName: CicsCmciConstants.CICS_URIMAP,
@@ -27,7 +25,7 @@ export const URIMapMeta: IResourceMeta<IURIMap> = {
   },
 
   getDefaultCriteria: function () {
-    return PersistentStorage.getDefaultFilter(CicsCmciConstants.CICS_URIMAP, "uriMap");
+    return PersistentStorage.getDefaultResourceFilter(CicsCmciConstants.CICS_URIMAP, "uriMap");
   },
 
   getLabel: function (resource: Resource<IURIMap>): string {
@@ -65,10 +63,10 @@ export const URIMapMeta: IResourceMeta<IURIMap> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addURIMapsSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_URIMAP, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getURIMapSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_URIMAP);
   },
 };

--- a/packages/vsce/src/doc/meta/webservice.meta.ts
+++ b/packages/vsce/src/doc/meta/webservice.meta.ts
@@ -11,11 +11,9 @@
 
 import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 import { Resource } from "../../resources/Resource";
-import { PersistentStorage } from "../../utils/PersistentStorage";
+import PersistentStorage from "../../utils/PersistentStorage";
 import { IWebService } from "../resources";
 import { IResourceMeta } from "./IResourceMeta";
-
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
 
 export const WebServiceMeta: IResourceMeta<IWebService> = {
   resourceName: CicsCmciConstants.CICS_WEBSERVICE_RESOURCE,
@@ -27,7 +25,7 @@ export const WebServiceMeta: IResourceMeta<IWebService> = {
   },
 
   getDefaultCriteria: function () {
-    return PersistentStorage.getDefaultFilter(CicsCmciConstants.CICS_WEBSERVICE_RESOURCE, "webService");
+    return PersistentStorage.getDefaultResourceFilter(CicsCmciConstants.CICS_WEBSERVICE_RESOURCE, "webService");
   },
 
   getLabel: function (resource: Resource<IWebService>): string {
@@ -51,11 +49,11 @@ export const WebServiceMeta: IResourceMeta<IWebService> = {
   },
 
   async appendCriteriaHistory(criteria: string) {
-    await persistentStorage.addWebServiceSearchHistory(criteria);
+    await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_WEBSERVICE_RESOURCE, criteria);
   },
 
   getCriteriaHistory() {
-    return persistentStorage.getWebServiceSearchHistory();
+    return PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_WEBSERVICE_RESOURCE);
   },
 
   maximumPrimaryKeyLength: 32,

--- a/packages/vsce/src/resources/ResourceContainer.ts
+++ b/packages/vsce/src/resources/ResourceContainer.ts
@@ -13,7 +13,7 @@ import { CICSSession, CicsCmciConstants, getCache } from "@zowe/cics-for-zowe-sd
 import { imperative } from "@zowe/zowe-explorer-api";
 import constants from "../constants/CICS.defaults";
 import { IResource, IResourceMeta } from "../doc";
-import { PersistentStorage } from "../utils/PersistentStorage";
+import PersistentStorage from "../utils/PersistentStorage";
 import { toArray } from "../utils/commandUtils";
 import { runGetResource } from "../utils/resourceUtils";
 import { Resource } from "./Resource";
@@ -91,8 +91,8 @@ export class ResourceContainer<T extends IResource> {
     this.numberToFetch = num;
   }
 
-  async resetNumberToFetch() {
-    this.numberToFetch = await PersistentStorage.getNumberOfResourcesToFetch();
+  resetNumberToFetch() {
+    this.numberToFetch = PersistentStorage.getNumberOfResourcesToFetch();
   }
 
   /**

--- a/packages/vsce/src/trees/CICSResourceContainerNode.ts
+++ b/packages/vsce/src/trees/CICSResourceContainerNode.ts
@@ -172,7 +172,7 @@ export class CICSResourceContainerNode<T extends IResource> extends CICSTreeNode
     await this.loadPageOfResources();
     this.refreshIcon(true);
     this.viewMore = false;
-    await this.childResource.resources.resetNumberToFetch();
+    this.childResource.resources.resetNumberToFetch();
     return this.children;
   }
 

--- a/packages/vsce/src/utils/lastUsedRegionUtils.ts
+++ b/packages/vsce/src/utils/lastUsedRegionUtils.ts
@@ -15,18 +15,16 @@ import { Gui } from "@zowe/zowe-explorer-api";
 import { l10n, QuickPick, QuickPickItem } from "vscode";
 import { CICSTree } from "../trees";
 import { CICSLogger } from "./CICSLogger";
-import { PersistentStorage } from "./PersistentStorage";
+import PersistentStorage from "./PersistentStorage";
 import { InfoLoaded, ProfileManagement } from "./profileManagement";
 
-const persistentStorage = new PersistentStorage("zowe.cics.persistent");
-
 export function getLastUsedRegion(): { profileName: string; regionName: string; cicsPlexName: string } {
-  return persistentStorage.getLastUsedRegion();
+  return PersistentStorage.getLastUsedRegion();
 }
 
 export function setLastUsedRegion(regionName: string, profileName: string, cicsPlexName?: string) {
   if (regionName != null && profileName != undefined && regionName.length > 0 && profileName.length > 0) {
-    persistentStorage.setLastUsedRegion({ regionName, cicsPlexName, profileName });
+    PersistentStorage.setLastUsedRegion({ regionName, cicsPlexName, profileName });
     CICSLogger.info(`Region set to ${regionName} for profile ${profileName} and plex ${cicsPlexName}`);
   }
   //on error, do not update region


### PR DESCRIPTION
**What It Does**
Genericises the PersistentStorage class methods to prevent having a set of 4 methods for EACH resource type.
Also converts to a singleton to prevent instantiating it in each file we use it.

This, in turn, allows you to inspect CICSLibraryDatasetName and CICSBundlePart resources from the command palette, as it adds them to the list of supported resources. This builds on top of the PR to validate those input lengths.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
