### PR TITLE
fix: redundant optional chaining in `putResource`

### DIFF
--- a/packages/sdk/src/methods/put/Put.ts
+++ b/packages/sdk/src/methods/put/Put.ts
@@ -48,8 +48,8 @@ export async function putResource(
     "PUT request - Resource [" + parms.name + "]" +
       (parms.cicsPlex ? ", CICSplex [" + parms.cicsPlex + "]" : "") +
       (parms.regionName ? ", Region [" + parms.regionName + "]" : "") +
-      (parms?.criteria ? ", Criteria [" + parms?.criteria + "]" : "") +
-      (parms?.parameter ? ", Parameter [" + parms?.parameter + "]" : "")
+      (parms.criteria ? ", Criteria [" + parms.criteria + "]" : "") +
+      (parms.parameter ? ", Parameter [" + parms.parameter + "]" : "")
   );
 
   return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, headers, requestBody, requestOptions);


### PR DESCRIPTION
**What It Does**

Fixes issue detected by static analysis tool where use of optional chaining is unnecessary on `parms`.

**How to Test**

Build and test, no issues should occur

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)