### PR TITLE
wip: use the abstract rest client instead

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,7 +12,10 @@
         "cwd": "${workspaceFolder}/packages/vsce"
       },
       "command": "npm",
-      "args": ["run", "watch"],
+      "args": [
+        "run",
+        "watch"
+      ],
       "problemMatcher": {
         "owner": "typescript",
         "source": "ts",
@@ -34,10 +37,10 @@
         "background": {
           "activeOnStart": true,
           "beginsPattern": {
-            "regexp": "CLI Change detected:(.*?)"
+            "regexp": "(.*?)Compiler starting...(.*?)"
           },
           "endsPattern": {
-            "regexp": "(.*?)DTS ⚡️ Build success in(.*?)"
+            "regexp": "(.*?)Compiler is watching files for updates...(.*?)"
           }
         }
       }

--- a/packages/sdk/__tests__/__unit__/get/Get.resource.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/get/Get.resource.unit.test.ts
@@ -9,8 +9,8 @@
  *
  */
 
-import { ImperativeError, Session } from "@zowe/imperative";
-import { CicsCmciConstants, CicsCmciRestClient, CicsCmciRestError, ICMCIApiResponse, IResourceParms, getResource } from "../../../src";
+import { ImperativeError, RestClient, Session } from "@zowe/imperative";
+import { CicsCmciConstants, CicsCmciRestError, ICMCIApiResponse, IResourceParms, getResource } from "../../../src";
 import { nodataContent, nodataXmlResponse, ok2RecordsXmlResponse, okContent2Records } from "../../__mocks__/CmciGetResponse";
 
 describe("CMCI - Get resource", () => {
@@ -89,7 +89,7 @@ describe("CMCI - Get resource", () => {
   });
 
   describe("success scenarios", () => {
-    const getExpectStringMock = jest.spyOn(CicsCmciRestClient, "getExpectString");
+    const getExpectStringMock = jest.spyOn(RestClient, "getExpectString");
 
     beforeEach(() => {
       response = undefined;

--- a/packages/sdk/src/rest/CicsCmciRestClient.ts
+++ b/packages/sdk/src/rest/CicsCmciRestClient.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import { AbstractSession, IImperativeError, ImperativeError, Logger, RestClient, TextUtils } from "@zowe/imperative";
+import { AbstractRestClient, AbstractSession, IImperativeError, ImperativeError, Logger, RestClient, TextUtils } from "@zowe/imperative";
 import { Builder, Parser } from "xml2js";
 import { CicsCmciConstants } from "../constants";
 import { CicsCmciMessages } from "../constants/CicsCmci.messages";
@@ -24,7 +24,7 @@ import { CicsCmciRestError } from "./CicsCmciRestError";
  * @class CicsCmciRestClient
  * @extends {RestClient}
  */
-export class CicsCmciRestClient extends RestClient {
+export class CicsCmciRestClient extends AbstractRestClient {
   /**
    * If the API request is successful, this value should be in
    * api_response1 in  the resultsummary object in the response
@@ -63,7 +63,7 @@ export class CicsCmciRestClient extends RestClient {
     reqHeaders: any[] = [],
     requestOptions?: ICMCIRequestOptions
   ): Promise<ICMCIApiResponse> {
-    const data = await CicsCmciRestClient.getExpectString(session, resource, reqHeaders);
+    const data = await RestClient.getExpectString.call(AbstractRestClient, session, resource, reqHeaders);
     const apiResponse: ICMCIApiResponse = CicsCmciRestClient.parseStringSync(data);
     if (requestOptions?.failOnNoData === false && !apiResponse.response.records) {
       const resourceName = resource.split(`${CicsCmciConstants.CICS_SYSTEM_MANAGEMENT}/`)[1].split("/")[0].toLowerCase();
@@ -83,7 +83,7 @@ export class CicsCmciRestClient extends RestClient {
    * @throws {ImperativeError} verifyResponseCodes fails
    */
   public static async deleteExpectParsedXml(session: AbstractSession, resource: string, reqHeaders: any[] = []): Promise<ICMCIApiResponse> {
-    const data = await CicsCmciRestClient.deleteExpectString(session, resource, reqHeaders);
+    const data = await RestClient.deleteExpectString.call(AbstractRestClient, session, resource, reqHeaders);
     const apiResponse = CicsCmciRestClient.parseStringSync(data);
     return CicsCmciRestClient.verifyResponseCodes(apiResponse);
   }
@@ -108,7 +108,7 @@ export class CicsCmciRestClient extends RestClient {
     if (payload != null) {
       payload = CicsCmciRestClient.convertPayloadToXML(payload);
     }
-    const data = await CicsCmciRestClient.putExpectString(session, resource, reqHeaders, payload);
+    const data = await RestClient.putExpectString.call(AbstractRestClient, session, resource, reqHeaders, payload);
     const apiResponse = CicsCmciRestClient.parseStringSync(data);
     return CicsCmciRestClient.verifyResponseCodes(apiResponse);
   }
@@ -133,7 +133,7 @@ export class CicsCmciRestClient extends RestClient {
     if (payload != null) {
       payload = CicsCmciRestClient.convertPayloadToXML(payload);
     }
-    const data = await CicsCmciRestClient.postExpectString(session, resource, reqHeaders, payload);
+    const data = await RestClient.postExpectString.call(AbstractRestClient, session, resource, reqHeaders, payload);
     const apiResponse: ICMCIApiResponse = CicsCmciRestClient.parseStringSync(data);
     return CicsCmciRestClient.verifyResponseCodes(apiResponse);
   }

--- a/packages/vsce/src/utils/resourceUtils.ts
+++ b/packages/vsce/src/utils/resourceUtils.ts
@@ -17,7 +17,7 @@ import {
   IResourceQueryParams,
   Utils
 } from "@zowe/cics-for-zowe-sdk";
-import { Session } from "@zowe/imperative";
+import { Session, AuthOrder } from "@zowe/imperative";
 import constants from "../constants/CICS.defaults";
 import { getErrorCode } from "./errorUtils";
 import { CICSLogger } from "./CICSLogger";
@@ -51,7 +51,7 @@ export async function runGetResource({
     (cicsPlex ? ", CICSplex [" + cicsPlex + "]" : "") +
     (regionName ? ", Region [" + regionName + "]" : "") +
     (params?.criteria ? ", Criteria [" + params?.criteria + "]" : "") +
-    (params?.parameter ? ", Parameter [" + params?.parameter + "]" : "") );
+    (params?.parameter ? ", Parameter [" + params?.parameter + "]" : ""));
 
   const requestOptions = {
     failOnNoData: false,
@@ -60,6 +60,7 @@ export async function runGetResource({
 
   try {
     // First attempt
+    AuthOrder.makingRequestForToken(session.ISession);
     return await getResource(
       session,
       resourceParams,
@@ -76,6 +77,7 @@ export async function runGetResource({
   // Making a second attempt as ltpa token has expired
   CICSLogger.debug("Retrying as validation of the LTPA token failed because the token has expired.");
   session.ISession.tokenValue = null;
+  AuthOrder.makingRequestForToken(session.ISession);
   return getResource(
     session,
     resourceParams,
@@ -111,10 +113,11 @@ export async function runPutResource(
     (cicsPlex ? ", CICSplex [" + cicsPlex + "]" : "") +
     (regionName ? ", Region [" + regionName + "]" : "") +
     (params?.criteria ? ", Criteria [" + params?.criteria + "]" : "") +
-    (params?.parameter ? ", Parameter [" + params?.parameter + "]" : "") );
+    (params?.parameter ? ", Parameter [" + params?.parameter + "]" : ""));
 
   try {
     // First attempt
+    AuthOrder.makingRequestForToken(session.ISession);
     return await CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
   } catch (error) {
     // Make sure the error is not caused by the ltpa token expiring
@@ -126,6 +129,7 @@ export async function runPutResource(
   // Making a second attempt as ltpa token has expired
   CICSLogger.debug("Retrying as validation of the LTPA token failed because the token has expired.");
   session.ISession.tokenValue = null;
+  AuthOrder.makingRequestForToken(session.ISession);
   return await CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
 }
 

--- a/packages/vsce/src/utils/resourceUtils.ts
+++ b/packages/vsce/src/utils/resourceUtils.ts
@@ -60,7 +60,7 @@ export async function runGetResource({
 
   try {
     // First attempt
-    AuthOrder.makingRequestForToken(session.ISession);
+    if (!session.ISession.tokenValue) AuthOrder.makingRequestForToken(session.ISession);
     return await getResource(
       session,
       resourceParams,


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] considered whether the docs need updating
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->

You will need to modify the AuthOrder.removeExtraCredsFromSession function...
```
node_modules/@zowe/imperative/lib/rest/src/session/AuthOrder.js
```

```
                case SessConstants.AUTH_TYPE_BASIC:
                    if (sessCfg.base64EncodedAuth) {
                        AuthOrder.keepCred("base64EncodedAuth", credsToRemove);
                        AuthOrder.keepCred("user", credsToRemove);
                        AuthOrder.keepCred("password", credsToRemove);
                        
                        // -------- Add these lines ---------
                        if (sessCfg._authCache.authTypeToRequestToken) { 
                            // we want to actually use the token type, so keep its value
                            AuthOrder.keepCred("tokenType", credsToRemove);
                        }
                        // ---------------------------------
                        
                    }
                    break;
```

---

UPDATE:

It seems better to properly make the token available as soon as possible by adding it to the session as soon as we get it 😋 
Here is the PR that introduces the proper fix in Imperative:
- https://github.com/zowe/zowe-cli/pull/2605

To make the same changes (before the PR is merged and published) 

You can either build from source and replace the impeartive version to `file:///PATH/to/cli-monorepo/packages/imperative`)

OR

Just go into your node_modules and change the following file

```shell
node_modules/@zowe/imperative/lib/rest/src/session/AbstractSession.js
```

```javascript
// "import"
const AuthOrder_1 = require("./AuthOrder");
// ...
// Inside the storeCookie function...
                    if (split >= 0) {
                        const tokenType = element.substring(0, split);
                        const tokenValue = element.substring(split + 1);
                        AuthOrder_1.AuthOrder.addCredsToSession(this.ISession, {
                            "$0": "NameNotUsed", "_": [],
                            "authOrder": "token",
                            tokenType,
                            tokenValue,
                        });
                        this.ISession.tokenType = tokenType;
                        this.ISession.tokenValue = tokenValue;
                    }
```

<img width="652" height="488" alt="image" src="https://github.com/user-attachments/assets/6cb13386-051d-4455-92f6-b21940d4fecc" />

