### PR TITLE
Remove obsolete feature flags

### DIFF
--- a/packages/vsce/__tests__/__e2e__/globalUserSettings.json
+++ b/packages/vsce/__tests__/__e2e__/globalUserSettings.json
@@ -5,8 +5,6 @@
   "security.workspace.trust.untrustedFiles": "open",
   "zowe.settings.displayReleaseNotes": false,
   "zowe.security.secureCredentialsEnabled": false,
-  "zowe.cics.showAllCommandsInPalette": true,
-  "zowe.cics.resourceInspector": true,
   "zowe.cics.persistent": {
     "persistence": true,
     "programSearchHistory": [],

--- a/packages/vsce/package.json
+++ b/packages/vsce/package.json
@@ -299,31 +299,27 @@
       "commandPalette": [
         {
           "command": "cics-extension-for-zowe.inspectTreeResource",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.setCICSRegion",
           "when": "never"
         },
         {
-          "command": "cics-extension-for-zowe.inspectResource",
-          "when": "!config.zowe.cics.showAllCommandsInPalette"
-        },
-        {
           "command": "cics-extension-for-zowe.purgeTask",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.inquireProgram",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.newCopyProgram",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.phaseInCommand",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.showRegionAttributes",
@@ -335,91 +331,91 @@
         },
         {
           "command": "cics-extension-for-zowe.showRegionLogs",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.clearFilter",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.filterPlexResources",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.clearPlexFilter",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.enableProgram",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.disableProgram",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.enableTransaction",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.disableTransaction",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.enableLocalFile",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.disableLocalFile",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.closeLocalFile",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.openLocalFile",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.inquireTransaction",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.disableLibrary",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.enableLibrary",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.manageSession",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.filterResources",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.showResourceAttributes",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.showLibrary",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.enableProgram",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.enableBundle",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.disableBundle",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.copyResourceName",
@@ -427,19 +423,19 @@
         },
         {
           "command": "cics-extension-for-zowe.disableJVMServer",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.enableJVMServer",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.disableJVMEndpoint",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         },
         {
           "command": "cics-extension-for-zowe.enableJVMEndpoint",
-          "when": "config.zowe.cics.showAllCommandsInPalette"
+          "when": "never"
         }
       ],
       "view/title": [


### PR DESCRIPTION
**What It Does**

In the past, we've used feature flags to hide/show commands from the command palette and tree context menus. Now we've released Resource Inspector, we no longer need to specify when or not to offer it as an option. 

We also don't need to show the commands for e2e testing.

**How to Test**

See available commands in command palette.

<img width="894" height="271" alt="Screenshot 2025-10-09 at 3 15 48 PM" src="https://github.com/user-attachments/assets/f53708df-8c3c-40ae-b99d-e3d18da72eec" />

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [ ] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
