### PR TITLE
Bugfix: inspect resource from palette meta array

### DIFF
--- a/packages/vsce/src/commands/inspectResourceCommandUtils.ts
+++ b/packages/vsce/src/commands/inspectResourceCommandUtils.ts
@@ -182,7 +182,7 @@ export function getInspectableResourceTypes(): Map<string, IResourceMeta<IResour
     }
     // for now we only show our externally visible types (so not LIBDSN)
     if (SupportedResourceTypes.includes(item.resourceName as ResourceTypes)) {
-      acc.set(item.humanReadableNameSingular, item);
+      acc.set(item.humanReadableNameSingular, [item]);
     }
     return acc;
   }, new Map());


### PR DESCRIPTION
**What It Does**
Sends an array of metas back regardless of how many to ensure all resources are inspected from command palette.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [ ] added/updated automated tests
- [x] updated the changelog
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
