### PR TITLE
Make .npmrc changes [v3]

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-registry=https://registry.npmjs.org/
 @zowe:registry=https://zowe.jfrog.io/zowe/api/npm/npm-release/
+omit-lockfile-registry-resolved=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -712,7 +712,6 @@
     },
     "node_modules/@dabh/diagnostics": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
       "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
       "dependencies": {
         "colorspace": "1.1.x",
@@ -1700,7 +1699,6 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
       "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -2128,7 +2126,6 @@
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
       "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "node_modules/@types/trusted-types": {
@@ -2390,7 +2387,6 @@
     },
     "node_modules/@vscode/codicons": {
       "version": "0.0.40",
-      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.40.tgz",
       "integrity": "sha512-R8sEDXthD86JHsk3xERrMcTN6sMovbk1AXYB5/tGoEYCE8DWwya6al5VLrAmQYXC1bQhUHIfHALj8ijQUs11cQ==",
       "license": "CC-BY-4.0"
     },
@@ -2799,7 +2795,6 @@
     },
     "node_modules/@zowe/core-for-zowe-sdk": {
       "version": "8.27.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/core-for-zowe-sdk/-/@zowe/core-for-zowe-sdk-8.27.0.tgz",
       "integrity": "sha512-25XBI7gf67k5+6U0qlKoPVWhGn1YXmQwODqbmw9ysRddrx7LluKrz50n89Gj3iWH9p9E3pepdsJzAN5zlLjgLQ==",
       "license": "EPL-2.0",
       "dependencies": {
@@ -2815,7 +2810,6 @@
     },
     "node_modules/@zowe/imperative": {
       "version": "8.27.2",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/imperative/-/@zowe/imperative-8.27.2.tgz",
       "integrity": "sha512-uffR4ioW8LnuzQ/9KM6NBxQbsZr3vYruDlEGLqTjQ5OiEJT2dE4pMeqCn5zbZE+9rHxns2mSyChtw/Cjz0079Q==",
       "license": "EPL-2.0",
       "dependencies": {
@@ -2911,7 +2905,6 @@
     },
     "node_modules/@zowe/secrets-for-zowe-sdk": {
       "version": "8.27.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/secrets-for-zowe-sdk/-/@zowe/secrets-for-zowe-sdk-8.27.0.tgz",
       "integrity": "sha512-T8wZc5wyqLYnzt4FT77zJuqTVh0lIIJz4DnZkikTfSX9tV2+ibBRX0kGmtsr/et3UqgSBkugWvGIYT+4U01xFw==",
       "hasInstallScript": true,
       "license": "EPL-2.0",
@@ -2921,7 +2914,6 @@
     },
     "node_modules/@zowe/zos-console-for-zowe-sdk": {
       "version": "8.27.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-console-for-zowe-sdk/-/@zowe/zos-console-for-zowe-sdk-8.27.0.tgz",
       "integrity": "sha512-oXrx7gDI17MZ3AyL7PtIJmZx70Cy3Wrom0yHHzQE2FjBys2vPkWS8rmDUkgE3TG0jEGQwHC3/LJ1NV9iIU+Pvw==",
       "license": "EPL-2.0",
       "engines": {
@@ -2934,7 +2926,6 @@
     },
     "node_modules/@zowe/zos-files-for-zowe-sdk": {
       "version": "8.27.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-files-for-zowe-sdk/-/@zowe/zos-files-for-zowe-sdk-8.27.0.tgz",
       "integrity": "sha512-v6CXIKYK900DO2x9nJEY3L9d5zRxauH4d15MTD3C9tUNHmwcS6SSrYjWX87kNNB0Wn+RK8lvon/ANzgEVCZUKw==",
       "license": "EPL-2.0",
       "dependencies": {
@@ -2951,7 +2942,6 @@
     },
     "node_modules/@zowe/zos-files-for-zowe-sdk/node_modules/minimatch": {
       "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
       "dependencies": {
@@ -2966,7 +2956,6 @@
     },
     "node_modules/@zowe/zos-jobs-for-zowe-sdk": {
       "version": "8.27.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-jobs-for-zowe-sdk/-/@zowe/zos-jobs-for-zowe-sdk-8.27.0.tgz",
       "integrity": "sha512-2L/7suld08Ag3+r76XGskHF8bd4qUsgX5pYWu277AOD+DD2Q5N0uqvHuHYRS2X2MpCJgBYKX2DjAlV7QePGOyg==",
       "license": "EPL-2.0",
       "dependencies": {
@@ -2982,7 +2971,6 @@
     },
     "node_modules/@zowe/zos-tso-for-zowe-sdk": {
       "version": "8.27.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-tso-for-zowe-sdk/-/@zowe/zos-tso-for-zowe-sdk-8.27.0.tgz",
       "integrity": "sha512-bhxs3/FeR4I1rk+pewQ+rgne3ouDQpIfj9rvyI57JspIXnPlf6rZSWWYWG3vBPRcx6+kAb3GvOZ1elxkRsPWIw==",
       "license": "EPL-2.0",
       "dependencies": {
@@ -2998,7 +2986,6 @@
     },
     "node_modules/@zowe/zos-uss-for-zowe-sdk": {
       "version": "8.27.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zos-uss-for-zowe-sdk/-/@zowe/zos-uss-for-zowe-sdk-8.27.0.tgz",
       "integrity": "sha512-7Iw1QiA+TxJM38hf1xdRTbdOsSlyCYhqyyq7jdhVpNseFB/pdgKYs0RHKVtUPBjrRP2cBDlCQhv85rF6wvAyCA==",
       "license": "EPL-2.0",
       "dependencies": {
@@ -3013,7 +3000,6 @@
     },
     "node_modules/@zowe/zosmf-for-zowe-sdk": {
       "version": "8.27.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zosmf-for-zowe-sdk/-/@zowe/zosmf-for-zowe-sdk-8.27.0.tgz",
       "integrity": "sha512-oH94RDEmWzncPM2+LATm3oGS7cpJ6pnisNfY1W5/QiLsC9B+xeIXzdmC6wfy0Ardwco2bA28nw3jRADRW+VEgA==",
       "license": "EPL-2.0",
       "engines": {
@@ -3026,7 +3012,6 @@
     },
     "node_modules/@zowe/zowe-explorer-api": {
       "version": "3.3.0",
-      "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/@zowe/zowe-explorer-api/-/zowe-explorer-api-3.3.0.tgz",
       "integrity": "sha512-Xe0/MPUKdY3+crMQk0v/dn9Vjo7m9A/r2UQK5Ye7A2Ravj7AKyRNa7COblP0EuY83yuuV1dyud1FXhfKa7Mykg==",
       "license": "EPL-2.0",
       "dependencies": {
@@ -3154,7 +3139,6 @@
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
       "dev": true,
       "license": "MIT",
@@ -3262,7 +3246,6 @@
     },
     "node_modules/asn1": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
       "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "license": "MIT",
       "dependencies": {
@@ -3447,7 +3430,6 @@
     },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3456,7 +3438,6 @@
     },
     "node_modules/big.js": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
       "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
       "dev": true,
       "license": "MIT",
@@ -3530,7 +3511,6 @@
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
@@ -3664,7 +3644,6 @@
     },
     "node_modules/buildcheck": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.6.tgz",
       "integrity": "sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==",
       "optional": true,
       "engines": {
@@ -4313,7 +4292,6 @@
     },
     "node_modules/color": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
       "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
       "dependencies": {
         "color-convert": "^1.9.3",
@@ -4336,7 +4314,6 @@
     },
     "node_modules/color-string": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
       "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
       "dependencies": {
         "color-name": "^1.0.0",
@@ -4345,7 +4322,6 @@
     },
     "node_modules/color/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dependencies": {
         "color-name": "1.1.3"
@@ -4353,7 +4329,6 @@
     },
     "node_modules/color/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/colorette": {
@@ -4370,7 +4345,6 @@
     },
     "node_modules/colorspace": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
       "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
       "dependencies": {
         "color": "^3.1.3",
@@ -4426,7 +4400,6 @@
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
@@ -4446,7 +4419,6 @@
     },
     "node_modules/copy-webpack-plugin": {
       "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz",
       "integrity": "sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==",
       "dev": true,
       "license": "MIT",
@@ -4471,7 +4443,6 @@
     },
     "node_modules/copy-webpack-plugin/node_modules/ajv": {
       "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
@@ -4488,7 +4459,6 @@
     },
     "node_modules/copy-webpack-plugin/node_modules/ajv-keywords": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
       "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
       "dev": true,
       "license": "MIT",
@@ -4501,7 +4471,6 @@
     },
     "node_modules/copy-webpack-plugin/node_modules/globby": {
       "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.2.tgz",
       "integrity": "sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==",
       "dev": true,
       "license": "MIT",
@@ -4521,14 +4490,12 @@
     },
     "node_modules/copy-webpack-plugin/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
       "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
       "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "dev": true,
       "license": "MIT",
@@ -4548,7 +4515,6 @@
     },
     "node_modules/copy-webpack-plugin/node_modules/slash": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
       "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
       "dev": true,
       "license": "MIT",
@@ -4565,7 +4531,6 @@
     },
     "node_modules/cpu-features": {
       "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
       "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
       "hasInstallScript": true,
       "optional": true,
@@ -4730,7 +4695,6 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
       "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
@@ -5332,7 +5296,6 @@
     },
     "node_modules/emojis-list": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true,
       "license": "MIT",
@@ -5342,7 +5305,6 @@
     },
     "node_modules/enabled": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
       "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
     },
     "node_modules/encoding": {
@@ -6114,7 +6076,6 @@
     },
     "node_modules/fecha": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
     },
     "node_modules/file-entry-cache": {
@@ -6284,7 +6245,6 @@
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/foreground-child": {
@@ -6303,7 +6263,6 @@
     },
     "node_modules/form-data": {
       "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
       "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
@@ -7865,7 +7824,6 @@
     },
     "node_modules/jest-stare": {
       "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/jest-stare/-/jest-stare-2.5.3.tgz",
       "integrity": "sha512-HXykqTNNxguOQZiWCEcUPC5HleaVngQysyyniG6LzoeBsM4dtq4YDw/JruS2ChfRBS/9PUcG04eAx6NdcbFDDg==",
       "dev": true,
       "license": "MIT",
@@ -8253,7 +8211,6 @@
     },
     "node_modules/kuler": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
     },
     "node_modules/leven": {
@@ -8352,7 +8309,6 @@
     },
     "node_modules/loader-utils": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
       "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
       "dev": true,
       "license": "MIT",
@@ -8474,7 +8430,6 @@
     },
     "node_modules/logform": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
       "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
       "dependencies": {
         "@colors/colors": "1.6.0",
@@ -8490,7 +8445,6 @@
     },
     "node_modules/logform/node_modules/@colors/colors": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "engines": {
         "node": ">=0.1.90"
@@ -8766,7 +8720,6 @@
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
       "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
@@ -9082,7 +9035,6 @@
     },
     "node_modules/nan": {
       "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.23.0.tgz",
       "integrity": "sha512-1UxuyYGdoQHcGg87Lkqm3FzefucTa0NAiOcuRsDmysep3c1LVCRK2krrUDafMWtjSG04htvAmvg96+SDknOmgQ==",
       "license": "MIT",
       "optional": true
@@ -9417,7 +9369,6 @@
     },
     "node_modules/one-time": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
       "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
       "dependencies": {
         "fn.name": "1.x.x"
@@ -9924,7 +9875,6 @@
     },
     "node_modules/playwright": {
       "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
       "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
       "dev": true,
       "license": "Apache-2.0",
@@ -9943,7 +9893,6 @@
     },
     "node_modules/playwright-core": {
       "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
       "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
       "dev": true,
       "license": "Apache-2.0",
@@ -9956,7 +9905,6 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
@@ -10706,7 +10654,6 @@
     },
     "node_modules/raw-loader": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
       "integrity": "sha512-ZnScIV3ag9A4wPX/ZayxL/jZH+euYb6FcUinPcgiQW0+UBtEv0O6Q3lGd3cqJ+GHH+rksEv3Pj99oxJ3u3VIKA==",
       "dev": true,
       "license": "MIT",
@@ -11156,7 +11103,6 @@
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
       "engines": {
         "node": ">=10"
@@ -11242,7 +11188,6 @@
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
       "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "license": "MIT",
@@ -11485,7 +11430,6 @@
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
       "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
       "dependencies": {
         "is-arrayish": "^0.3.1"
@@ -11493,7 +11437,6 @@
     },
     "node_modules/simple-swizzle/node_modules/is-arrayish": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
     "node_modules/sisteransi": {
@@ -11601,7 +11544,6 @@
     },
     "node_modules/ssh2": {
       "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
       "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
       "hasInstallScript": true,
       "dependencies": {
@@ -11924,7 +11866,6 @@
     },
     "node_modules/tar-fs": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.3.tgz",
       "integrity": "sha512-090nwYJDmlhwFwEW3QQl+vaNnxsO2yVsd45eTKRBzSzu+hlb1w2K9inVq5b0ngXuLVqQ4ApvsUHHnu/zQNkWAg==",
       "dev": true,
       "license": "MIT",
@@ -12056,7 +11997,6 @@
     },
     "node_modules/targz/node_modules/tar-fs": {
       "version": "1.16.5",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.5.tgz",
       "integrity": "sha512-1ergVCCysmwHQNrOS+Pjm4DQ4nrGp43+Xnu4MRGjCnQu/m3hEgLNS78d5z+B8OJ1hN5EejJdCSFZE1oM6AQXAQ==",
       "dev": true,
       "license": "MIT",
@@ -12265,7 +12205,6 @@
     },
     "node_modules/text-hex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
     "node_modules/text-table": {
@@ -12338,7 +12277,6 @@
     },
     "node_modules/tmp": {
       "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
       "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
@@ -12392,7 +12330,6 @@
     },
     "node_modules/triple-beam": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
       "engines": {
         "node": ">= 14.0.0"
@@ -12754,7 +12691,6 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
       "license": "Unlicense"
     },
@@ -12863,7 +12799,6 @@
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true,
       "license": "MIT"
@@ -13677,7 +13612,6 @@
     },
     "node_modules/winston": {
       "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.17.0.tgz",
       "integrity": "sha512-DLiFIXYC5fMPxaRg832S6F5mJYvePtmO5G9v9IgUFPhXm9/GkXarH/TUrBAVzhTCzAj9anE/+GjrgXp/54nOgw==",
       "dependencies": {
         "@colors/colors": "^1.6.0",
@@ -13698,7 +13632,6 @@
     },
     "node_modules/winston-transport": {
       "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
       "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
       "dependencies": {
         "logform": "^2.7.0",
@@ -13711,7 +13644,6 @@
     },
     "node_modules/winston/node_modules/@colors/colors": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
       "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
       "engines": {
         "node": ">=0.1.90"
@@ -14033,14 +13965,12 @@
     },
     "packages/vsce-api/node_modules/@types/vscode": {
       "version": "1.53.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
       "integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
       "dev": true,
       "license": "MIT"
     },
     "packages/vsce/node_modules/@types/node": {
       "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.0.tgz",
       "integrity": "sha512-3xyG3pMCq3oYCNg7/ZP+E1ooTaGB4cG8JWRsqqOYQdbWNY4zbaV0Ennrd7stjiJEFZCaybcIgpTjJWHRfBSIDw==",
       "dev": true,
       "license": "MIT",
@@ -14055,7 +13985,6 @@
     },
     "packages/vsce/node_modules/undici-types": {
       "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
       "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
       "dev": true,
       "license": "MIT"


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Removes the registry field from the .npmrc forcing the use of `registry.npmjs.org`.
Adds the `omit-lockfile-registry-resolved = true` setting, which removes resolved registry locations from the lockfiles.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
