### PR TITLE
Correct filtering when we have set a region in the zowe config file

### DIFF
--- a/packages/vsce/src/commands/clearPlexFilterCommand.ts
+++ b/packages/vsce/src/commands/clearPlexFilterCommand.ts
@@ -20,6 +20,7 @@ import type { CICSTree } from "../trees/CICSTree";
  */
 export function getClearPlexFilterCommand(tree: CICSTree) {
   return commands.registerCommand("cics-extension-for-zowe.clearPlexFilter", async (node: CICSRegionsContainer) => {
-    node.filterRegions("*", tree);
+    await node.filterRegions("*");
+    tree._onDidChangeTreeData.fire(node);
   });
 }

--- a/packages/vsce/src/commands/getFilterPlexResources.ts
+++ b/packages/vsce/src/commands/getFilterPlexResources.ts
@@ -25,24 +25,28 @@ import { getPatternFromFilter } from "../utils/filterUtils";
 export function getFilterPlexResources(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.filterPlexResources", async (node) => {
     const selection = treeview.selection;
-    let chosenNode: any;
-    if (node) {
-      chosenNode = node;
-    } else if (selection[selection.length - 1] && selection[selection.length - 1] instanceof CICSRegionsContainer) {
-      chosenNode = selection[selection.length - 1];
-    } else {
+    const chosenNode = node || selection[selection.length - 1];
+
+    if (!chosenNode || !(chosenNode instanceof CICSRegionsContainer)) {
       window.showErrorMessage(l10n.t("No 'Regions' node selected"));
       return;
     }
+
     await treeview.reveal(chosenNode, { expand: true });
 
-    // Only filter regions
     const resourceHistory = PersistentStorage.getSearchHistory(CicsCmciConstants.CICS_CMCI_MANAGED_REGION);
+    const profile = chosenNode.getParent().getProfile().profile;
+    const profileRegionName = profile.cicsPlex && profile.regionName ? profile.regionName.toUpperCase() : undefined;
+
+    if (profileRegionName && !resourceHistory.includes(profileRegionName)) {
+      resourceHistory.unshift(profileRegionName);
+    }
+
     const pattern = await getPatternFromFilter("Region", resourceHistory);
 
     if (pattern) {
       await PersistentStorage.appendSearchHistory(CicsCmciConstants.CICS_CMCI_MANAGED_REGION, pattern);
-      chosenNode.filterRegions(pattern, tree);
+      await chosenNode.filterRegions(pattern);
       tree._onDidChangeTreeData.fire(chosenNode);
     }
   });

--- a/packages/vsce/src/extension.ts
+++ b/packages/vsce/src/extension.ts
@@ -83,7 +83,7 @@ export async function activate(context: ExtensionContext): Promise<IExtensionAPI
     treeDataProv._onDidChangeTreeData.fire(node.element);
   });
 
-  treeview.onDidCollapseElement((node) => {
+  treeview.onDidCollapseElement(async (node) => {
     const interestedContextValues = ["cicsregionscontainer."];
 
     if (interestedContextValues.some((item) => node.element.contextValue.includes(item))) {

--- a/packages/vsce/src/trees/CICSPlexTree.ts
+++ b/packages/vsce/src/trees/CICSPlexTree.ts
@@ -106,11 +106,7 @@ export class CICSPlexTree extends TreeItem {
       return this.children;
     }
 
-    if (this.profile.profile.regionName && this.profile.profile.cicsPlex && !this.getGroupName()) {
-      await this.loadOnlyRegion();
-      return this.children;
-    }
-
+    // Always show the Regions container
     this.regionsContainer.collapsibleState = TreeItemCollapsibleState.Expanded;
     return this.children;
   }

--- a/packages/vsce/src/trees/CICSRegionsContainer.ts
+++ b/packages/vsce/src/trees/CICSRegionsContainer.ts
@@ -24,7 +24,8 @@ export class CICSRegionsContainer extends TreeItem {
   children: CICSRegionTree[];
   parent: CICSPlexTree;
   activeFilter: string;
-  private requireDescriptionUpdate: boolean = false;
+  private requireDescriptionUpdate = false;
+  private isRefreshing = false;
 
   constructor(
     parent: CICSPlexTree,
@@ -34,9 +35,8 @@ export class CICSRegionsContainer extends TreeItem {
     this.parent = parent;
     this.children = [];
 
-    //To store the filter
-    const savedFilter = PersistentStorage.getCriteria(this.buildFilterStorageKey());
-    this.activeFilter = savedFilter || "*";
+    const profile = parent.getProfile().profile;
+    this.activeFilter = profile.cicsPlex && profile.regionName ? profile.regionName : "*";
     this.updateLabelAndContext();
   }
 
@@ -49,10 +49,11 @@ export class CICSRegionsContainer extends TreeItem {
     this.contextValue = `cicsregionscontainer.${this.activeFilter !== "*" ? "FILTERED" : ""}`;
   }
 
-  public async filterRegions(pattern: string, _tree: CICSTree) {
+  public async filterRegions(pattern: string) {
     this.activeFilter = pattern;
     this.updateLabelAndContext();
-    await PersistentStorage.setCriteria(this.buildFilterStorageKey(), pattern === "*" ? undefined : pattern);
+    await PersistentStorage.setCriteria(this.buildFilterStorageKey(), pattern);
+    this.isRefreshing = true;
 
     await window.withProgress(
       {
@@ -73,8 +74,8 @@ export class CICSRegionsContainer extends TreeItem {
     );
   }
 
-  public async loadRegionsInCICSGroup(_tree: CICSTree) {
-    const parentPlex = this.getParent();
+  public async loadRegionsInCICSGroup() {
+    const parentPlex = this.parent;
     const plexProfile = parentPlex.getProfile();
     const regionsObtained = await runGetResource({
       profileName: plexProfile.name,
@@ -90,7 +91,7 @@ export class CICSRegionsContainer extends TreeItem {
   }
 
   public async loadRegionsInPlex() {
-    const parentPlex = this.getParent();
+    const parentPlex = this.parent;
     const regionInfo = await ProfileManagement.getRegionInfoInPlex(parentPlex);
     if (regionInfo) {
       this.addRegionsUtility(regionInfo);
@@ -99,22 +100,17 @@ export class CICSRegionsContainer extends TreeItem {
       this.updateDescription();
     }
   }
-  public refreshIcon(folderOpen: boolean = false): void {
+  public refreshIcon(folderOpen = false): void {
     this.iconPath = getFolderIcon(folderOpen);
   }
 
-  /**
-   * Count the number of total and active regions
-   * @param regionsArray
-   */
   private addRegionsUtility(regionsArray: any[]) {
     this.children = [];
 
-    const parentPlex = this.getParent();
+    const parentPlex = this.parent;
     const regionFilterRegex = this.activeFilter && this.activeFilter !== "*" ? new RegExp(this.patternIntoRegex(this.activeFilter)) : null;
 
     for (const region of regionsArray) {
-      // If region filter exists then match it
       if (!regionFilterRegex || region.cicsname.match(regionFilterRegex)) {
         const newRegionTree = new CICSRegionTree(region.cicsname, region, parentPlex.getParent(), parentPlex, this);
         this.children.push(newRegionTree);
@@ -140,15 +136,26 @@ export class CICSRegionsContainer extends TreeItem {
       return this.children;
     }
 
-    const parentPlex = this.getParent();
+    if (this.isRefreshing || this.children.length > 0) {
+      this.isRefreshing = false;
+      const savedFilter = PersistentStorage.getCriteria(this.buildFilterStorageKey());
+      if (savedFilter) {
+        this.activeFilter = savedFilter;
+        this.updateLabelAndContext();
+      }
+    }
+
+    const parentPlex = this.parent;
+    const shouldLoadRegions = this.activeFilter !== "*" || this.children.length === 0;
+
     if (parentPlex.getProfile().profile.regionName && parentPlex.getProfile().profile.cicsPlex) {
       if (parentPlex.getGroupName()) {
-        await this.loadRegionsInCICSGroup(this.getParent().getSessionNode().getParent());
-      }
-    } else {
-      if (this.activeFilter === "*" || this.children.length === 0) {
+        await this.loadRegionsInCICSGroup();
+      } else if (shouldLoadRegions) {
         await this.loadRegionsInPlex();
       }
+    } else if (shouldLoadRegions) {
+      await this.loadRegionsInPlex();
     }
 
     return this.children;
@@ -160,7 +167,7 @@ export class CICSRegionsContainer extends TreeItem {
 
     for (const child of this.children) {
       if (child.region?.cicsstate === "ACTIVE") {
-        activeCount += 1;
+        activeCount++;
       }
     }
 
@@ -172,7 +179,7 @@ export class CICSRegionsContainer extends TreeItem {
     this.description = description;
 
     this.requireDescriptionUpdate = true;
-    this.getParent().getSessionNode().getParent().refresh(this);
+    this.parent.getSessionNode().getParent().refresh(this);
   }
 
   public setLabel(label: string) {
@@ -188,6 +195,6 @@ export class CICSRegionsContainer extends TreeItem {
   }
 
   public getSession() {
-    return this.getParent().getSession();
+    return this.parent.getSession();
   }
 }


### PR DESCRIPTION
**What It Does**

1. If you have a region named in your zowe config
2. When you expand the cicsplex and then regions node
3. The regions node should show a filter set matching what was named in the zowe config
4. You should be able to set a new filter or remove the existing filter
5. If you close and open the regions node again i think it could revert to the original filter

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->

**Which Issue It Relates To**
<!-- Either "Resolves #XXX" or "Working towards #XXX" - these must be github.com/zowe links. These allow you to navigate from a github issue to the PRs that delivered code to resolve it -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] considered whether the docs need updating
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
