### PR TITLE
[v2] Fix sha mismatch error when packaging cli plugin

### DIFF
--- a/scripts/bundleTgz.js
+++ b/scripts/bundleTgz.js
@@ -20,7 +20,8 @@ process.chdir(rootDir);
 const cliPkgDir = path.join(process.cwd(), "packages", "cli");
 const pkgJsonFile = path.join(cliPkgDir, "package.json");
 const sdkPkgJson = JSON.parse(fsE.readFileSync(path.join(cliPkgDir, "../sdk/package.json"), "utf-8"));
-const npmInstallCmd = "npm install --ignore-scripts --workspaces=false";
+const zoweRegistry = sdkPkgJson.publishConfig.registry;
+const npmInstallCmd = `npm install --ignore-scripts --workspaces=false --@zowe:registry=${zoweRegistry}`;
 const execCmd = (cmd) => childProcess.execSync(cmd, { cwd: cliPkgDir, stdio: "inherit" });
 fsE.mkdirpSync("dist");
 


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Ports #462 to zowe-v2-lts

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] considered whether the docs need updating
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
