### PR TITLE
CLI close local file

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented 
 
 ## Recent Changes
 
-- Enhancement: Migrates close local file operation to the SDK (and expose via CLI). [#241](https://github.com/zowe/cics-for-zowe-client/issues/241)
+- Enhancement: Adds close local file operation. [#241](https://github.com/zowe/cics-for-zowe-client/issues/241)
 
 ## `6.18.0`
 

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Migrates close local file operation to the SDK (and expose via CLI). [#241](https://github.com/zowe/cics-for-zowe-client/issues/241)
+
 ## `6.18.0`
 
 - Update dependencies. [#567](https://github.com/zowe/cics-for-zowe-client/pull/567)

--- a/packages/cli/__tests__/__unit__/close/localFile/LocalFile.handler.unit.test.ts
+++ b/packages/cli/__tests__/__unit__/close/localFile/LocalFile.handler.unit.test.ts
@@ -1,0 +1,209 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { mockHandlerParameters } from "@zowe/cli-test-utils";
+import { type IHandlerParameters, Session } from "@zowe/imperative";
+import type { ICMCIApiResponse } from "../../../../src";
+import { LocalFileDefinition } from "../../../../src/close/localFile/LocalFile.definition";
+import LocalFileHandler from "../../../../src/close/localFile/LocalFile.handler";
+
+jest.mock("@zowe/cics-for-zowe-sdk");
+const Close = require("@zowe/cics-for-zowe-sdk");
+
+const host = "somewhere.com";
+const port = 43443;
+const user = "someone";
+const password = "somesecret";
+const protocol = "http";
+const rejectUnauthorized = false;
+
+const PROFILE_MAP = {
+  name: "cics",
+  type: "cics",
+  host,
+  port,
+  user,
+  password,
+};
+const DEFAULT_PARAMETERS: IHandlerParameters = mockHandlerParameters({
+  positionals: ["cics", "close", "local-file"],
+  definition: LocalFileDefinition,
+  arguments: PROFILE_MAP,
+});
+
+describe("CloseLocalFileHandler", () => {
+  const fileName = "TESTFILE";
+  const regionName = "testRegion";
+  const cicsPlex = "testPlex";
+
+  const defaultReturn: ICMCIApiResponse = {
+    response: {
+      resultsummary: { api_response1: "1024", api_response2: "0", recordcount: "0", displayed_recordcount: "0" },
+      records: "testing",
+    },
+  };
+
+  const functionSpy = jest.spyOn(Close, "closeLocalFile");
+
+  beforeEach(() => {
+    functionSpy.mockClear();
+    functionSpy.mockImplementation(async () => defaultReturn);
+  });
+
+  it("should call the closeLocalFile api without busy parameter", async () => {
+    const handler = new LocalFileHandler();
+
+    const commandParameters = { ...DEFAULT_PARAMETERS };
+    commandParameters.arguments = {
+      ...commandParameters.arguments,
+      fileName,
+      regionName,
+      host,
+      port,
+      user,
+      password,
+      protocol,
+      rejectUnauthorized,
+    };
+
+    await handler.process(commandParameters);
+
+    expect(functionSpy).toHaveBeenCalledTimes(1);
+
+    expect(functionSpy).toHaveBeenCalledWith(
+      new Session({
+        type: "basic",
+        hostname: PROFILE_MAP.host,
+        port: PROFILE_MAP.port,
+        user: PROFILE_MAP.user,
+        password: PROFILE_MAP.password,
+        rejectUnauthorized,
+        protocol,
+        _authCache: {
+          availableCreds: {
+            base64EncodedAuth: "c29tZW9uZTpzb21lc2VjcmV0",
+            password: "somesecret",
+            user: "someone",
+          },
+          didUserSetAuthOrder: false,
+          topDefaultAuth: "basic",
+        },
+        authTypeOrder: ["basic", "token", "bearer", "cert-pem"],
+      }),
+      {
+        name: fileName,
+        regionName,
+        busy: undefined,
+      }
+    );
+  });
+
+  it("should call the closeLocalFile api with busy parameter", async () => {
+    const handler = new LocalFileHandler();
+
+    const commandParameters = { ...DEFAULT_PARAMETERS };
+    commandParameters.arguments = {
+      ...commandParameters.arguments,
+      fileName,
+      regionName,
+      cicsPlex,
+      busy: "FORCE",
+      host,
+      port,
+      user,
+      password,
+      protocol,
+      rejectUnauthorized,
+    };
+
+    await handler.process(commandParameters);
+
+    expect(functionSpy).toHaveBeenCalledTimes(1);
+
+    expect(functionSpy).toHaveBeenCalledWith(
+      new Session({
+        type: "basic",
+        hostname: PROFILE_MAP.host,
+        port: PROFILE_MAP.port,
+        user: PROFILE_MAP.user,
+        password: PROFILE_MAP.password,
+        rejectUnauthorized,
+        protocol,
+        _authCache: {
+          availableCreds: {
+            base64EncodedAuth: "c29tZW9uZTpzb21lc2VjcmV0",
+            password: "somesecret",
+            user: "someone",
+          },
+          didUserSetAuthOrder: false,
+          topDefaultAuth: "basic",
+        },
+        authTypeOrder: ["basic", "token", "bearer", "cert-pem"],
+      }),
+      {
+        name: fileName,
+        regionName,
+        cicsPlex,
+        busy: "FORCE",
+      }
+    );
+  });
+  it("should call the closeLocalFile api with lowercase busy parameter (case-insensitive)", async () => {
+    const handler = new LocalFileHandler();
+
+    const commandParameters = { ...DEFAULT_PARAMETERS };
+    commandParameters.arguments = {
+      ...commandParameters.arguments,
+      fileName,
+      regionName,
+      host,
+      port,
+      user,
+      password,
+      protocol,
+      rejectUnauthorized,
+      busy: "wait", // lowercase
+    };
+
+    await handler.process(commandParameters);
+
+    expect(functionSpy).toHaveBeenCalledTimes(1);
+
+    expect(functionSpy).toHaveBeenCalledWith(
+      new Session({
+        type: "basic",
+        hostname: PROFILE_MAP.host,
+        port: PROFILE_MAP.port,
+        user: PROFILE_MAP.user,
+        password: PROFILE_MAP.password,
+        rejectUnauthorized,
+        protocol,
+        _authCache: {
+          availableCreds: {
+            base64EncodedAuth: "c29tZW9uZTpzb21lc2VjcmV0",
+            password: "somesecret",
+            user: "someone",
+          },
+          didUserSetAuthOrder: false,
+          topDefaultAuth: "basic",
+        },
+        authTypeOrder: ["basic", "token", "bearer", "cert-pem"],
+      }),
+      {
+        name: fileName,
+        regionName,
+        busy: "wait", // Should be passed as-is; SDK will handle uppercase conversion
+      }
+    );
+  });
+});
+
+

--- a/packages/cli/__tests__/__unit__/close/localFile/__snapshots__/LocalFile.handler.unit.test.ts.snap
+++ b/packages/cli/__tests__/__unit__/close/localFile/__snapshots__/LocalFile.handler.unit.test.ts.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`CloseLocalFileHandler should call the closeLocalFile api with busy parameter 1`] = `"The local file '%s' was closed successfully."`;
+
+exports[`CloseLocalFileHandler should call the closeLocalFile api with busy parameter 2`] = `
+{
+  "response": {
+    "records": "testing",
+    "resultsummary": {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;
+
+exports[`CloseLocalFileHandler should call the closeLocalFile api with lowercase busy parameter (case-insensitive) 1`] = `"The local file '%s' was closed successfully."`;
+
+exports[`CloseLocalFileHandler should call the closeLocalFile api with lowercase busy parameter (case-insensitive) 2`] = `
+{
+  "response": {
+    "records": "testing",
+    "resultsummary": {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;
+
+exports[`CloseLocalFileHandler should call the closeLocalFile api without busy parameter 1`] = `"The local file '%s' was closed successfully."`;
+
+exports[`CloseLocalFileHandler should call the closeLocalFile api without busy parameter 2`] = `
+{
+  "response": {
+    "records": "testing",
+    "resultsummary": {
+      "api_response1": "1024",
+      "api_response2": "0",
+      "displayed_recordcount": "0",
+      "recordcount": "0",
+    },
+  },
+}
+`;

--- a/packages/cli/src/-strings-/en.ts
+++ b/packages/cli/src/-strings-/en.ts
@@ -266,6 +266,31 @@ export default {
       },
     },
   },
+  CLOSE: {
+    SUMMARY: "Close resources in CICS",
+    DESCRIPTION: "Close resources (for example, local files) in CICS through IBM CMCI.",
+    RESOURCES: {
+      LOCALFILE: {
+        DESCRIPTION: "Close a local file in CICS.",
+        POSITIONALS: {
+          FILENAME: "The name of the local file to close. The maximum length of the file name is eight characters.",
+        },
+        OPTIONS: {
+          REGIONNAME: "The CICS region name in which to close the local file",
+          CICSPLEX: "The name of the CICSPlex in which to close the local file",
+          BUSY: "The busy condition option for closing the file. Valid values: WAIT, NOWAIT, FORCE. Default is WAIT.",
+        },
+        MESSAGES: {
+          SUCCESS: "The local file '%s' was closed successfully.",
+          PROGRESS: "Closing local file from CICS",
+        },
+        EXAMPLES: {
+          EX1: "Close a local file named TESTFILE from the region named MYREGION",
+          EX2: "Close a local file named TESTFILE from the region named MYREGION with BUSY=FORCE",
+        },
+      },
+    },
+  },
   DISABLE: {
     SUMMARY: "Disable resources from CICS",
     DESCRIPTION: "Disable resources (for example, urimaps) from CICS through IBM CMCI.",

--- a/packages/cli/src/close/Close.definition.ts
+++ b/packages/cli/src/close/Close.definition.ts
@@ -1,0 +1,28 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import type { ICommandDefinition } from "@zowe/imperative";
+import { LocalFileDefinition } from "./localFile/LocalFile.definition";
+
+import type i18nTypings from "../-strings-/en";
+
+const strings = (require("../-strings-/en").default as typeof i18nTypings).CLOSE;
+
+const definition: ICommandDefinition = {
+  name: "close",
+  aliases: ["cls"],
+  summary: strings.SUMMARY,
+  description: strings.DESCRIPTION,
+  type: "group",
+  children: [LocalFileDefinition],
+};
+export = definition;
+

--- a/packages/cli/src/close/localFile/LocalFile.definition.ts
+++ b/packages/cli/src/close/localFile/LocalFile.definition.ts
@@ -10,14 +10,12 @@
  */
 
 import type { ICommandDefinition } from "@zowe/imperative";
+import { CicsCmciConstants } from "@zowe/cics-for-zowe-sdk";
 
 import type i18nTypings from "../../-strings-/en";
 
 // Does not use the import in anticipation of some internationalization work to be done later.
 const strings = (require("../../-strings-/en").default as typeof i18nTypings).CLOSE.RESOURCES.LOCALFILE;
-
-// Valid BUSY parameter values - kept in sync with SDK constants
-const BUSY_VALUES = ["WAIT", "NOWAIT", "FORCE"];
 
 export const LocalFileDefinition: ICommandDefinition = {
   name: "local-file",
@@ -50,7 +48,7 @@ export const LocalFileDefinition: ICommandDefinition = {
       type: "string",
       defaultValue: "WAIT",
       allowableValues: {
-        values: [...BUSY_VALUES],
+        values: [...CicsCmciConstants.CICS_LOCAL_FILE_BUSY_VALUES],
         caseSensitive: false,
       },
     },

--- a/packages/cli/src/close/localFile/LocalFile.definition.ts
+++ b/packages/cli/src/close/localFile/LocalFile.definition.ts
@@ -1,0 +1,69 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import type { ICommandDefinition } from "@zowe/imperative";
+
+import type i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).CLOSE.RESOURCES.LOCALFILE;
+
+// Valid BUSY parameter values - kept in sync with SDK constants
+const BUSY_VALUES = ["WAIT", "NOWAIT", "FORCE"];
+
+export const LocalFileDefinition: ICommandDefinition = {
+  name: "local-file",
+  aliases: ["lf"],
+  description: strings.DESCRIPTION,
+  handler: __dirname + "/LocalFile.handler",
+  type: "command",
+  positionals: [
+    {
+      name: "fileName",
+      description: strings.POSITIONALS.FILENAME,
+      type: "string",
+      required: true,
+    },
+  ],
+  options: [
+    {
+      name: "region-name",
+      description: strings.OPTIONS.REGIONNAME,
+      type: "string",
+    },
+    {
+      name: "cics-plex",
+      description: strings.OPTIONS.CICSPLEX,
+      type: "string",
+    },
+    {
+      name: "busy",
+      description: strings.OPTIONS.BUSY,
+      type: "string",
+      defaultValue: "WAIT",
+      allowableValues: {
+        values: [...BUSY_VALUES],
+        caseSensitive: false,
+      },
+    },
+  ],
+  profile: { optional: ["cics"] },
+  examples: [
+    {
+      description: strings.EXAMPLES.EX1,
+      options: "TESTFILE --region-name MYREGION",
+    },
+    {
+      description: strings.EXAMPLES.EX2,
+      options: "TESTFILE --region-name MYREGION --busy FORCE",
+    },
+  ],
+};

--- a/packages/cli/src/close/localFile/LocalFile.handler.ts
+++ b/packages/cli/src/close/localFile/LocalFile.handler.ts
@@ -1,0 +1,56 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { closeLocalFile, type ICMCIApiResponse } from "@zowe/cics-for-zowe-sdk";
+import { type AbstractSession, type IHandlerParameters, type ITaskWithStatus, TaskStage } from "@zowe/imperative";
+import { CicsBaseHandler } from "../../CicsBaseHandler";
+
+import type i18nTypings from "../../-strings-/en";
+
+// Does not use the import in anticipation of some internationalization work to be done later.
+const strings = (require("../../-strings-/en").default as typeof i18nTypings).CLOSE.RESOURCES.LOCALFILE;
+
+/**
+ * Command handler for closing CICS local files via CMCI
+ * @export
+ * @class LocalFileHandler
+ * @implements {ICommandHandler}
+ */
+export default class LocalFileHandler extends CicsBaseHandler {
+  /**
+   * Process the command to close a CICS local file
+   * @param {IHandlerParameters} params - Command handler parameters
+   * @param {AbstractSession} session - The session to use for the CMCI request
+   * @returns {Promise<ICMCIApiResponse>} The CMCI API response
+   * @throws {ImperativeError} Various errors from validation or CMCI request failures
+   * @memberof LocalFileHandler
+   */
+  public async processWithSession(params: IHandlerParameters, session: AbstractSession): Promise<ICMCIApiResponse> {
+    const status: ITaskWithStatus = {
+      statusMessage: strings.MESSAGES.PROGRESS,
+      percentComplete: 0,
+      stageName: TaskStage.IN_PROGRESS,
+    };
+    params.response.progress.startBar({ task: status });
+
+    // Error handling is managed by the base handler (CicsBaseHandler)
+    // which catches and formats errors appropriately for CLI output
+    const response = await closeLocalFile(session, {
+      name: params.arguments.fileName,
+      regionName: params.arguments.regionName,
+      cicsPlex: params.arguments.cicsPlex,
+      busy: params.arguments.busy,
+    });
+
+    params.response.console.log(strings.MESSAGES.SUCCESS, params.arguments.fileName);
+    return response;
+  }
+}

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented in this file.
 
+## Recent Changes
+
+- Enhancement: Migrates close local file operation to the SDK (and expose via CLI). [#241](https://github.com/zowe/cics-for-zowe-client/issues/241)
+
 ## `6.18.0`
 
 - Update dependencies. [#567](https://github.com/zowe/cics-for-zowe-client/pull/567)

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the IBM® CICS® Plug-in for Zowe CLI will be documented 
 
 ## Recent Changes
 
-- Enhancement: Migrates close local file operation to the SDK (and expose via CLI). [#241](https://github.com/zowe/cics-for-zowe-client/issues/241)
+- Enhancement: Exposes closeLocalFile method. [#241](https://github.com/zowe/cics-for-zowe-client/issues/241)
 
 ## `6.18.0`
 

--- a/packages/sdk/__tests__/__unit__/close/Close.localFile.unit.test.ts
+++ b/packages/sdk/__tests__/__unit__/close/Close.localFile.unit.test.ts
@@ -1,0 +1,329 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { Session } from "@zowe/imperative";
+import { CicsCmciConstants, CicsCmciRestClient, closeLocalFile, type ICMCIApiResponse, type ILocalFileParms } from "../../../src";
+
+describe("CMCI - Close local file", () => {
+  const localFile = "TESTFILE";
+  const region = "region";
+  const content = "ThisIsATest" as unknown as ICMCIApiResponse;
+
+  const closeParms: ILocalFileParms = {
+    regionName: region,
+    name: localFile,
+  };
+
+  const dummySession = new Session({
+    user: "fake",
+    password: "fake",
+    hostname: "fake",
+    port: 1490,
+  });
+
+  let error: any;
+  let response: any;
+  let endPoint: any;
+  let requestBody: any;
+
+  describe("validation", () => {
+    beforeEach(() => {
+      response = undefined;
+      error = undefined;
+      closeParms.regionName = region;
+      closeParms.name = localFile;
+    });
+
+    it("should throw an error if no region name is specified", async () => {
+      (closeParms as any).regionName = undefined;
+      try {
+        response = await closeLocalFile(dummySession, closeParms);
+      } catch (err) {
+        error = err;
+      }
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("CICS region name is required");
+    });
+
+    it("should throw an error if no local file name is specified", async () => {
+      (closeParms as any).name = undefined;
+      try {
+        response = await closeLocalFile(dummySession, closeParms);
+      } catch (err) {
+        error = err;
+      }
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("CICS local file name is required");
+    });
+
+    it("should throw an error if invalid BUSY parameter is specified", async () => {
+      closeParms.busy = "INVALID";
+      try {
+        response = await closeLocalFile(dummySession, closeParms);
+      } catch (err) {
+        error = err;
+      }
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("Invalid BUSY parameter value");
+      expect(error.message).toContain("WAIT, NOWAIT, FORCE");
+    });
+
+    it("should throw an error if file name exceeds maximum length", async () => {
+      closeParms.name = "TOOLONGNAME"; // 11 characters, exceeds 8 char limit
+      try {
+        response = await closeLocalFile(dummySession, closeParms);
+      } catch (err) {
+        error = err;
+      }
+      expect(response).toBeUndefined();
+      expect(error).toBeDefined();
+      expect(error.message).toContain("exceeds maximum length");
+      expect(error.message).toContain("8 characters");
+    });
+  });
+
+  describe("success scenarios", () => {
+    const closeSpy = jest.spyOn(CicsCmciRestClient, "putExpectParsedXml").mockResolvedValue(content);
+
+    beforeEach(() => {
+      response = undefined;
+      error = undefined;
+      closeSpy.mockClear();
+      closeSpy.mockResolvedValue(content);
+      closeParms.regionName = region;
+      closeParms.name = localFile;
+      closeParms.busy = undefined;
+    });
+
+    it("should be able to close a local file without BUSY parameter", async () => {
+      endPoint =
+        "/" +
+        CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
+        "/" +
+        CicsCmciConstants.CICS_CMCI_LOCAL_FILE +
+        "/" +
+        region +
+        `?CRITERIA=(file%3D${closeParms.name})`;
+      requestBody = {
+        request: {
+          action: {
+            $: {
+              name: "CLOSE",
+            },
+            parameter: {
+              $: {
+                name: "BUSY",
+                value: "WAIT",
+              },
+            },
+          },
+        },
+      };
+
+      response = await closeLocalFile(dummySession, closeParms);
+      expect(response).toContain(content);
+      expect(closeSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+
+    it("should be able to close a local file with BUSY=WAIT parameter", async () => {
+      closeParms.busy = "WAIT";
+      endPoint =
+        "/" +
+        CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
+        "/" +
+        CicsCmciConstants.CICS_CMCI_LOCAL_FILE +
+        "/" +
+        region +
+        `?CRITERIA=(file%3D${closeParms.name})`;
+      requestBody = {
+        request: {
+          action: {
+            $: {
+              name: "CLOSE",
+            },
+            parameter: {
+              $: {
+                name: "BUSY",
+                value: "WAIT",
+              },
+            },
+          },
+        },
+      };
+
+      response = await closeLocalFile(dummySession, closeParms);
+      expect(response).toContain(content);
+      expect(closeSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+
+    it("should be able to close a local file with BUSY=NOWAIT parameter", async () => {
+      closeParms.busy = "NOWAIT";
+      endPoint =
+        "/" +
+        CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
+        "/" +
+        CicsCmciConstants.CICS_CMCI_LOCAL_FILE +
+        "/" +
+        region +
+        `?CRITERIA=(file%3D${closeParms.name})`;
+      requestBody = {
+        request: {
+          action: {
+            $: {
+              name: "CLOSE",
+            },
+            parameter: {
+              $: {
+                name: "BUSY",
+                value: "NOWAIT",
+              },
+            },
+          },
+        },
+      };
+
+      response = await closeLocalFile(dummySession, closeParms);
+      expect(response).toContain(content);
+      expect(closeSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+
+    it("should be able to close a local file with BUSY=FORCE parameter", async () => {
+      closeParms.busy = "FORCE";
+      endPoint =
+        "/" +
+        CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
+        "/" +
+        CicsCmciConstants.CICS_CMCI_LOCAL_FILE +
+        "/" +
+        region +
+        `?CRITERIA=(file%3D${closeParms.name})`;
+      requestBody = {
+        request: {
+          action: {
+            $: {
+              name: "CLOSE",
+            },
+            parameter: {
+              $: {
+                name: "BUSY",
+                value: "FORCE",
+              },
+            },
+          },
+        },
+      };
+
+      response = await closeLocalFile(dummySession, closeParms);
+      expect(response).toContain(content);
+      expect(closeSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+
+    it("should uppercase the BUSY parameter value", async () => {
+      closeParms.busy = "wait";
+      endPoint =
+        "/" +
+        CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
+        "/" +
+        CicsCmciConstants.CICS_CMCI_LOCAL_FILE +
+        "/" +
+        region +
+        `?CRITERIA=(file%3D${closeParms.name})`;
+      requestBody = {
+        request: {
+          action: {
+            $: {
+              name: "CLOSE",
+            },
+            parameter: {
+              $: {
+                name: "BUSY",
+                value: "WAIT",
+              },
+            },
+          },
+        },
+      };
+
+      response = await closeLocalFile(dummySession, closeParms);
+      expect(response).toContain(content);
+      expect(closeSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+
+    it("should handle empty string BUSY parameter gracefully", async () => {
+      closeParms.busy = ""; // Empty string defaults to WAIT
+      endPoint =
+        "/" +
+        CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
+        "/" +
+        CicsCmciConstants.CICS_CMCI_LOCAL_FILE +
+        "/" +
+        region +
+        `?CRITERIA=(file%3D${closeParms.name})`;
+      requestBody = {
+        request: {
+          action: {
+            $: {
+              name: "CLOSE",
+            },
+            parameter: {
+              $: {
+                name: "BUSY",
+                value: "WAIT",
+              },
+            },
+          },
+        },
+      };
+
+      response = await closeLocalFile(dummySession, closeParms);
+      expect(response).toContain(content);
+      // Verify that BUSY parameter defaults to WAIT
+      expect(closeSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+
+    it("should handle whitespace-only BUSY parameter gracefully", async () => {
+      closeParms.busy = "   "; // Whitespace only defaults to WAIT
+      endPoint =
+        "/" +
+        CicsCmciConstants.CICS_SYSTEM_MANAGEMENT +
+        "/" +
+        CicsCmciConstants.CICS_CMCI_LOCAL_FILE +
+        "/" +
+        region +
+        `?CRITERIA=(file%3D${closeParms.name})`;
+      requestBody = {
+        request: {
+          action: {
+            $: {
+              name: "CLOSE",
+            },
+            parameter: {
+              $: {
+                name: "BUSY",
+                value: "WAIT",
+              },
+            },
+          },
+        },
+      };
+
+      response = await closeLocalFile(dummySession, closeParms);
+      expect(response).toContain(content);
+      // Verify that BUSY parameter defaults to WAIT
+      expect(closeSpy).toHaveBeenCalledWith(dummySession, endPoint, [], requestBody);
+    });
+  });
+});
+
+

--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -195,9 +195,9 @@ export const CicsCmciConstants = {
   CICS_LOCAL_FILE_BUSY_VALUES: ["WAIT", "NOWAIT", "FORCE"],
 
   /**
-   * Maximum length for CICS resource names (programs, files, etc.)
+   * Maximum length for CICS local file names
    */
-  CICS_RESOURCE_NAME_MAX_LENGTH: 8,
+  CICS_LOCAL_FILE_MAX_LENGTH: 8,
 
   /**
    * The CICS CMCI remote file

--- a/packages/sdk/src/constants/CicsCmci.constants.ts
+++ b/packages/sdk/src/constants/CicsCmci.constants.ts
@@ -185,6 +185,21 @@ export const CicsCmciConstants = {
   CICS_CMCI_LOCAL_FILE: "CICSLocalFile",
 
   /**
+   * The criteria field name for local file resources
+   */
+  CICS_LOCAL_FILE_CRITERIA_FIELD: "file",
+
+  /**
+   * Valid BUSY parameter values for closing local files
+   */
+  CICS_LOCAL_FILE_BUSY_VALUES: ["WAIT", "NOWAIT", "FORCE"],
+
+  /**
+   * Maximum length for CICS resource names (programs, files, etc.)
+   */
+  CICS_RESOURCE_NAME_MAX_LENGTH: 8,
+
+  /**
    * The CICS CMCI remote file
    */
   CICS_CMCI_REMOTE_FILE: "CICSRemoteFile",

--- a/packages/sdk/src/doc/ILocalFileParms.ts
+++ b/packages/sdk/src/doc/ILocalFileParms.ts
@@ -1,0 +1,29 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import type { IResourceParms } from "./IResourceParms";
+
+/**
+ * Interface for CICS local file parameters
+ * @export
+ * @interface ILocalFileParms
+ * @extends {IResourceParms}
+ */
+export interface ILocalFileParms extends IResourceParms {
+  /**
+   * The busy condition option for closing the file
+   * Valid values: "WAIT", "NOWAIT", "FORCE" (case-insensitive)
+   * Value will be automatically converted to uppercase
+   * @type {string}
+   * @memberof ILocalFileParms
+   */
+  busy?: string;
+}

--- a/packages/sdk/src/doc/index.ts
+++ b/packages/sdk/src/doc/index.ts
@@ -18,6 +18,7 @@ export * from "./ICMCIResponseErrors";
 export * from "./ICSDGroupParms";
 export * from "./ICacheParms";
 export * from "./IGetResourceUriOptions";
+export * from "./ILocalFileParms";
 export * from "./IProgramParms";
 export * from "./IResourceParms";
 export * from "./IResourceQueryParms";

--- a/packages/sdk/src/methods/close/Close.ts
+++ b/packages/sdk/src/methods/close/Close.ts
@@ -35,18 +35,17 @@ export async function closeLocalFile(session: AbstractSession, parms: ILocalFile
   ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
 
   // Validate file name length (CICS resource names are limited to 8 characters)
-  if (parms.name.length > CicsCmciConstants.CICS_RESOURCE_NAME_MAX_LENGTH) {
+  if (parms.name.length > CicsCmciConstants.CICS_LOCAL_FILE_MAX_LENGTH) {
     throw new ImperativeError({
-      msg: `CICS local file name "${parms.name}" exceeds maximum length of ${CicsCmciConstants.CICS_RESOURCE_NAME_MAX_LENGTH} characters`,
+      msg: `CICS local file name "${parms.name}" exceeds maximum length of ${CicsCmciConstants.CICS_LOCAL_FILE_MAX_LENGTH} characters`,
     });
   }
 
-  // Set default BUSY value if not provided
-  const busyValue = parms.busy && parms.busy.trim() ? parms.busy.trim() : "WAIT";
+  // Set default BUSY value if not provided and convert to uppercase
+  const busyValue = parms.busy?.trim().toUpperCase() || "WAIT";
   
   // Validate BUSY parameter
-  const busyUpper = busyValue.toUpperCase();
-  if (!CicsCmciConstants.CICS_LOCAL_FILE_BUSY_VALUES.includes(busyUpper as any)) {
+  if (!CicsCmciConstants.CICS_LOCAL_FILE_BUSY_VALUES.includes(busyValue as any)) {
     throw new ImperativeError({
       msg: `Invalid BUSY parameter value: "${busyValue}". Must be one of: ${CicsCmciConstants.CICS_LOCAL_FILE_BUSY_VALUES.join(", ")}`,
     });
@@ -62,21 +61,20 @@ export async function closeLocalFile(session: AbstractSession, parms: ILocalFile
 
   const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, options);
 
+  // BUSY parameter is required by CMCI. Default to WAIT if not provided.
   const requestBody: any = {
     request: {
       action: {
         $: {
           name: "CLOSE",
         },
+        parameter: {
+          $: {
+            name: "BUSY",
+            value: busyValue,
+          },
+        },
       },
-    },
-  };
-
-  // BUSY parameter is required by CMCI. Default to WAIT if not provided.
-  requestBody.request.action.parameter = {
-    $: {
-      name: "BUSY",
-      value: busyUpper,
     },
   };
 

--- a/packages/sdk/src/methods/close/Close.ts
+++ b/packages/sdk/src/methods/close/Close.ts
@@ -1,0 +1,85 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { type AbstractSession, ImperativeError, ImperativeExpect, Logger } from "@zowe/imperative";
+import { CicsCmciConstants } from "../../constants";
+import type { ICMCIApiResponse, IGetResourceUriOptions, ILocalFileParms } from "../../doc";
+import { CicsCmciRestClient } from "../../rest";
+import { Utils } from "../../utils";
+
+/**
+ * Close a local file in CICS through CMCI REST API
+ * @param {AbstractSession} session - the session to connect to CMCI with
+ * @param {ILocalFileParms} parms - parameters for closing your local file
+ * @param {string} parms.name - the name of the local file to close (1-8 characters)
+ * @param {string} parms.regionName - the CICS region name
+ * @param {string} [parms.cicsPlex] - the CICSPlex name (optional)
+ * @param {string} [parms.busy] - busy condition option: "WAIT", "NOWAIT", or "FORCE" (case-insensitive, optional)
+ * @returns {Promise<ICMCIApiResponse>} promise that resolves to the response (XML parsed into a javascript object)
+ *                          when the request is complete
+ * @throws {ImperativeError} CICS local file name not defined, blank, or exceeds maximum length
+ * @throws {ImperativeError} CICS region name not defined or blank
+ * @throws {ImperativeError} Invalid BUSY parameter value
+ * @throws {ImperativeError} CicsCmciRestClient request fails
+ */
+export async function closeLocalFile(session: AbstractSession, parms: ILocalFileParms): Promise<ICMCIApiResponse> {
+  ImperativeExpect.toBeDefinedAndNonBlank(parms.name, "CICS Local File name", "CICS local file name is required");
+  ImperativeExpect.toBeDefinedAndNonBlank(parms.regionName, "CICS Region name", "CICS region name is required");
+
+  // Validate file name length (CICS resource names are limited to 8 characters)
+  if (parms.name.length > CicsCmciConstants.CICS_RESOURCE_NAME_MAX_LENGTH) {
+    throw new ImperativeError({
+      msg: `CICS local file name "${parms.name}" exceeds maximum length of ${CicsCmciConstants.CICS_RESOURCE_NAME_MAX_LENGTH} characters`,
+    });
+  }
+
+  // Set default BUSY value if not provided
+  const busyValue = parms.busy && parms.busy.trim() ? parms.busy.trim() : "WAIT";
+  
+  // Validate BUSY parameter
+  const busyUpper = busyValue.toUpperCase();
+  if (!CicsCmciConstants.CICS_LOCAL_FILE_BUSY_VALUES.includes(busyUpper as any)) {
+    throw new ImperativeError({
+      msg: `Invalid BUSY parameter value: "${busyValue}". Must be one of: ${CicsCmciConstants.CICS_LOCAL_FILE_BUSY_VALUES.join(", ")}`,
+    });
+  }
+
+  Logger.getAppLogger().debug("Attempting to close a local file with the following parameters:\n%s", JSON.stringify(parms));
+
+  const options: IGetResourceUriOptions = {
+    cicsPlex: parms.cicsPlex,
+    regionName: parms.regionName,
+    criteria: `${CicsCmciConstants.CICS_LOCAL_FILE_CRITERIA_FIELD}=${parms.name}`,
+  };
+
+  const cmciResource = Utils.getResourceUri(CicsCmciConstants.CICS_CMCI_LOCAL_FILE, options);
+
+  const requestBody: any = {
+    request: {
+      action: {
+        $: {
+          name: "CLOSE",
+        },
+      },
+    },
+  };
+
+  // BUSY parameter is required by CMCI. Default to WAIT if not provided.
+  requestBody.request.action.parameter = {
+    $: {
+      name: "BUSY",
+      value: busyUpper,
+    },
+  };
+
+  return CicsCmciRestClient.putExpectParsedXml(session, cmciResource, [], requestBody);
+}
+

--- a/packages/sdk/src/methods/close/index.ts
+++ b/packages/sdk/src/methods/close/index.ts
@@ -1,0 +1,12 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+export * from "./Close";

--- a/packages/sdk/src/methods/index.ts
+++ b/packages/sdk/src/methods/index.ts
@@ -11,6 +11,7 @@
 
 export * from "./add-to-list";
 export * from "./cache";
+export * from "./close";
 export * from "./define";
 export * from "./delete";
 export * from "./disable";

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 
  - Enhancement: Adds hyperlinks to appropriate attributes in RI highlights. [#621](https://github.com/zowe/cics-for-zowe-client/issues/621)
  - BugFix: Render USS paths with a trailing slash (e.g. `JAVA_HOME=/usr/lpp/java/J8.0_64/`) as hyperlinks in the Resource Inspector. [#638](https://github.com/zowe/cics-for-zowe-client/issues/638)
+ - Enhancement: Migrates close local file operation to the SDK (and expose via CLI). [#241](https://github.com/zowe/cics-for-zowe-client/issues/241)
 
 ## `3.21.0`
 

--- a/packages/vsce/__tests__/__e2e__/specs/files.spec.ts
+++ b/packages/vsce/__tests__/__e2e__/specs/files.spec.ts
@@ -35,6 +35,7 @@ test.describe("LocalFile tests", () => {
     await findAndClickTreeItem(page, constants.CICSPLEX_NAME);
     await findAndClickTreeItem(page, constants.REGION_NAME);
     await findAndClickTreeItem(page, "Files");
+    await page.waitForTimeout(200);
 
     await expect(getTreeItem(page, constants.LOCAL_FILE_1_NAME)).toHaveText(constants.LOCAL_FILE_1_NAME);
     await expect(getTreeItem(page, constants.LOCAL_FILE_1_NAME)).toBeVisible();
@@ -64,6 +65,7 @@ test.describe("LocalFile tests", () => {
     await findAndClickTreeItem(page, constants.CICSPLEX_NAME);
     await findAndClickTreeItem(page, constants.REGION_NAME);
     await findAndClickTreeItem(page, "Files");
+    await page.waitForTimeout(200);
 
     await findAndClickTreeItem(page, constants.LOCAL_FILE_1_NAME, "right");
     await page.waitForTimeout(200);

--- a/packages/vsce/__tests__/__e2e__/specs/files.spec.ts
+++ b/packages/vsce/__tests__/__e2e__/specs/files.spec.ts
@@ -35,7 +35,6 @@ test.describe("LocalFile tests", () => {
     await findAndClickTreeItem(page, constants.CICSPLEX_NAME);
     await findAndClickTreeItem(page, constants.REGION_NAME);
     await findAndClickTreeItem(page, "Files");
-    await page.waitForTimeout(200);
 
     await expect(getTreeItem(page, constants.LOCAL_FILE_1_NAME)).toHaveText(constants.LOCAL_FILE_1_NAME);
     await expect(getTreeItem(page, constants.LOCAL_FILE_1_NAME)).toBeVisible();
@@ -65,7 +64,6 @@ test.describe("LocalFile tests", () => {
     await findAndClickTreeItem(page, constants.CICSPLEX_NAME);
     await findAndClickTreeItem(page, constants.REGION_NAME);
     await findAndClickTreeItem(page, "Files");
-    await page.waitForTimeout(200);
 
     await findAndClickTreeItem(page, constants.LOCAL_FILE_1_NAME, "right");
     await page.waitForTimeout(200);

--- a/packages/vsce/__tests__/__e2e__/wiremock/__files/CICSLocalFile/open/response.xml
+++ b/packages/vsce/__tests__/__e2e__/wiremock/__files/CICSLocalFile/open/response.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<response xmlns="http://www.ibm.com/xmlns/prod/CICS/smw2int" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+xsi:schemaLocation="http://www.ibm.com/xmlns/prod/CICS/smw2int http://my-localhost:8080/CICSSystemManagement/schema/CICSSystemManagement.xsd" 
+version="3.0" connect_version="0610">
+	<resultsummary api_response1="1024" api_response2="0" api_response1_alt="OK" api_response2_alt="" recordcount="1" displayed_recordcount="1" />
+	<records>
+		<cicslocalfile _keydata="C3E4E2E3D6D4C5D9" accessmethod="VSAM" add="ADDABLE" addcnt="0" basdefinever="0" 
+        basedsname="USER.AUTO.CBSA.CUSTOMER" blockformat="BLOCKED" blockkeyln="N/A" blocksize="N/A" browse="BROWSABLE" 
+        browsecnt="0" browupdcnt="0" changeagent="SYSTEM" changeagrel="0710" changetime="2026-03-16T02:10:52.000000+00:00" 
+        changeusrid="USER" datasettype="K" definesource="SYSTEM" definetime="2026-03-16T02:10:52.000000+00:00" delete="DELETABLE" 
+        dexcpcnt="0" disposition="SHARE" dsname="USER.AUTO.CBSA.CUSTOMER" emptystatus="NOEMPTYREQ" enablestatus="ENABLED" exclusive="NOTAPPLIC" 
+        eyu_cicsname="MYREG1" eyu_cicsrel="E760" eyu_reserved="0" file="LOCFILE1" fwdrecstatus="NOTFWDRCVBLE" getcnt="0" getupdcnt="0" 
+        gmtfilecls="0000-00-00T00:00:00.000000+00:00" gmtfileopn="2026-04-17T00:00:00.000000+00:00" iexcpcnt="0" installagent="SYSTEM" 
+        installtime="2026-03-16T02:10:52.000000+00:00" installusrid="USER" journalnum="0" keylength="0" keyposition="0" locdelcnt="0" 
+        lsrpoolid="1" numactstring="0" numdatbuff="0" numindexbuff="0" numstringwt="0" object="BASE" openstatus="OPEN" rbatype="NOTAPPLIC" 
+        read="READABLE" readinteg="NOTAPPLIC" recordformat="VARIABLE" recordsize="0" recovstatus="NOTRECOVABLE" reltype="NOTAPPLIC" rlsaccess="NOTRLS" 
+        rlsreqwtto="0" strings="6" timeclose="00:00:00.0" timeopen="00:00:00.0" update="UPDATABLE" updatecnt="0" vsamtype="NOTAPPLIC" wstrccurcnt="0" wstrcnt="0" />
+	</records>
+</response>

--- a/packages/vsce/__tests__/__e2e__/wiremock/mappings/scenarios/open-file-scenario.json
+++ b/packages/vsce/__tests__/__e2e__/wiremock/mappings/scenarios/open-file-scenario.json
@@ -1,0 +1,25 @@
+{
+  "mappings": [
+    {
+      "scenarioName": "Open File",
+      "requiredScenarioState": "Started",
+      "newScenarioState": "locfile1-opened",
+      "request": {
+        "method": "PUT",
+        "url": "/CICSSystemManagement/CICSLocalFile/MYPLEX1/MYREG1?CRITERIA=(file%3DLOCFILE1)",
+        "bodyPatterns": [
+          {
+            "equalToXml": "<request><action name=\"OPEN\"/> </request>"
+          }
+        ]
+      },
+      "response": {
+        "status": 200,
+        "bodyFileName": "CICSLocalFile/open/response.xml",
+        "headers": {
+          "Content-Type": "text/xml"
+        }
+      }
+    }
+  ]
+}

--- a/packages/vsce/__tests__/__unit__/commands/closeLocalFileCommand.test.ts
+++ b/packages/vsce/__tests__/__unit__/commands/closeLocalFileCommand.test.ts
@@ -120,9 +120,11 @@ describe("closeLocalFileCommand", () => {
       nodes: mockNodes,
       tree: mockTree,
       parameter: {
-        name: "BUSY",
+        name: "busy",
         value: "WAIT",
       },
+      customAction: expect.any(Function),
+      getResourceName: expect.any(Function),
     });
   });
 
@@ -137,9 +139,11 @@ describe("closeLocalFileCommand", () => {
       nodes: mockNodes,
       tree: mockTree,
       parameter: {
-        name: "BUSY",
+        name: "busy",
         value: "NOWAIT",
       },
+      customAction: expect.any(Function),
+      getResourceName: expect.any(Function),
     });
   });
 
@@ -154,9 +158,11 @@ describe("closeLocalFileCommand", () => {
       nodes: mockNodes,
       tree: mockTree,
       parameter: {
-        name: "BUSY",
+        name: "busy",
         value: "FORCE",
       },
+      customAction: expect.any(Function),
+      getResourceName: expect.any(Function),
     });
   });
 
@@ -171,9 +177,11 @@ describe("closeLocalFileCommand", () => {
       nodes: mockNodes,
       tree: mockTree,
       parameter: {
-        name: "BUSY",
-        value: "WAIT",
+        name: "busy",
+        value: undefined,
       },
+      customAction: expect.any(Function),
+      getResourceName: expect.any(Function),
     });
   });
 
@@ -190,9 +198,11 @@ describe("closeLocalFileCommand", () => {
       nodes: singleNode,
       tree: mockTree,
       parameter: {
-        name: "BUSY",
+        name: "busy",
         value: "WAIT",
       },
+      customAction: expect.any(Function),
+      getResourceName: expect.any(Function),
     });
   });
 
@@ -207,9 +217,11 @@ describe("closeLocalFileCommand", () => {
       nodes: mockNodes,
       tree: mockTree,
       parameter: {
-        name: "BUSY",
+        name: "busy",
         value: "FORCE",
       },
+      customAction: expect.any(Function),
+      getResourceName: expect.any(Function),
     });
   });
 });

--- a/packages/vsce/l10n/bundle.l10n.json
+++ b/packages/vsce/l10n/bundle.l10n.json
@@ -275,5 +275,10 @@
   "No CICS resource information available to compare": "No CICS resource information available to compare",
   "Failed to compare resources: {0}": "Failed to compare resources: {0}",
   "Enter {0} name to compare with": "Enter {0} name to compare with",
-  "No CICS local file selected": "No CICS local file selected"
+  "No CICS local file selected": "No CICS local file selected",
+  "{0} {1} ({2} of {3})": "{0} {1} ({2} of {3})",
+  "Failed to {0} {1} ({2} of {3})": "Failed to {0} {1} ({2} of {3})",
+  "Failed to {0} all {1} resource(s)": "Failed to {0} all {1} resource(s)",
+  "{0} {1} of {2} resource(s). {3} failed.": "{0} {1} of {2} resource(s). {3} failed.",
+  "Successfully {0} {1} resource(s)": "Successfully {0} {1} resource(s)"
 }

--- a/packages/vsce/src/commands/actionResourceCommand.ts
+++ b/packages/vsce/src/commands/actionResourceCommand.ts
@@ -14,6 +14,8 @@ import type { ICMCIApiResponse, ICMCIResponseResultSummary } from "@zowe/cics-fo
 import { ProgressLocation, l10n, window } from "vscode";
 import constants from "../constants/CICS.defaults";
 import { CICSErrorHandler } from "../errors/CICSErrorHandler";
+import { CICSExtensionError } from "../errors/CICSExtensionError";
+import { SessionHandler } from "../resources";
 import type { CICSResourceContainerNode } from "../trees";
 import type { CICSTree } from "../trees/CICSTree";
 import { pollForCompleteAction } from "../utils/resourceUtils";
@@ -27,9 +29,28 @@ interface IActionTreeItemArgs {
   getParentResource?: (node: CICSResourceContainerNode<IResource>) => IResource;
   pollCriteria?: (response: { resultsummary: ICMCIResponseResultSummary; records: any }) => boolean;
   parameter?: { name: string; value: string };
+  /**
+   * Custom SDK function to call instead of setResource.
+   * Receives session and parameters object with: name, regionName, cicsPlex, and parameter value.
+   */
+  customAction?: (session: any, params: any) => Promise<ICMCIApiResponse>;
+  /**
+   * Function to extract the resource name from a node.
+   * Used for progress messages and error handling when using customAction.
+   */
+  getResourceName?: (node: CICSResourceContainerNode<IResource>) => string;
 }
 
-export const actionTreeItem = async ({ action, nodes, tree, getParentResource, pollCriteria, parameter }: IActionTreeItemArgs) => {
+export const actionTreeItem = async ({
+  action,
+  nodes,
+  tree,
+  getParentResource,
+  pollCriteria,
+  parameter,
+  customAction,
+  getResourceName,
+}: IActionTreeItemArgs) => {
   await window.withProgress(
     {
       title: resourceActionVerbMap[action],
@@ -40,27 +61,49 @@ export const actionTreeItem = async ({ action, nodes, tree, getParentResource, p
       token.onCancellationRequested(() => {});
 
       const nodesToRefresh = new Set();
+      const errors: Array<{ node: CICSResourceContainerNode<IResource>; error: any }> = [];
+      let successCount = 0;
 
       for (let i = 0; i < nodes.length; i++) {
         const node = nodes[i];
+        const resourceName = getResourceName ? getResourceName(node) : node.getContainedResourceName();
+        
         progress.report({
-          message: l10n.t("{0} of {1}", i + 1, nodes.length),
+          message: customAction
+            ? l10n.t("{0} {1} ({2} of {3})", resourceActionVerbMap[action], resourceName, i + 1, nodes.length)
+            : l10n.t("{0} of {1}", i + 1, nodes.length),
           increment: (1 / nodes.length) * constants.PERCENTAGE_MAX,
         });
 
         try {
-          const response = await setResource({
-            ctx: {
-              profileName: node.getProfileName(),
+          let response: ICMCIApiResponse;
+
+          if (customAction) {
+            // Use custom SDK function
+            const profile = SessionHandler.getInstance().getProfile(node.getProfileName());
+            const session = SessionHandler.getInstance().getSession(profile);
+
+            response = await customAction(session, {
+              name: resourceName,
               regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
-              cicsplexName: node.cicsplexName,
-            },
-            meta: node.getContainedResource().meta,
-            resourceName: node.getContainedResourceName(),
-            parentResource: getParentResource ? getParentResource(node.getParent() as CICSResourceContainerNode<IResource>) : undefined,
-            parameter,
-            action,
-          });
+              cicsPlex: node.cicsplexName,
+              ...(parameter && { [parameter.name]: parameter.value }),
+            });
+          } else {
+            // Use standard setResource
+            response = await setResource({
+              ctx: {
+                profileName: node.getProfileName(),
+                regionName: node.regionName ?? node.getContainedResource().resource.attributes.eyu_cicsname,
+                cicsplexName: node.cicsplexName,
+              },
+              meta: node.getContainedResource().meta,
+              resourceName,
+              parentResource: getParentResource ? getParentResource(node.getParent() as CICSResourceContainerNode<IResource>) : undefined,
+              parameter,
+              action,
+            });
+          }
 
           nodesToRefresh.add(node.getParent());
 
@@ -74,13 +117,44 @@ export const actionTreeItem = async ({ action, nodes, tree, getParentResource, p
           } else {
             evaluateTreeNodes(node, response, node.getContainedResource().meta);
           }
+          
+          successCount++;
         } catch (error) {
-          CICSErrorHandler.handleCMCIRestError(error);
+          errors.push({ node, error });
+          
+          if (customAction) {
+            const wrappedError = new CICSExtensionError({
+              baseError: error,
+              resourceName,
+              profileName: node.getProfileName(),
+            });
+            CICSErrorHandler.handleCMCIRestError(wrappedError);
+            
+            progress.report({
+              message: l10n.t("Failed to {0} {1} ({2} of {3})", action.toLowerCase(), resourceName, i + 1, nodes.length),
+            });
+          } else {
+            CICSErrorHandler.handleCMCIRestError(error);
+          }
         }
       }
+      
       nodesToRefresh.forEach((v) => {
         tree.refresh(v);
       });
+
+      // Show summary message for custom actions with multiple nodes
+      if (customAction && nodes.length > 1) {
+        if (errors.length > 0) {
+          const errorMessage =
+            errors.length === nodes.length
+              ? l10n.t("Failed to {0} all {1} resource(s)", action.toLowerCase(), nodes.length)
+              : l10n.t("{0} {1} of {2} resource(s). {3} failed.", resourceActionVerbMap[action], successCount, nodes.length, errors.length);
+          window.showWarningMessage(errorMessage);
+        } else {
+          window.showInformationMessage(l10n.t("Successfully {0} {1} resource(s)", action.toLowerCase(), successCount));
+        }
+      }
     }
   );
 };

--- a/packages/vsce/src/commands/closeLocalFileCommand.ts
+++ b/packages/vsce/src/commands/closeLocalFileCommand.ts
@@ -9,12 +9,21 @@
  *
  */
 
+import type { ILocalFile } from "@zowe/cics-for-zowe-explorer-api";
+import { closeLocalFile } from "@zowe/cics-for-zowe-sdk";
 import { type TreeView, commands, l10n, window } from "vscode";
 import { LocalFileMeta } from "../doc";
 import type { CICSTree } from "../trees/CICSTree";
+import type { CICSResourceContainerNode } from "../trees/CICSResourceContainerNode";
 import { findSelectedNodes } from "../utils/commandUtils";
 import { actionTreeItem } from "./actionResourceCommand";
 
+/**
+ * Registers the command to close CICS local files from the VS Code tree view
+ * @param tree - The CICS tree to refresh after closing
+ * @param treeview - The tree view containing selected nodes
+ * @returns Disposable command registration
+ */
 export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>) {
   return commands.registerCommand("cics-extension-for-zowe.closeLocalFile", async (clickedNode) => {
     const nodes = findSelectedNodes(treeview, LocalFileMeta, clickedNode);
@@ -29,24 +38,21 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
       [l10n.t("Force")]: "FORCE",
     };
 
-    const picked = await window.showInformationMessage(
+    const selectedBusyOption = await window.showInformationMessage(
       l10n.t("Choose one of the following for the file busy condition"),
       ...Object.keys(busyChoices)
     );
-    if (!picked) {
+    if (!selectedBusyOption) {
       return;
     }
-
-    const busyDecision = busyChoices[picked] ?? "WAIT";
 
     await actionTreeItem({
       action: "CLOSE",
       nodes,
       tree,
-      parameter: {
-        name: "BUSY",
-        value: busyDecision.replace(" ", "").toUpperCase(),
-      },
+      parameter: { name: "busy", value: busyChoices[selectedBusyOption] },
+      customAction: closeLocalFile,
+      getResourceName: (node) => (node as CICSResourceContainerNode<ILocalFile>).getContainedResource().resource.attributes.file,
     });
   });
 }


### PR DESCRIPTION
**What It Does**
This PR adds the ability to close CICS local files via the CLI by migrating the close local file functionality from the VS Code extension (VSCE) to the SDK, making it available for command-line usage. The implementation includes comprehensive test coverage for both the SDK method and CLI handler.


**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
Resolving https://github.com/zowe/cics-for-zowe-client/issues/241
