### PR TITLE
Skip Sonar check on fork PRs

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   sonar:
+    # PRs from forks do not have access to workflow secrets so Sonarqube fails.
+    # Therefore we are skipping this job on forks.
+    if: github.event.repository.fork != true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**What It Does**
Prevents Sonar job running on forks. It does not have access to secrets so always fails.
