### PR TITLE
Removal of RI Actions for unsupported Resources

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "cics-extension-for-zowe" extension will be documented in this file.
 
+## Recent Changes
+
+- Removal of RI Actions component for unsupported Resources [#423](https://github.com/zowe/cics-for-zowe-client/issues/423)
+
 ## `3.12.0`
 
 - Validate input using maximum resource length when inspecting resource. [#402](https://github.com/zowe/cics-for-zowe-client/issues/402)

--- a/packages/vsce/src/webviews/resource-inspector-panel/Contextmenu.tsx
+++ b/packages/vsce/src/webviews/resource-inspector-panel/Contextmenu.tsx
@@ -7,9 +7,11 @@ import "../css/style.css";
 const Contextmenu = ({
   resourceActions,
   refreshIconPath,
+  resourceHumanReadableName,
 }: {
   resourceActions: { id: string; name: string; iconPath?: { light: Uri; dark: Uri } }[];
   refreshIconPath: { light: string; dark: string };
+  resourceHumanReadableName: string;
 }) => {
   const [x, setX] = React.useState(0);
   const [y, setY] = React.useState(0);
@@ -115,6 +117,9 @@ const Contextmenu = ({
     vscode.postVscMessage({ command: "refresh" });
   };
 
+  const allowedNames = ["Transaction", "Program", "Local File"];
+  const showThreeDots = allowedNames.includes(resourceHumanReadableName);
+
   return (
     <div className="dropdown-container">
       <img
@@ -128,9 +133,11 @@ const Contextmenu = ({
           }
         }}
       />
-      <div id="three-dots" className="three-dots" onClick={handleThreeDotsClick} ref={threeDotsRef} tabIndex={0} onKeyDown={handleKeyDown}>
-        ...
-      </div>
+      {showThreeDots && (
+        <div id="three-dots" className="three-dots" onClick={handleThreeDotsClick} ref={threeDotsRef} tabIndex={0} onKeyDown={handleKeyDown}>
+          ...
+        </div>
+      )}
       {show && (
         <VscodeContextMenu
           data={resourceActions.map(({ id, name }) => ({ label: name, value: id }))}

--- a/packages/vsce/src/webviews/resource-inspector-panel/Contextmenu.tsx
+++ b/packages/vsce/src/webviews/resource-inspector-panel/Contextmenu.tsx
@@ -7,11 +7,9 @@ import "../css/style.css";
 const Contextmenu = ({
   resourceActions,
   refreshIconPath,
-  resourceHumanReadableName,
 }: {
   resourceActions: { id: string; name: string; iconPath?: { light: Uri; dark: Uri } }[];
   refreshIconPath: { light: string; dark: string };
-  resourceHumanReadableName: string;
 }) => {
   const [x, setX] = React.useState(0);
   const [y, setY] = React.useState(0);

--- a/packages/vsce/src/webviews/resource-inspector-panel/Contextmenu.tsx
+++ b/packages/vsce/src/webviews/resource-inspector-panel/Contextmenu.tsx
@@ -116,9 +116,8 @@ const Contextmenu = ({
   const handleRefresh = () => {
     vscode.postVscMessage({ command: "refresh" });
   };
-
-  const allowedNames = ["Transaction", "Program", "Local File"];
-  const showThreeDots = allowedNames.includes(resourceHumanReadableName);
+  
+  const showThreeDots = resourceActions.length > 0;
 
   return (
     <div className="dropdown-container">

--- a/packages/vsce/src/webviews/resource-inspector-panel/ResourceInspector.tsx
+++ b/packages/vsce/src/webviews/resource-inspector-panel/ResourceInspector.tsx
@@ -84,13 +84,7 @@ const ResourceInspector = () => {
                 // @ts-ignore
                 resourceInfo ? (resourceInfo?.resource.status || resourceInfo?.resource.enablestatus) : "..."}
             </div>
-            {resourceInfo && (
-              <Contextmenu
-                resourceActions={resourceActions}
-                refreshIconPath={resourceInfo?.refreshIconPath}
-                resourceHumanReadableName={resourceInfo?.humanReadableNameSingular}
-              />
-            )}
+            {resourceInfo && <Contextmenu resourceActions={resourceActions} refreshIconPath={resourceInfo?.refreshIconPath} />}
           </th>
         </thead>
         <tbody className="padding-left-10 padding-top-20">

--- a/packages/vsce/src/webviews/resource-inspector-panel/ResourceInspector.tsx
+++ b/packages/vsce/src/webviews/resource-inspector-panel/ResourceInspector.tsx
@@ -84,7 +84,13 @@ const ResourceInspector = () => {
                 // @ts-ignore
                 resourceInfo ? (resourceInfo?.resource.status || resourceInfo?.resource.enablestatus) : "..."}
             </div>
-            {resourceInfo && <Contextmenu resourceActions={resourceActions} refreshIconPath={resourceInfo?.refreshIconPath} />}
+            {resourceInfo && (
+              <Contextmenu
+                resourceActions={resourceActions}
+                refreshIconPath={resourceInfo?.refreshIconPath}
+                resourceHumanReadableName={resourceInfo?.humanReadableNameSingular}
+              />
+            )}
           </th>
         </thead>
         <tbody className="padding-left-10 padding-top-20">


### PR DESCRIPTION
**What It Does**
Removes RI Action div for the resource types which does not have any extended actions.

**How to Test**

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] considered whether the docs need updating
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

