### PR TITLE
Sonarqube CI

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -12,7 +12,7 @@ jobs:
   sonar:
     # PRs from forks do not have access to workflow secrets so Sonarqube fails.
     # Therefore we are skipping this job on forks.
-    if: github.event.repository.fork != true
+    if: contains(github.event.pull_request.head.repo.url, '/repos/zowe/cics-for-zowe-client')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**What It Does**
Uses the PR head URL to determine if the Sonar CI job runs. This is to prevent it running on fork PRs as they do not have access to secrets.
