### PR TITLE
Reduce e2e wait time

### DIFF
--- a/packages/vsce/__tests__/__e2e__/playwright.config.ts
+++ b/packages/vsce/__tests__/__e2e__/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   testDir: "./specs/",
   fullyParallel: false,
   reporter: "list",
-  timeout: 30 * 1000,
+  timeout: 10 * 1000,
   expect: {
     timeout: 5000,
   },

--- a/packages/vsce/__tests__/__e2e__/resources/extender-extension/package-lock.json
+++ b/packages/vsce/__tests__/__e2e__/resources/extender-extension/package-lock.json
@@ -27,10 +27,10 @@
     },
     "../../../../../vsce-api": {
       "name": "@zowe/cics-for-zowe-explorer-api",
-      "version": "6.14.0",
+      "version": "6.15.0",
       "license": "EPL-2.0",
       "dependencies": {
-        "@zowe/cics-for-zowe-sdk": "^6.14.0",
+        "@zowe/cics-for-zowe-sdk": "^6.15.0",
         "compare-versions": "^6.1.1"
       },
       "devDependencies": {

--- a/packages/vsce/__tests__/__e2e__/utils/helpers.ts
+++ b/packages/vsce/__tests__/__e2e__/utils/helpers.ts
@@ -90,7 +90,7 @@ export const getResourceInspector = (page: Page) => {
 export const findAndClickTreeItem = async (page: Page, label: string, button: "left" | "right" | "middle" = "left") => {
   await expect(getTreeItem(page, label)).toBeVisible();
   await expect(getTreeItem(page, label)).toHaveText(label);
-  await getTreeItem(page, label).click({ button });
+  await getTreeItem(page, label).click({ button, force: true });
 };
 
 export const waitForNotification = async (page: Page, string: string) => {
@@ -100,7 +100,7 @@ export const waitForNotification = async (page: Page, string: string) => {
 
 export const findAndClickText = async (page: Page, label: string, button: "left" | "right" | "middle" = "left") => {
   await expect(page.getByText(label)).toBeVisible();
-  await page.getByText(label).click({ button });
+  await page.getByText(label).click({ button, force: true });
 };
 
 export const runInCommandPalette = async (page: Page, command: string) => {


### PR DESCRIPTION
**What It Does**
Reduces the timeout for a failing test - 30 seconds was too long and meant CI took longer than necessary.

Also tries forcing the clicks on components - experimenting with this to see if success rate improves

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] considered whether the docs need updating
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
