### PR TITLE
Update README.md with valid but simple Zowe config

### DIFF
--- a/packages/vsce/README.md
+++ b/packages/vsce/README.md
@@ -91,7 +91,7 @@ The following example shows a CICS profile stored in a configuration file. The h
             "type": "cics",
             "properties": {
                 // replace the host, port, and protocol with your CMCI connection details
-                "host": "cics-cmci.example.com",
+                "host": "cics.example.com",
                 "port": 1490,
                 "protocol": "https",
                 // reject self-signed server certificates if using https?


### PR DESCRIPTION
**What It Does**
Minor update to the sample Zowe config in the readme to make it valid "out of the box".

Tested by copying/pasting into a project config - only change needed to make it work is to fix the port number.

I haven't updated the changelog for this change.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
