### PR TITLE
Enabled resource filters to be edited before reuse

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -305,6 +305,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -894,6 +895,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -916,6 +918,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5616,6 +5619,7 @@
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -5642,6 +5646,7 @@
       "version": "19.2.14",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5751,7 +5756,8 @@
     "node_modules/@types/vscode": {
       "version": "1.109.0",
       "integrity": "sha512-0Pf95rnwEIwDbmXGC08r0B4TQhAbsHQ5UyTIgVgoieDe4cOnf92usuR5dEczb6bTKEp7ziZH4TV1TRGPPCExtw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -5856,6 +5862,7 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -7088,6 +7095,7 @@
       "version": "8.30.1",
       "integrity": "sha512-i94jNwb2PaEQ8pJP9Dn/9Kj8dQaSUv/Mx9hQP0ZAr/x9w7QPp3dbtoH0iglUyYsH2SMEnDWNJAq3SBbNLmWvAA==",
       "license": "EPL-2.0",
+      "peer": true,
       "dependencies": {
         "comment-json": "~4.2.3",
         "string-width": "^4.2.3"
@@ -7103,6 +7111,7 @@
       "version": "8.30.1",
       "integrity": "sha512-Q6Xod3nXfjJd6oXfWjycHrpH/mD0MHYUz+ZSC86U14B+Ekpp0iO+dHzMtWOqO0ClzyVlFyqhDPFfwQHg9mJUZw==",
       "license": "EPL-2.0",
+      "peer": true,
       "dependencies": {
         "@types/semver": "^7.5.0",
         "@types/yargs": "^17.0.32",
@@ -7244,6 +7253,7 @@
       "version": "3.4.1",
       "integrity": "sha512-4y/WE3vggvPGl5gNVEHl7g66CQQtGDyhu8yMyTIfirr1Ej2cbVr4/V3XZ6Z1bLKxTDVPUFM1YsHWdoEjntSTPg==",
       "license": "EPL-2.0",
+      "peer": true,
       "dependencies": {
         "@types/vscode": "^1.53.2",
         "@zowe/core-for-zowe-sdk": "^8.29.9",
@@ -7293,6 +7303,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7346,6 +7357,7 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7954,6 +7966,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9866,6 +9879,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9953,6 +9967,7 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -11739,6 +11754,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -15367,6 +15383,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -16194,6 +16211,7 @@
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -16538,6 +16556,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16919,6 +16938,7 @@
       "version": "19.2.4",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16927,6 +16947,7 @@
       "version": "19.2.4",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -17412,6 +17433,7 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -18680,6 +18702,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18884,6 +18907,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -18958,7 +18982,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsup": {
       "version": "8.5.1",
@@ -19267,6 +19292,7 @@
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -19666,6 +19692,7 @@
       "integrity": "sha512-LLBBA4oLmT7sZdHiYE/PeVuifOxYyE2uL/V+9VQP7YSYdJU7bSf7H8bZRRxW8kEPMkmVjnrXmoR3oejIdX0xbg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -19714,6 +19741,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -20259,6 +20287,7 @@
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 - Enhancement: Added "Show in Data sets View" command for CICS Library Datasets to view them in Zowe Explorer. [#633](https://github.com/zowe/cics-for-zowe-client/issues/633)
 - Enhancement: Inquire program, Show Library and Inquire Transaction can open respective resources from Resource Inspector. [#449](https://github.com/zowe/cics-for-zowe-client/issues/449)
 - BugFix: Region filtering selects only regions. [#575](https://github.com/zowe/cics-for-zowe-client/issues/575)
+- BugFix: Enable previously used resource filters to be edited before reuse. [#618](https://github.com/zowe/cics-for-zowe-client/issues/618)
 
 ## `3.20.0`
 

--- a/packages/vsce/__tests__/__e2e__/specs/error.spec.ts
+++ b/packages/vsce/__tests__/__e2e__/specs/error.spec.ts
@@ -89,7 +89,7 @@ test.describe("Error scenarios", () => {
     await expect(filterButton).toBeVisible();
     await filterButton.click();
 
-    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: true });
+    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: false });
     await expect(textBox).toBeEditable();
     await textBox.fill("FILTER");
     await textBox.press("Enter");
@@ -157,7 +157,7 @@ test.describe("Error scenarios", () => {
     await expect(filterButton).toBeVisible();
     await filterButton.click();
 
-    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: true });
+    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: false });
     await expect(textBox).toBeEditable();
     await textBox.fill("PROG3,PROG4");
     await textBox.press("Enter");

--- a/packages/vsce/__tests__/__e2e__/specs/jvmEndpoint.spec.ts
+++ b/packages/vsce/__tests__/__e2e__/specs/jvmEndpoint.spec.ts
@@ -70,7 +70,7 @@ test.describe("JVM Endpoint should be visible from plex-level", () => {
     await expect(filterButton).toBeVisible();
     await filterButton.click();
 
-    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: true });
+    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: false });
     await expect(textBox).toBeEditable();
     await textBox.fill("MYJVM1");
     await textBox.press("Enter");

--- a/packages/vsce/__tests__/__e2e__/specs/regionFilter.spec.ts
+++ b/packages/vsce/__tests__/__e2e__/specs/regionFilter.spec.ts
@@ -72,8 +72,6 @@ test.describe("Region Filter", () => {
     await expect(textBox).toBeEditable();
     await textBox.fill("NOREG");
     await textBox.press("Escape");
-
-    await expect(page.getByText("No Selection Made", { exact: true })).toBeVisible();
   });
   test("Should clear all filters", async ({ page }) => {
     await findAndClickTreeItem(page, constants.PROFILE_NAME);

--- a/packages/vsce/__tests__/__e2e__/specs/regionFilter.spec.ts
+++ b/packages/vsce/__tests__/__e2e__/specs/regionFilter.spec.ts
@@ -31,7 +31,7 @@ test.describe("Region Filter", () => {
     await expect(filterButton).toBeVisible();
     await filterButton.click();
 
-    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: true });
+    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: false });
     await expect(textBox).toBeEditable();
     await textBox.fill("MYREG1");
     await textBox.press("Enter");
@@ -51,7 +51,7 @@ test.describe("Region Filter", () => {
     await expect(filterButton).toBeVisible();
     await filterButton.click();
 
-    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: true });
+    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: false });
     await expect(textBox).toBeEditable();
     await textBox.fill("NOREG");
     await textBox.press("Enter");
@@ -68,7 +68,7 @@ test.describe("Region Filter", () => {
     await expect(filterButton).toBeVisible();
     await filterButton.click();
 
-    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: true });
+    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: false });
     await expect(textBox).toBeEditable();
     await textBox.fill("NOREG");
     await textBox.press("Escape");
@@ -84,7 +84,7 @@ test.describe("Region Filter", () => {
     await expect(filterButton).toBeVisible();
     await filterButton.click();
 
-    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: true });
+    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: false });
     await expect(textBox).toBeEditable();
     await textBox.fill("MYREG1");
     await textBox.press("Enter");
@@ -107,7 +107,7 @@ test.describe("Region Filter", () => {
     await expect(filterButton).toBeVisible();
     await filterButton.click();
 
-    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: true });
+    const textBox = page.getByRole("textbox", { name: "Select a Filter", exact: false });
     await expect(textBox).toBeEditable();
     await textBox.fill("MYREG1");
     await textBox.press("Enter");

--- a/packages/vsce/__tests__/__unit__/commands/filterResourceCommands.test.ts
+++ b/packages/vsce/__tests__/__unit__/commands/filterResourceCommands.test.ts
@@ -81,6 +81,7 @@ describe("Filter Resource Commands", () => {
       const mockPattern = "NEWPROG*";
       (getPatternFromFilter as jest.Mock).mockResolvedValue(mockPattern);
 
+      getFilterResourcesCommand(tree, treeview);
       const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
 
       await commandHandler(resourceNode);
@@ -101,6 +102,7 @@ describe("Filter Resource Commands", () => {
       const mockPattern = "PROG*,CUST*,TEST*";
       (getPatternFromFilter as jest.Mock).mockResolvedValue(mockPattern);
 
+      getFilterResourcesCommand(tree, treeview);
       const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
 
       await commandHandler(resourceNode);
@@ -112,6 +114,7 @@ describe("Filter Resource Commands", () => {
       const mockPattern = "PROG* , CUST* , TEST*";
       (getPatternFromFilter as jest.Mock).mockResolvedValue(mockPattern);
 
+      getFilterResourcesCommand(tree, treeview);
       const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
 
       await commandHandler(resourceNode);
@@ -125,6 +128,7 @@ describe("Filter Resource Commands", () => {
       // Clear previous mock calls
       jest.clearAllMocks();
 
+      getFilterResourcesCommand(tree, treeview);
       const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
 
       await commandHandler(resourceNode);
@@ -147,6 +151,7 @@ describe("Filter Resource Commands", () => {
       };
       resourceNode.resourceTypes.push(secondResourceType as any);
 
+      getFilterResourcesCommand(tree, treeview);
       const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
 
       await commandHandler(resourceNode);
@@ -160,6 +165,7 @@ describe("Filter Resource Commands", () => {
       const mockPattern = "CaseSensitive*";
       (getPatternFromFilter as jest.Mock).mockResolvedValue(mockPattern);
 
+      getFilterResourcesCommand(tree, treeview);
       const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
 
       await commandHandler(resourceNode);
@@ -185,6 +191,7 @@ describe("Filter Resource Commands", () => {
     });
 
     it("should clear filter and reset node", async () => {
+      getClearFilterCommand(tree);
       const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
 
       await commandHandler(resourceNode);
@@ -195,6 +202,7 @@ describe("Filter Resource Commands", () => {
     });
 
     it("should not reveal node after clearing filter", async () => {
+      getClearFilterCommand(tree);
       const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
 
       await commandHandler(resourceNode);

--- a/packages/vsce/__tests__/__unit__/commands/filterResourceCommands.test.ts
+++ b/packages/vsce/__tests__/__unit__/commands/filterResourceCommands.test.ts
@@ -1,0 +1,205 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { IProgram } from "@zowe/cics-for-zowe-explorer-api";
+import { commands, TreeView } from "vscode";
+import { getClearFilterCommand, getFilterResourcesCommand } from "../../../src/commands/filterResourceCommands";
+import { ProgramMeta } from "../../../src/doc";
+import { CICSRegionTree, CICSResourceContainerNode, CICSSessionTree, CICSTree } from "../../../src/trees";
+import { getPatternFromFilter } from "../../../src/utils/filterUtils";
+import PersistentStorage from "../../../src/utils/PersistentStorage";
+import { profile } from "../../__mocks__";
+
+jest.mock("../../../src/utils/filterUtils");
+jest.spyOn(PersistentStorage, "getCriteria").mockReturnValue(undefined);
+
+describe("Filter Resource Commands", () => {
+  let tree: CICSTree;
+  let treeview: TreeView<any>;
+  let sessionTree: CICSSessionTree;
+  let regionTree: CICSRegionTree;
+  let resourceNode: CICSResourceContainerNode<IProgram>;
+
+  beforeEach(() => {
+    tree = new CICSTree();
+    treeview = {
+      reveal: jest.fn().mockResolvedValue(undefined),
+    } as any;
+
+    sessionTree = new CICSSessionTree(profile, tree);
+    regionTree = new CICSRegionTree("REG", {}, sessionTree, undefined, sessionTree);
+
+    resourceNode = new CICSResourceContainerNode<IProgram>(
+      "Programs",
+      {
+        profile,
+        parentNode: regionTree,
+        regionName: "REG",
+      },
+      undefined,
+      [ProgramMeta]
+    );
+
+    // Mock the resource type methods
+    resourceNode.resourceTypes[0].getCriteriaHistory = jest.fn().mockReturnValue(["PROG*", "CUST*"]);
+    resourceNode.resourceTypes[0].appendCriteriaHistory = jest.fn().mockResolvedValue(undefined);
+    resourceNode.resourceTypes[0].filterCaseSensitive = false;
+
+    // Mock node methods
+    resourceNode.reset = jest.fn().mockResolvedValue(undefined);
+    resourceNode.setCriteria = jest.fn();
+    resourceNode.clearCriteria = jest.fn();
+
+    // Mock tree fire method
+    tree._onDidChangeTreeData.fire = jest.fn();
+
+    // Clear mocks
+    jest.clearAllMocks();
+  });
+
+  describe("getFilterResourcesCommand", () => {
+    it("should register the filter resources command", () => {
+      const registerCommandSpy = jest.spyOn(commands, "registerCommand");
+      
+      getFilterResourcesCommand(tree, treeview);
+
+      expect(registerCommandSpy).toHaveBeenCalledWith(
+        "cics-extension-for-zowe.filterResources",
+        expect.any(Function)
+      );
+    });
+
+    it("should apply filter when pattern is provided", async () => {
+      const mockPattern = "NEWPROG*";
+      (getPatternFromFilter as jest.Mock).mockResolvedValue(mockPattern);
+
+      const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
+
+      await commandHandler(resourceNode);
+
+      expect(getPatternFromFilter).toHaveBeenCalledWith(
+        "Programs",
+        ["PROG*", "CUST*"],
+        false
+      );
+      expect(resourceNode.resourceTypes[0].appendCriteriaHistory).toHaveBeenCalledWith(mockPattern);
+      expect(resourceNode.reset).toHaveBeenCalled();
+      expect(resourceNode.setCriteria).toHaveBeenCalledWith([mockPattern]);
+      expect(tree._onDidChangeTreeData.fire).toHaveBeenCalledWith(resourceNode);
+      expect(treeview.reveal).toHaveBeenCalledWith(resourceNode, { expand: true });
+    });
+
+    it("should handle comma-separated patterns", async () => {
+      const mockPattern = "PROG*,CUST*,TEST*";
+      (getPatternFromFilter as jest.Mock).mockResolvedValue(mockPattern);
+
+      const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
+
+      await commandHandler(resourceNode);
+
+      expect(resourceNode.setCriteria).toHaveBeenCalledWith(["PROG*", "CUST*", "TEST*"]);
+    });
+
+    it("should trim whitespace from patterns", async () => {
+      const mockPattern = "PROG* , CUST* , TEST*";
+      (getPatternFromFilter as jest.Mock).mockResolvedValue(mockPattern);
+
+      const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
+
+      await commandHandler(resourceNode);
+
+      expect(resourceNode.setCriteria).toHaveBeenCalledWith(["PROG*", "CUST*", "TEST*"]);
+    });
+
+    it("should not apply filter when no pattern is provided", async () => {
+      (getPatternFromFilter as jest.Mock).mockResolvedValue(undefined);
+
+      // Clear previous mock calls
+      jest.clearAllMocks();
+
+      const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
+
+      await commandHandler(resourceNode);
+
+      expect(resourceNode.reset).not.toHaveBeenCalled();
+      expect(resourceNode.setCriteria).not.toHaveBeenCalled();
+      expect(tree._onDidChangeTreeData.fire).not.toHaveBeenCalled();
+      expect(treeview.reveal).not.toHaveBeenCalled();
+    });
+
+    it("should append criteria to history for all resource types", async () => {
+      const mockPattern = "MULTI*";
+      (getPatternFromFilter as jest.Mock).mockResolvedValue(mockPattern);
+
+      // Add a second resource type
+      const secondResourceType = {
+        getCriteriaHistory: jest.fn().mockReturnValue([]),
+        appendCriteriaHistory: jest.fn().mockResolvedValue(undefined),
+        filterCaseSensitive: false,
+      };
+      resourceNode.resourceTypes.push(secondResourceType as any);
+
+      const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
+
+      await commandHandler(resourceNode);
+
+      expect(resourceNode.resourceTypes[0].appendCriteriaHistory).toHaveBeenCalledWith(mockPattern);
+      expect(secondResourceType.appendCriteriaHistory).toHaveBeenCalledWith(mockPattern);
+    });
+
+    it("should use case sensitive setting from resource type", async () => {
+      resourceNode.resourceTypes[0].filterCaseSensitive = true;
+      const mockPattern = "CaseSensitive*";
+      (getPatternFromFilter as jest.Mock).mockResolvedValue(mockPattern);
+
+      const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
+
+      await commandHandler(resourceNode);
+
+      expect(getPatternFromFilter).toHaveBeenCalledWith(
+        "Programs",
+        ["PROG*", "CUST*"],
+        true
+      );
+    });
+  });
+
+  describe("getClearFilterCommand", () => {
+    it("should register the clear filter command", () => {
+      const registerCommandSpy = jest.spyOn(commands, "registerCommand");
+      
+      getClearFilterCommand(tree);
+
+      expect(registerCommandSpy).toHaveBeenCalledWith(
+        "cics-extension-for-zowe.clearFilter",
+        expect.any(Function)
+      );
+    });
+
+    it("should clear filter and reset node", async () => {
+      const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
+
+      await commandHandler(resourceNode);
+
+      expect(resourceNode.clearCriteria).toHaveBeenCalled();
+      expect(resourceNode.reset).toHaveBeenCalled();
+      expect(tree._onDidChangeTreeData.fire).toHaveBeenCalledWith(resourceNode);
+    });
+
+    it("should not reveal node after clearing filter", async () => {
+      const commandHandler = (commands.registerCommand as jest.Mock).mock.calls[0][1];
+
+      await commandHandler(resourceNode);
+
+      expect(treeview.reveal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/vsce/__tests__/__unit__/utils/filterUtils.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/utils/filterUtils.unit.test.ts
@@ -10,24 +10,255 @@
  */
 
 import { Gui } from "@zowe/zowe-explorer-api";
-import { buildQuickPick, getPatternFromFilter } from "../../../src/utils/filterUtils";
+import { buildQuickPick, FilterDescriptor, getPatternFromFilter, toEscapedCriteriaString } from "../../../src/utils/filterUtils";
+
+describe("FilterDescriptor", () => {
+  it("should create FilterDescriptor with correct label", () => {
+    const descriptor = new FilterDescriptor("Test Label");
+    expect(descriptor.label).toBe("Test Label");
+  });
+
+  it("should have empty description", () => {
+    const descriptor = new FilterDescriptor("Test");
+    expect(descriptor.description).toBe("");
+  });
+
+  it("should always show", () => {
+    const descriptor = new FilterDescriptor("Test");
+    expect(descriptor.alwaysShow).toBe(true);
+  });
+});
+
+describe("toEscapedCriteriaString", () => {
+  it("should create criteria string for single filter", () => {
+    const result = toEscapedCriteriaString("PROG*", "name");
+    expect(result).toBe("(name=PROG*)");
+  });
+
+  it("should create criteria string for multiple filters", () => {
+    const result = toEscapedCriteriaString("PROG*,CUST*,TEST*", "name");
+    expect(result).toBe("(name=PROG* OR name=CUST* OR name=TEST*)");
+  });
+
+  it("should handle different attribute names", () => {
+    const result = toEscapedCriteriaString("VALUE1,VALUE2", "attribute");
+    expect(result).toBe("(attribute=VALUE1 OR attribute=VALUE2)");
+  });
+});
 
 describe("Filter Utils tests", () => {
 
-  it("should return qucikpick object to use", () => {
+  it("should return quickpick object with history items", () => {
 
     const quickpick = buildQuickPick("MYRES", ["prev1", "prev2"]);
 
-    expect(quickpick.items).toHaveLength(3);
-    expect(quickpick.items[0].label).toContain("Create New MYRES Filter");
-    expect(quickpick.items[1]).toEqual({ label: "prev1" });
-    expect(quickpick.items[2]).toEqual({ label: "prev2" });
+    expect(quickpick.items).toHaveLength(2);
+    expect(quickpick.items[0]).toEqual({ label: "prev1" });
+    expect(quickpick.items[1]).toEqual({ label: "prev2" });
+    expect(quickpick.placeholder).toContain("Select a filter or type to create a new one (use commas to separate multiple values)");
 
   });
 
-  it("should get pattern", async () => {
+  it("should get pattern when user types exact match", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "NEWPATTERN",
+    };
+    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
     jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce({ label: "NEWPATTERN" });
+    
     const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
     expect(pattern).toEqual("NEWPATTERN");
+  });
+
+  it("should get pattern when user types without selecting", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "TYPED*",
+    };
+    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
+    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    
+    const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
+    expect(pattern).toEqual("TYPED*");
+  });
+
+  it("should return undefined when no selection and no input", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "",
+    };
+    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
+    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    
+    const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
+    expect(pattern).toBeUndefined();
+  });
+
+  it("should show edit quickpick when user clicks history item", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "",
+    };
+    const mockEditQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "prev1",
+    };
+    
+    let callCount = 0;
+    jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
+    });
+    
+    jest.spyOn(Gui, "resolveQuickPick")
+      .mockResolvedValueOnce({ label: "prev1" })
+      .mockResolvedValueOnce({ label: "prev1", description: "Press Enter to use this filter" });
+    
+    const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
+    expect(pattern).toEqual("PREV1");
+    expect(mockEditQuickPick.show).toHaveBeenCalled();
+  });
+
+  it("should show edit quickpick when user types to filter then clicks different item", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "PRE",
+    };
+    const mockEditQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "prev1",
+    };
+    
+    let callCount = 0;
+    jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
+    });
+    
+    jest.spyOn(Gui, "resolveQuickPick")
+      .mockResolvedValueOnce({ label: "prev1" })
+      .mockResolvedValueOnce({ label: "prev1", description: "Press Enter to use this filter" });
+    
+    const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
+    expect(pattern).toEqual("PREV1");
+    expect(mockEditQuickPick.show).toHaveBeenCalled();
+  });
+
+  it("should convert to uppercase when case insensitive", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "lowercase*",
+    };
+    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
+    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    
+    const pattern = await getPatternFromFilter("MYRES", [], false);
+    expect(pattern).toEqual("LOWERCASE*");
+  });
+
+  it("should preserve case when case sensitive", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "MixedCase*",
+    };
+    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
+    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    
+    const pattern = await getPatternFromFilter("MYRES", [], true);
+    expect(pattern).toEqual("MixedCase*");
+  });
+
+  it("should remove whitespace from pattern", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "PAT TERN*",
+    };
+    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
+    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    
+    const pattern = await getPatternFromFilter("MYRES", [], false);
+    expect(pattern).toEqual("PATTERN*");
+  });
+
+  it("should handle comma-separated patterns", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "PAT1*, PAT2*",
+    };
+    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
+    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    
+    const pattern = await getPatternFromFilter("MYRES", [], false);
+    expect(pattern).toEqual("PAT1*,PAT2*");
+  });
+
+
+  it("should show input box when 'Edit filter' option is selected", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "",
+    };
+    const mockEditQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "prev1",
+    };
+    
+    let callCount = 0;
+    jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
+    });
+    
+    jest.spyOn(Gui, "resolveQuickPick")
+      .mockResolvedValueOnce({ label: "prev1" })
+      .mockResolvedValueOnce({ label: "Edit filter", description: "Modify the filter before applying" });
+    
+    jest.spyOn(Gui, "showInputBox").mockResolvedValueOnce("INPUTBOX*");
+    
+    const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
+    expect(pattern).toEqual("INPUTBOX*");
+    expect(Gui.showInputBox).toHaveBeenCalled();
+  });
+
+  it("should return undefined when pattern is empty after input", async () => {
+    const mockQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "",
+    };
+    const mockEditQuickPick = {
+      show: jest.fn(),
+      hide: jest.fn(),
+      value: "prev1",
+    };
+    
+    let callCount = 0;
+    jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
+    });
+    
+    jest.spyOn(Gui, "resolveQuickPick")
+      .mockResolvedValueOnce({ label: "prev1" })
+      .mockResolvedValueOnce({ label: "Edit filter", description: "Modify the filter before applying" });
+    
+    jest.spyOn(Gui, "showInputBox").mockResolvedValueOnce("");
+    
+    const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
+    expect(pattern).toBeUndefined();
   });
 });

--- a/packages/vsce/__tests__/__unit__/utils/filterUtils.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/utils/filterUtils.unit.test.ts
@@ -13,17 +13,33 @@ import { Gui } from "@zowe/zowe-explorer-api";
 import { buildQuickPick, FilterDescriptor, getPatternFromFilter, toEscapedCriteriaString } from "../../../src/utils/filterUtils";
 
 // Helper function to create a mock QuickPick
-const createMockQuickPick = (value: string) => ({
-  show: jest.fn(),
-  hide: jest.fn(),
-  value,
-});
+const createMockQuickPick = (value: string, selectedItems: any[] = []) => {
+  const mockQuickPick = {
+    show: jest.fn(),
+    hide: jest.fn(),
+    value,
+    selectedItems,
+    onDidAccept: jest.fn(),
+    onDidHide: jest.fn(),
+  };
+  
+  // Auto-trigger onDidAccept when show is called (simulates user pressing Enter)
+  mockQuickPick.show.mockImplementation(() => {
+    const acceptHandler = mockQuickPick.onDidAccept.mock.calls[0]?.[0];
+    if (acceptHandler) {
+      // Simulate async behavior
+      setTimeout(() => acceptHandler(), 0);
+    }
+  });
+  
+  return mockQuickPick;
+};
 
 // Helper function to setup single quickpick scenario
 const setupSingleQuickPick = (value: string, resolvedValue?: { label: string; description?: string }) => {
-  const mockQuickPick = createMockQuickPick(value);
+  const selectedItems = resolvedValue ? [resolvedValue] : [];
+  const mockQuickPick = createMockQuickPick(value, selectedItems);
   jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
-  jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(resolvedValue);
   return mockQuickPick;
 };
 
@@ -34,18 +50,17 @@ const setupDualQuickPick = (
   firstResolve: { label: string; description?: string },
   secondResolve: { label: string; description?: string }
 ) => {
-  const mockQuickPick = createMockQuickPick(initialValue);
-  const mockEditQuickPick = createMockQuickPick(editValue);
+  const firstSelectedItems = firstResolve ? [firstResolve] : [];
+  const secondSelectedItems = secondResolve ? [secondResolve] : [];
+  
+  const mockQuickPick = createMockQuickPick(initialValue, firstSelectedItems);
+  const mockEditQuickPick = createMockQuickPick(editValue, secondSelectedItems);
   
   let callCount = 0;
   jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
     callCount++;
     return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
   });
-  
-  jest.spyOn(Gui, "resolveQuickPick")
-    .mockResolvedValueOnce(firstResolve)
-    .mockResolvedValueOnce(secondResolve);
   
   return { mockQuickPick, mockEditQuickPick };
 };

--- a/packages/vsce/__tests__/__unit__/utils/filterUtils.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/utils/filterUtils.unit.test.ts
@@ -12,6 +12,44 @@
 import { Gui } from "@zowe/zowe-explorer-api";
 import { buildQuickPick, FilterDescriptor, getPatternFromFilter, toEscapedCriteriaString } from "../../../src/utils/filterUtils";
 
+// Helper function to create a mock QuickPick
+const createMockQuickPick = (value: string) => ({
+  show: jest.fn(),
+  hide: jest.fn(),
+  value,
+});
+
+// Helper function to setup single quickpick scenario
+const setupSingleQuickPick = (value: string, resolvedValue?: { label: string; description?: string }) => {
+  const mockQuickPick = createMockQuickPick(value);
+  jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
+  jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(resolvedValue);
+  return mockQuickPick;
+};
+
+// Helper function to setup dual quickpick scenario (initial + edit)
+const setupDualQuickPick = (
+  initialValue: string,
+  editValue: string,
+  firstResolve: { label: string; description?: string },
+  secondResolve: { label: string; description?: string }
+) => {
+  const mockQuickPick = createMockQuickPick(initialValue);
+  const mockEditQuickPick = createMockQuickPick(editValue);
+  
+  let callCount = 0;
+  jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
+    callCount++;
+    return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
+  });
+  
+  jest.spyOn(Gui, "resolveQuickPick")
+    .mockResolvedValueOnce(firstResolve)
+    .mockResolvedValueOnce(secondResolve);
+  
+  return { mockQuickPick, mockEditQuickPick };
+};
+
 describe("FilterDescriptor", () => {
   it("should create FilterDescriptor with correct label", () => {
     const descriptor = new FilterDescriptor("Test Label");
@@ -60,65 +98,33 @@ describe("Filter Utils tests", () => {
   });
 
   it("should get pattern when user types exact match", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "NEWPATTERN",
-    };
-    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
-    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce({ label: "NEWPATTERN" });
+    setupSingleQuickPick("NEWPATTERN", { label: "NEWPATTERN" });
     
     const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
     expect(pattern).toEqual("NEWPATTERN");
   });
 
   it("should get pattern when user types without selecting", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "TYPED*",
-    };
-    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
-    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    setupSingleQuickPick("TYPED*", undefined);
     
     const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
     expect(pattern).toEqual("TYPED*");
   });
 
   it("should return undefined when no selection and no input", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "",
-    };
-    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
-    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    setupSingleQuickPick("", undefined);
     
     const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
     expect(pattern).toBeUndefined();
   });
 
   it("should show edit quickpick when user clicks history item", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "",
-    };
-    const mockEditQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "prev1",
-    };
-    
-    let callCount = 0;
-    jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
-      callCount++;
-      return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
-    });
-    
-    jest.spyOn(Gui, "resolveQuickPick")
-      .mockResolvedValueOnce({ label: "prev1" })
-      .mockResolvedValueOnce({ label: "prev1", description: "Press Enter to use this filter" });
+    const { mockEditQuickPick } = setupDualQuickPick(
+      "",
+      "prev1",
+      { label: "prev1" },
+      { label: "prev1", description: "Press Enter to use this filter" }
+    );
     
     const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
     expect(pattern).toEqual("PREV1");
@@ -126,26 +132,12 @@ describe("Filter Utils tests", () => {
   });
 
   it("should show edit quickpick when user types to filter then clicks different item", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "PRE",
-    };
-    const mockEditQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "prev1",
-    };
-    
-    let callCount = 0;
-    jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
-      callCount++;
-      return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
-    });
-    
-    jest.spyOn(Gui, "resolveQuickPick")
-      .mockResolvedValueOnce({ label: "prev1" })
-      .mockResolvedValueOnce({ label: "prev1", description: "Press Enter to use this filter" });
+    const { mockEditQuickPick } = setupDualQuickPick(
+      "PRE",
+      "prev1",
+      { label: "prev1" },
+      { label: "prev1", description: "Press Enter to use this filter" }
+    );
     
     const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
     expect(pattern).toEqual("PREV1");
@@ -153,52 +145,28 @@ describe("Filter Utils tests", () => {
   });
 
   it("should convert to uppercase when case insensitive", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "lowercase*",
-    };
-    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
-    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    setupSingleQuickPick("lowercase*", undefined);
     
     const pattern = await getPatternFromFilter("MYRES", [], false);
     expect(pattern).toEqual("LOWERCASE*");
   });
 
   it("should preserve case when case sensitive", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "MixedCase*",
-    };
-    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
-    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    setupSingleQuickPick("MixedCase*", undefined);
     
     const pattern = await getPatternFromFilter("MYRES", [], true);
     expect(pattern).toEqual("MixedCase*");
   });
 
   it("should remove whitespace from pattern", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "PAT TERN*",
-    };
-    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
-    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    setupSingleQuickPick("PAT TERN*", undefined);
     
     const pattern = await getPatternFromFilter("MYRES", [], false);
     expect(pattern).toEqual("PATTERN*");
   });
 
   it("should handle comma-separated patterns", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "PAT1*, PAT2*",
-    };
-    jest.spyOn(Gui, "createQuickPick").mockReturnValue(mockQuickPick as any);
-    jest.spyOn(Gui, "resolveQuickPick").mockResolvedValueOnce(undefined);
+    setupSingleQuickPick("PAT1*, PAT2*", undefined);
     
     const pattern = await getPatternFromFilter("MYRES", [], false);
     expect(pattern).toEqual("PAT1*,PAT2*");
@@ -206,27 +174,12 @@ describe("Filter Utils tests", () => {
 
 
   it("should show input box when 'Edit filter' option is selected", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "",
-    };
-    const mockEditQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "prev1",
-    };
-    
-    let callCount = 0;
-    jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
-      callCount++;
-      return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
-    });
-    
-    jest.spyOn(Gui, "resolveQuickPick")
-      .mockResolvedValueOnce({ label: "prev1" })
-      .mockResolvedValueOnce({ label: "Edit filter", description: "Modify the filter before applying" });
-    
+    setupDualQuickPick(
+      "",
+      "prev1",
+      { label: "prev1" },
+      { label: "Edit filter", description: "Modify the filter before applying" }
+    );
     jest.spyOn(Gui, "showInputBox").mockResolvedValueOnce("INPUTBOX*");
     
     const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);
@@ -235,27 +188,12 @@ describe("Filter Utils tests", () => {
   });
 
   it("should return undefined when pattern is empty after input", async () => {
-    const mockQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "",
-    };
-    const mockEditQuickPick = {
-      show: jest.fn(),
-      hide: jest.fn(),
-      value: "prev1",
-    };
-    
-    let callCount = 0;
-    jest.spyOn(Gui, "createQuickPick").mockImplementation(() => {
-      callCount++;
-      return callCount === 1 ? mockQuickPick as any : mockEditQuickPick as any;
-    });
-    
-    jest.spyOn(Gui, "resolveQuickPick")
-      .mockResolvedValueOnce({ label: "prev1" })
-      .mockResolvedValueOnce({ label: "Edit filter", description: "Modify the filter before applying" });
-    
+    setupDualQuickPick(
+      "",
+      "prev1",
+      { label: "prev1" },
+      { label: "Edit filter", description: "Modify the filter before applying" }
+    );
     jest.spyOn(Gui, "showInputBox").mockResolvedValueOnce("");
     
     const pattern = await getPatternFromFilter("MYRES", ["prev1"], false);

--- a/packages/vsce/l10n/bundle.l10n.json
+++ b/packages/vsce/l10n/bundle.l10n.json
@@ -15,8 +15,11 @@
   "Profile {0} is invalid or not present": "Profile {0} is invalid or not present",
   "Error fetching CICSplex information for profile with reason {0}": "Error fetching CICSplex information for profile with reason {0}",
   "Select CICS Region": "Select CICS Region",
-  "{0} Create New {1} Filter (use a comma to separate multiple patterns e.g. LG*,I*)": "{0} Create New {1} Filter (use a comma to separate multiple patterns e.g. LG*,I*)",
-  "Select a Filter": "Select a Filter",
+  "Select a filter or type to create a new one (use commas to separate multiple values)": "Select a filter or type to create a new one (use commas to separate multiple values)",
+  "Press Enter to use this filter": "Press Enter to use this filter",
+  "Edit filter": "Edit filter",
+  "Modify the filter before applying": "Modify the filter before applying",
+  "Press Enter to use '{0}' or select 'Edit filter'": "Press Enter to use '{0}' or select 'Edit filter'",
   "No Selection Made": "No Selection Made",
   "You must enter a pattern": "You must enter a pattern",
   "Select a profile to access the logs": "Select a profile to access the logs",
@@ -27,7 +30,9 @@
   "Initialized logger for Zowe Explorer for IBM CICS TS": "Initialized logger for Zowe Explorer for IBM CICS TS",
   "Zowe Explorer for IBM CICS TS log level: {0}/Log level": {
     "message": "Zowe Explorer for IBM CICS TS log level: {0}",
-    "comment": ["Log level"]
+    "comment": [
+      "Log level"
+    ]
   },
   "View more...": "View more...",
   "Could not find region data and job id for region {0} to show logs.": "Could not find region data and job id for region {0} to show logs.",

--- a/packages/vsce/l10n/bundle.l10n.json
+++ b/packages/vsce/l10n/bundle.l10n.json
@@ -20,8 +20,6 @@
   "Edit filter": "Edit filter",
   "Modify the filter before applying": "Modify the filter before applying",
   "Press Enter to use '{0}' or select 'Edit filter'": "Press Enter to use '{0}' or select 'Edit filter'",
-  "No Selection Made": "No Selection Made",
-  "You must enter a pattern": "You must enter a pattern",
   "Select a profile to access the logs": "Select a profile to access the logs",
   "Region name is missing in the node description.": "Region name is missing in the node description.",
   "Are you sure you want to {0} the following {1}?": "Are you sure you want to {0} the following {1}?",

--- a/packages/vsce/src/utils/filterUtils.ts
+++ b/packages/vsce/src/utils/filterUtils.ts
@@ -38,6 +38,84 @@ export const buildQuickPick = (resName: string, history: string[]) => {
   return quickpick;
 };
 
+/**
+ * Shows an edit quickpick dialog for a selected filter choice.
+ * Allows the user to either use the filter as-is or edit it before applying.
+ *
+ * @internal This is an internal helper function for getPatternFromFilter
+ * @param choiceLabel - The label of the selected filter choice
+ * @returns The pattern to use, or undefined if cancelled
+ */
+export async function showEditQuickpick(choiceLabel: string): Promise<string | undefined> {
+  const editQuickpick = Gui.createQuickPick();
+  editQuickpick.items = [
+    { label: choiceLabel, description: l10n.t("Press Enter to use this filter") },
+    { label: l10n.t("Edit filter"), description: l10n.t("Modify the filter before applying") }
+  ];
+  editQuickpick.placeholder = l10n.t("Press Enter to use '{0}' or select 'Edit filter'", choiceLabel);
+  editQuickpick.value = choiceLabel;
+  editQuickpick.ignoreFocusOut = true;
+  editQuickpick.show();
+  
+  const editChoice = await Gui.resolveQuickPick(editQuickpick);
+  const editInput = editQuickpick.value;
+  editQuickpick.hide();
+  
+  // If user pressed Enter without selecting an item, use the edited input
+  if (!editChoice && editInput) {
+    return editInput;
+  }
+  
+  if (!editChoice) {
+    // User cancelled without any input
+    window.showInformationMessage(l10n.t("No Selection Made"));
+    return undefined;
+  }
+  
+  // If user modified the input or selected first option, use the input value
+  if (editInput !== choiceLabel || editChoice.label === choiceLabel) {
+    return editInput;
+  }
+  
+  // User selected "Edit filter" - show input box
+  return Gui.showInputBox({
+    prompt: l10n.t("Edit filter"),
+    value: choiceLabel
+  });
+}
+
+/**
+ * Normalizes and formats a pattern string.
+ * Converts to uppercase if case-insensitive and removes whitespace.
+ *
+ * @internal This is an internal helper function for getPatternFromFilter
+ * @param pattern - The pattern to normalize
+ * @param caseSensitive - Whether the pattern should be case-sensitive
+ * @returns The normalized pattern
+ */
+export function normalizePattern(pattern: string, caseSensitive: boolean): string {
+  let normalized = pattern;
+  if (!caseSensitive) {
+    normalized = normalized.toUpperCase();
+  }
+  return normalized.replace(/\s/g, "");
+}
+
+/**
+ * Checks if user input matches the selected choice (case-insensitive comparison).
+ *
+ * @internal This is an internal helper function for getPatternFromFilter
+ * @param userInput - The text typed by the user
+ * @param choiceLabel - The label of the selected choice
+ * @param caseSensitive - Whether to perform case-sensitive comparison
+ * @returns True if the input matches the choice
+ */
+export function inputMatchesChoice(userInput: string, choiceLabel: string, caseSensitive: boolean): boolean {
+  const normalizedInput = caseSensitive ? userInput : userInput.toUpperCase();
+  const normalizedChoice = caseSensitive ? choiceLabel : choiceLabel.toUpperCase();
+  return normalizedInput === normalizedChoice;
+}
+
 export async function getPatternFromFilter(resourceName: string, resourceHistory: string[], filterCaseSensitive: boolean = false) {
   const quickpick = buildQuickPick(resourceName, resourceHistory);
   quickpick.show();
@@ -45,100 +123,33 @@ export async function getPatternFromFilter(resourceName: string, resourceHistory
   const userInput = quickpick.value;
   quickpick.hide();
 
-  let pattern: string;
-  if (!choice && userInput) {
-    pattern = userInput;
-  } else if (!choice) {
-    return;
+  let pattern: string | undefined;
+  
+  // Handle case where no choice was selected
+  if (!choice) {
+    if (userInput) {
+      pattern = userInput;
+    } else {
+      return undefined;
+    }
   } else {
     // A history item was selected
-    // Check if user typed the value or clicked a different item from the list
-    const normalizedInput = filterCaseSensitive ? userInput : userInput.toUpperCase();
-    const normalizedChoice = filterCaseSensitive ? choice.label : choice.label.toUpperCase();
-    
-    if (userInput && normalizedInput === normalizedChoice) {
-      // User typed text that matches the selected item exactly - apply immediately
+    // If user typed text that matches the selected item exactly, apply immediately
+    if (userInput && inputMatchesChoice(userInput, choice.label, filterCaseSensitive)) {
       pattern = userInput;
-    } else if (userInput && normalizedInput !== normalizedChoice) {
-      // User typed to filter, then clicked a different item - show edit quickpick with that item
-      // This handles: user types "CUS" to filter, then clicks "CUSTOMER" from filtered list
-      const editQuickpick = Gui.createQuickPick();
-      editQuickpick.items = [
-        { label: choice.label, description: l10n.t("Press Enter to use this filter") },
-        { label: l10n.t("Edit filter"), description: l10n.t("Modify the filter before applying") }
-      ];
-      editQuickpick.placeholder = l10n.t("Press Enter to use '{0}' or select 'Edit filter'", choice.label);
-      editQuickpick.value = choice.label;
-      editQuickpick.ignoreFocusOut = true;
-      editQuickpick.show();
-      
-      const editChoice = await Gui.resolveQuickPick(editQuickpick);
-      const editInput = editQuickpick.value;
-      editQuickpick.hide();
-      
-      // If user pressed Enter without selecting an item, use the edited input
-      if (!editChoice && editInput) {
-        pattern = editInput;
-      } else if (!editChoice) {
-        // User cancelled without any input
-        window.showInformationMessage(l10n.t("No Selection Made"));
-        return;
-      } else if (editInput !== choice.label || editChoice.label === choice.label) {
-        // If user modified the input or selected first option, use the input value
-        pattern = editInput;
-      } else {
-        // User selected "Edit filter" - show input box
-        pattern = await Gui.showInputBox({
-          prompt: l10n.t("Edit filter"),
-          value: choice.label
-        });
-      }
     } else {
-      // No text in input - user clicked a history item directly - show edit quickpick
-      const editQuickpick = Gui.createQuickPick();
-      editQuickpick.items = [
-        { label: choice.label, description: l10n.t("Press Enter to use this filter") },
-        { label: l10n.t("Edit filter"), description: l10n.t("Modify the filter before applying") }
-      ];
-      editQuickpick.placeholder = l10n.t("Press Enter to use '{0}' or select 'Edit filter'", choice.label);
-      editQuickpick.value = choice.label;
-      editQuickpick.ignoreFocusOut = true;
-      editQuickpick.show();
-      
-      const editChoice = await Gui.resolveQuickPick(editQuickpick);
-      const editInput = editQuickpick.value;
-      editQuickpick.hide();
-      
-      // If user pressed Enter without selecting an item, use the edited input
-      if (!editChoice && editInput) {
-        pattern = editInput;
-      } else if (!editChoice) {
-        // User cancelled without any input
-        window.showInformationMessage(l10n.t("No Selection Made"));
-        return;
-      } else if (editInput !== choice.label || editChoice.label === choice.label) {
-        // If user modified the input or selected first option, use the input value
-        pattern = editInput;
-      } else {
-        // User selected "Edit filter" - show input box
-        pattern = await Gui.showInputBox({
-          prompt: l10n.t("Edit filter"),
-          value: choice.label
-        });
-      }
+      // User either clicked directly or typed to filter then clicked a different item
+      // Show edit quickpick to allow confirmation or editing
+      pattern = await showEditQuickpick(choice.label);
     }
   }
 
   if (!pattern) {
     window.showInformationMessage(l10n.t("You must enter a pattern"));
-    return;
+    return undefined;
   }
 
-  if (!filterCaseSensitive) {
-    pattern = pattern.toUpperCase();
-  }
-
-  return pattern.replace(/\s/g, "");
+  return normalizePattern(pattern, filterCaseSensitive);
 }
 
 export function toEscapedCriteriaString(activeFilter: string, attribute: string): string {

--- a/packages/vsce/src/utils/filterUtils.ts
+++ b/packages/vsce/src/utils/filterUtils.ts
@@ -26,16 +26,13 @@ export class FilterDescriptor implements QuickPickItem {
 }
 
 export const buildQuickPick = (resName: string, history: string[]) => {
-  const createPick = new FilterDescriptor(
-    l10n.t("{0} Create New {1} Filter (use a comma to separate multiple patterns e.g. LG*,I*)", "\uFF0B", resName)
-  );
   const items = history.map((loadedFilter) => {
     return { label: loadedFilter };
   });
 
   const quickpick = Gui.createQuickPick();
-  quickpick.items = [createPick, ...items];
-  quickpick.placeholder = l10n.t("Select a Filter");
+  quickpick.items = items;
+  quickpick.placeholder = l10n.t("Select a filter or type to create a new one (use commas to separate multiple values)");
   quickpick.ignoreFocusOut = true;
 
   return quickpick;
@@ -45,20 +42,91 @@ export async function getPatternFromFilter(resourceName: string, resourceHistory
   const quickpick = buildQuickPick(resourceName, resourceHistory);
   quickpick.show();
   const choice = await Gui.resolveQuickPick(quickpick);
+  const userInput = quickpick.value;
   quickpick.hide();
 
-  if (!choice) {
-    window.showInformationMessage(l10n.t("No Selection Made"));
+  let pattern: string;
+  if (!choice && userInput) {
+    pattern = userInput;
+  } else if (!choice) {
     return;
-  }
-
-  let pattern: string = "";
-  if (choice instanceof FilterDescriptor && quickpick.value) {
-    pattern = quickpick.value;
-  } else if (choice instanceof FilterDescriptor) {
-    pattern = await Gui.showInputBox({ prompt: "", value: pattern });
   } else {
-    pattern = choice.label;
+    // A history item was selected
+    // Check if user typed the value or clicked a different item from the list
+    const normalizedInput = filterCaseSensitive ? userInput : userInput.toUpperCase();
+    const normalizedChoice = filterCaseSensitive ? choice.label : choice.label.toUpperCase();
+    
+    if (userInput && normalizedInput === normalizedChoice) {
+      // User typed text that matches the selected item exactly - apply immediately
+      pattern = userInput;
+    } else if (userInput && normalizedInput !== normalizedChoice) {
+      // User typed to filter, then clicked a different item - show edit quickpick with that item
+      // This handles: user types "CUS" to filter, then clicks "CUSTOMER" from filtered list
+      const editQuickpick = Gui.createQuickPick();
+      editQuickpick.items = [
+        { label: choice.label, description: l10n.t("Press Enter to use this filter") },
+        { label: l10n.t("Edit filter"), description: l10n.t("Modify the filter before applying") }
+      ];
+      editQuickpick.placeholder = l10n.t("Press Enter to use '{0}' or select 'Edit filter'", choice.label);
+      editQuickpick.value = choice.label;
+      editQuickpick.ignoreFocusOut = true;
+      editQuickpick.show();
+      
+      const editChoice = await Gui.resolveQuickPick(editQuickpick);
+      const editInput = editQuickpick.value;
+      editQuickpick.hide();
+      
+      // If user pressed Enter without selecting an item, use the edited input
+      if (!editChoice && editInput) {
+        pattern = editInput;
+      } else if (!editChoice) {
+        // User cancelled without any input
+        window.showInformationMessage(l10n.t("No Selection Made"));
+        return;
+      } else if (editInput !== choice.label || editChoice.label === choice.label) {
+        // If user modified the input or selected first option, use the input value
+        pattern = editInput;
+      } else {
+        // User selected "Edit filter" - show input box
+        pattern = await Gui.showInputBox({
+          prompt: l10n.t("Edit filter"),
+          value: choice.label
+        });
+      }
+    } else {
+      // No text in input - user clicked a history item directly - show edit quickpick
+      const editQuickpick = Gui.createQuickPick();
+      editQuickpick.items = [
+        { label: choice.label, description: l10n.t("Press Enter to use this filter") },
+        { label: l10n.t("Edit filter"), description: l10n.t("Modify the filter before applying") }
+      ];
+      editQuickpick.placeholder = l10n.t("Press Enter to use '{0}' or select 'Edit filter'", choice.label);
+      editQuickpick.value = choice.label;
+      editQuickpick.ignoreFocusOut = true;
+      editQuickpick.show();
+      
+      const editChoice = await Gui.resolveQuickPick(editQuickpick);
+      const editInput = editQuickpick.value;
+      editQuickpick.hide();
+      
+      // If user pressed Enter without selecting an item, use the edited input
+      if (!editChoice && editInput) {
+        pattern = editInput;
+      } else if (!editChoice) {
+        // User cancelled without any input
+        window.showInformationMessage(l10n.t("No Selection Made"));
+        return;
+      } else if (editInput !== choice.label || editChoice.label === choice.label) {
+        // If user modified the input or selected first option, use the input value
+        pattern = editInput;
+      } else {
+        // User selected "Edit filter" - show input box
+        pattern = await Gui.showInputBox({
+          prompt: l10n.t("Edit filter"),
+          value: choice.label
+        });
+      }
+    }
   }
 
   if (!pattern) {

--- a/packages/vsce/src/utils/filterUtils.ts
+++ b/packages/vsce/src/utils/filterUtils.ts
@@ -10,7 +10,7 @@
  */
 
 import { Gui } from "@zowe/zowe-explorer-api";
-import { type QuickPickItem, l10n, window } from "vscode";
+import { type QuickPickItem, l10n } from "vscode";
 
 export class FilterDescriptor implements QuickPickItem {
   constructor(private text: string) {}
@@ -26,15 +26,10 @@ export class FilterDescriptor implements QuickPickItem {
 }
 
 export const buildQuickPick = (resName: string, history: string[]) => {
-  const items = history.map((loadedFilter) => {
-    return { label: loadedFilter };
-  });
-
   const quickpick = Gui.createQuickPick();
-  quickpick.items = items;
+  quickpick.items = history.map((loadedFilter) => ({ label: loadedFilter }));
   quickpick.placeholder = l10n.t("Select a filter or type to create a new one (use commas to separate multiple values)");
   quickpick.ignoreFocusOut = true;
-
   return quickpick;
 };
 
@@ -55,32 +50,43 @@ export async function showEditQuickpick(choiceLabel: string): Promise<string | u
   editQuickpick.placeholder = l10n.t("Press Enter to use '{0}' or select 'Edit filter'", choiceLabel);
   editQuickpick.value = choiceLabel;
   editQuickpick.ignoreFocusOut = true;
-  editQuickpick.show();
   
-  const editChoice = await Gui.resolveQuickPick(editQuickpick);
+  return new Promise<string | undefined>((resolve) => {
+    let wasAccepted = false;
+    
+    editQuickpick.onDidAccept(() => {
+      wasAccepted = true;
+      const selectedItem = editQuickpick.selectedItems[0];
   const editInput = editQuickpick.value;
+      
   editQuickpick.hide();
   
-  // If user pressed Enter without selecting an item, use the edited input
-  if (!editChoice && editInput) {
-    return editInput;
+      if (selectedItem) {
+        // User selected an item from the list
+        if (selectedItem.label === choiceLabel) {
+          // Selected first option - use the input value (may have been edited)
+          resolve(editInput);
+        } else {
+          // Selected "Edit filter" - show input box
+          Gui.showInputBox({
+            prompt: l10n.t("Edit filter"),
+            value: choiceLabel
+          }).then(resolve);
   }
-  
-  if (!editChoice) {
-    // User cancelled without any input
-    window.showInformationMessage(l10n.t("No Selection Made"));
-    return undefined;
-  }
-  
-  // If user modified the input or selected first option, use the input value
-  if (editInput !== choiceLabel || editChoice.label === choiceLabel) {
-    return editInput;
-  }
-  
-  // User selected "Edit filter" - show input box
-  return Gui.showInputBox({
-    prompt: l10n.t("Edit filter"),
-    value: choiceLabel
+      } else {
+        // User pressed Enter without selecting an item - use the edited input (or undefined if empty)
+        resolve(editInput || undefined);
+      }
+    });
+    
+    editQuickpick.onDidHide(() => {
+      if (!wasAccepted) {
+        // User pressed Escape or dismissed without accepting
+        resolve(undefined);
+      }
+    });
+    
+    editQuickpick.show();
   });
 }
 
@@ -118,38 +124,47 @@ export function inputMatchesChoice(userInput: string, choiceLabel: string, caseS
 
 export async function getPatternFromFilter(resourceName: string, resourceHistory: string[], filterCaseSensitive: boolean = false) {
   const quickpick = buildQuickPick(resourceName, resourceHistory);
-  quickpick.show();
-  const choice = await Gui.resolveQuickPick(quickpick);
+  
+  return new Promise<string | undefined>((resolve) => {
+    let wasAccepted = false;
+    
+    // Track when user accepts (Enter key or item selection)
+    quickpick.onDidAccept(() => {
+      wasAccepted = true;
+      const selectedItem = quickpick.selectedItems[0];
   const userInput = quickpick.value;
+      
   quickpick.hide();
 
-  let pattern: string | undefined;
-  
-  // Handle case where no choice was selected
-  if (!choice) {
-    if (userInput) {
-      pattern = userInput;
-    } else {
-      return undefined;
-    }
-  } else {
-    // A history item was selected
+      // If an item was selected from the list
+      if (selectedItem) {
     // If user typed text that matches the selected item exactly, apply immediately
-    if (userInput && inputMatchesChoice(userInput, choice.label, filterCaseSensitive)) {
-      pattern = userInput;
+        if (userInput && inputMatchesChoice(userInput, selectedItem.label, filterCaseSensitive)) {
+          const normalized = normalizePattern(userInput, filterCaseSensitive);
+          resolve(normalized);
     } else {
       // User either clicked directly or typed to filter then clicked a different item
       // Show edit quickpick to allow confirmation or editing
-      pattern = await showEditQuickpick(choice.label);
-    }
-  }
-
-  if (!pattern) {
-    window.showInformationMessage(l10n.t("You must enter a pattern"));
-    return undefined;
-  }
-
-  return normalizePattern(pattern, filterCaseSensitive);
+          showEditQuickpick(selectedItem.label).then((pattern) => {
+            resolve(pattern ? normalizePattern(pattern, filterCaseSensitive) : undefined);
+          });
+        }
+      } else {
+        // User typed something new and pressed Enter (no item selected), or pressed Enter with no input
+        resolve(userInput ? normalizePattern(userInput, filterCaseSensitive) : undefined);
+      }
+    });
+    
+    // Track when user dismisses (Escape key or clicking outside)
+    quickpick.onDidHide(() => {
+      if (!wasAccepted) {
+        // User pressed Escape or dismissed without accepting
+        resolve(undefined);
+      }
+    });
+    
+    quickpick.show();
+  });
 }
 
 export function toEscapedCriteriaString(activeFilter: string, attribute: string): string {


### PR DESCRIPTION
**What It Does**
Adds back the functionality to pick a previously used filter of resources and edit it before submission, rather than using it straight away.
Resolved #618 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
