### PR TITLE
Update PR template to include an explicit issue link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,6 @@
 I certify that I have:
 - [ ] tested my changes
 - [ ] added/updated automated tests
-- [ ] updated the changelog
 - [ ] considered whether the docs need updating
 - [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
 


### PR DESCRIPTION
**What It Does**
Lots of our PRs have missed the link back to the issue. This is important information because it allows you to look at an issue and see what PRs contributed to resolving it. It also helps us close issues that are completed!

I'm also removing the changelog tick box because we have a check that verifies it's been updated.