### PR TITLE
[v3] Remove classic npm token from release workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,7 +200,6 @@ jobs:
         NPM_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
         NPM_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         NPM_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}
-        NPM_TOKEN: ${{ secrets.VSCODE_NPM_PUBLISHER_TOKEN }}
         OVSX_PAT: ${{ secrets.VSCODE_OVSX_PUBLISHER_TOKEN }}
         VSCE_PAT: ${{ secrets.VSCODE_VSCE_PUBLISHER_TOKEN }}
       with:


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Since npm stopped supporting classic tokens as of Dec 9 2025, I've been doing a round of cleaning up old secrets throughout Zowe repos 🙂 I don't believe this token was being used anyway, since user/password should take precedence.

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] updated the changelog
- [ ] considered whether the docs need updating
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
