### PR TITLE
Update release workflow to avoid always pushing notice changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,8 +162,8 @@ jobs:
     - name: Update Dependencies
       uses: zowe-actions/octorelease/script@v1
       env:
-        GIT_COMMITTER_NAME: zowe_robot
-        GIT_COMMITTER_EMAIL: zowe.robot@gmail.com
+        GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
+        GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}
         NPM_RESOLUTIONS: ${{ needs.test.outputs.npm-resolutions }}
       with:
         config-dir: .github
@@ -172,31 +172,21 @@ jobs:
     - name: Update NOTICE file
       run: bash scripts/updateNotices.sh
 
-    - name: Push Notice Changes
+    - name: Commit Notice Changes
       env:
         GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
         GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}
-
-        GIT_CREDENTIALS: x-access-token:${{ secrets.ZOWE_ROBOT_TOKEN }}
       run: |
         set -e
 
         echo "Set config"
         git config --global user.name $GIT_COMMITTER_NAME
         git config --global user.email $GIT_COMMITTER_EMAIL
-        git config --global credential.helper store
-        git config --get remote.origin.url
-
-        touch ~/.git-credentials
-        echo "https://$GIT_CREDENTIALS@github.com" >> ~/.git-credentials
-
         git ls-remote --heads origin $GITHUB_REF
 
         git add packages/*/NOTICE
         git diff --name-only --cached
-
         git commit -s -m "Update Notice Files [ci skip]" || true
-        git push
 
     - name: Build Source
       run: npm run build


### PR DESCRIPTION
The release workflow runs every time a PR is merged into the main branch, and pushes a commit that updates notice files.

I believe the intent of the "Push Notice Changes" step was to push changes only when a new release is being produced. If that is wrong, feel free to close this PR.

Removing the `git push` call should achieve this behavior, because our Octorelease tool will run `git push` if there was a version bump. Otherwise the push will be skipped which matches the behavior of the "Update Dependencies" step.