### PR TITLE
New Copy programs nested under library dataset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7133,31 +7133,17 @@
       "link": true
     },
     "node_modules/@zowe/cli-test-utils": {
-      "version": "8.31.5",
-      "integrity": "sha512-KyUf+DSIqHaYNKWpp0Qc5EwtosUVupKOQOXJ5SWClaxcJvDfGZzFAqbx63q+trS/cV58g0pBE6ES8EMkyUt7NQ==",
+      "version": "8.32.0",
+      "integrity": "sha512-fgSkxkkTehbiIrDlwOIuck3cltmYYGmBZJCZXZULMsLfI/vlLOH4dPZQzeLVnwGV49kFyyRQr7pfsWKekp69Dg==",
       "dev": true,
       "license": "EPL-2.0",
       "dependencies": {
         "find-up": "^5.0.0",
         "js-yaml": "^4.0.0",
-        "rimraf": "^6.1.3",
-        "uuid": "^10.0.0"
+        "rimraf": "^6.1.3"
       },
       "peerDependencies": {
         "@zowe/imperative": "^8.0.0"
-      }
-    },
-    "node_modules/@zowe/cli-test-utils/node_modules/uuid": {
-      "version": "10.0.0",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "dev": true,
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@zowe/core-for-zowe-sdk": {
@@ -15468,8 +15454,8 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -255,26 +255,25 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.4",
-      "integrity": "sha512-G4LXGGggok1QC48uKu64/SV2DPRDlddmV8EieK8pflsNYMj9/Zz+Y9OHoEBhT15h+zpdwXXLYA/7PJCR/yZ8aw==",
+      "version": "5.1.5",
+      "integrity": "sha512-ObTeMoNPmq19X3z40et9Xvs4ZoWVeJg43PZMRLG5iwVL+2nCtAerG3YTDItqPp1CfXNwmCXBbg8jn1DOx65c3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.5.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
+        "@azure/msal-common": "16.5.2",
+        "jsonwebtoken": "^9.0.0"
       },
       "engines": {
         "node": ">=20"
       }
     },
-    "node_modules/@azure/msal-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+    "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
+      "version": "16.5.2",
+      "integrity": "sha512-GkDEL6TYo3HgT3UuqakdgE9PZfc1hMki6+Hwgy1uddb/EauvAKfu85vVhuofRSo22D1xTnWt8Ucwfg4vSCVwvA==",
       "dev": true,
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
  - Enhancement: Adds hyperlinks to appropriate attributes in RI highlights. [#621](https://github.com/zowe/cics-for-zowe-client/issues/621)
  - BugFix: Render USS paths with a trailing slash (e.g. `JAVA_HOME=/usr/lpp/java/J8.0_64/`) as hyperlinks in the Resource Inspector. [#638](https://github.com/zowe/cics-for-zowe-client/issues/638)
  - Enhancement: Migrates close local file operation to the SDK (and expose via CLI). [#241](https://github.com/zowe/cics-for-zowe-client/issues/241)
+ - BugFix: Enable NewCopy on programs under a Library Data set. [#642](https://github.com/zowe/cics-for-zowe-client/issues/642)
 
 ## `3.21.0`
 

--- a/packages/vsce/__tests__/__unit__/commands/newCopyCommand.test.ts
+++ b/packages/vsce/__tests__/__unit__/commands/newCopyCommand.test.ts
@@ -14,9 +14,9 @@ import { getNewCopyCommand } from "../../../src/commands/newCopyCommand";
 import { actionTreeItem } from "../../../src/commands/actionResourceCommand";
 import { findSelectedNodes } from "../../../src/utils/commandUtils";
 import { ProgramMeta } from "../../../src/doc";
-import type { CICSResourceContainerNode } from "../../../src/trees";
 import { CICSTree } from "../../../src/trees/CICSTree";
-import type { IProgram } from "@zowe/cics-for-zowe-explorer-api";
+import { CICSResourceContainerNode } from "../../../src/trees/CICSResourceContainerNode";
+import { IProgram } from "@zowe/cics-for-zowe-explorer-api";
 
 jest.mock("vscode");
 jest.mock("../../../src/commands/actionResourceCommand");
@@ -27,6 +27,8 @@ describe("newCopyCommand", () => {
   let mockTreeview: TreeView<CICSResourceContainerNode<IProgram>>;
   let mockNode: CICSResourceContainerNode<IProgram>;
   let commandCallback: (node: CICSResourceContainerNode<IProgram>) => Promise<void>;
+
+  const findSelectedNodesMock = findSelectedNodes as jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -66,7 +68,7 @@ describe("newCopyCommand", () => {
     });
 
     (actionTreeItem as jest.Mock) = jest.fn().mockResolvedValue(undefined);
-    (findSelectedNodes as jest.Mock) = jest.fn().mockReturnValue([mockNode]);
+    findSelectedNodesMock.mockReturnValue([mockNode]);
     (window.showErrorMessage as jest.Mock) = jest.fn();
   });
 
@@ -88,268 +90,188 @@ describe("newCopyCommand", () => {
     });
   });
 
+  // Test data constants
+  const INVALID_NODE_SCENARIOS: Array<{ desc: string; returnValue: CICSResourceContainerNode<IProgram>[] | null | undefined }> = [
+    { desc: "no nodes selected", returnValue: [] },
+    { desc: "null selection", returnValue: null },
+    { desc: "undefined selection", returnValue: undefined },
+  ];
+
+  const CONTEXT_VALUE_TEST_CASES: Array<{ desc: string; contextValue: string | undefined | null; expectsParentResource: boolean }> = [
+    {
+      desc: "with PARENT.CICSLibraryDatasetName",
+      contextValue: "CICS.Program.PARENT.CICSLibraryDatasetName",
+      expectsParentResource: true,
+    },
+    {
+      desc: "with PARENT.CICSLibraryDatasetName and additional context",
+      contextValue: "CICS.Program.PARENT.CICSLibraryDatasetName.SomeOtherContext",
+      expectsParentResource: true,
+    },
+    {
+      desc: "without PARENT.CICSLibraryDatasetName",
+      contextValue: "CICS.Program.SomeOtherContext",
+      expectsParentResource: false,
+    },
+    {
+      desc: "with empty string",
+      contextValue: "",
+      expectsParentResource: false,
+    },
+    {
+      desc: "with case mismatch",
+      contextValue: "CICS.Program.PARENT.cicslibrarydatasetname",
+      expectsParentResource: false,
+    },
+    {
+      desc: "with undefined",
+      contextValue: undefined,
+      expectsParentResource: false,
+    },
+    {
+      desc: "with null",
+      contextValue: null,
+      expectsParentResource: false,
+    },
+  ];
+
+  // Helper function to create mock program nodes with type safety
+  function createMockProgramNode(overrides: Partial<CICSResourceContainerNode<IProgram>> = {}): CICSResourceContainerNode<IProgram> {
+    return {
+      ...mockNode,
+      ...overrides,
+    } as CICSResourceContainerNode<IProgram>;
+  }
+
+  // Helper function to create mock node with parent resource
+  function createMockNodeWithParent(parentAttributes: Record<string, unknown>): CICSResourceContainerNode<IProgram> {
+    return createMockProgramNode({
+      getParent: jest.fn().mockReturnValue({
+        getContainedResource: jest.fn().mockReturnValue({
+          resource: { attributes: parentAttributes },
+        }),
+      }),
+    });
+  }
+
+  // Helper function to execute the new copy command
+  async function executeNewCopyCommand(node = mockNode) {
+    getNewCopyCommand(mockTree, mockTreeview);
+    await commandCallback(node);
+  }
+
+  // Helper function to assert actionTreeItem was called with expected parameters
+  function expectActionTreeItemCalledWith(
+    nodes: CICSResourceContainerNode<IProgram>[],
+    includeParentResource = false
+  ) {
+    const expectedCall = {
+      action: "NEWCOPY",
+      nodes,
+      tree: mockTree,
+      ...(includeParentResource && { getParentResource: expect.any(Function) }),
+    };
+    
+    expect(actionTreeItem).toHaveBeenCalledWith(expectedCall);
+  }
+
   describe("newCopyProgram command execution", () => {
     it("should perform new copy on a program successfully", async () => {
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
+      await executeNewCopyCommand();
 
       expect(findSelectedNodes).toHaveBeenCalledWith(mockTreeview, ProgramMeta, mockNode);
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode],
-        tree: mockTree,
-      });
+      expectActionTreeItemCalledWith([mockNode]);
       expect(window.showErrorMessage).not.toHaveBeenCalled();
     });
 
     it("should handle multiple selected programs", async () => {
-      const mockNode2 = {
-        ...mockNode,
+      const mockNode2 = createMockProgramNode({
         getContainedResourceName: jest.fn().mockReturnValue("TESTPROG2"),
-      } as Partial<CICSResourceContainerNode<IProgram>> as CICSResourceContainerNode<IProgram>;
-
-      (findSelectedNodes as jest.Mock).mockReturnValue([mockNode, mockNode2]);
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode, mockNode2],
-        tree: mockTree,
       });
+
+      findSelectedNodesMock.mockReturnValue([mockNode, mockNode2]);
+      await executeNewCopyCommand();
+
+      expectActionTreeItemCalledWith([mockNode, mockNode2]);
     });
 
-    it("should show error when no programs selected", async () => {
-      (findSelectedNodes as jest.Mock).mockReturnValue([]);
-      getNewCopyCommand(mockTree, mockTreeview);
+    describe("error handling", () => {
+      test.each(INVALID_NODE_SCENARIOS)(
+        "should show error when $desc",
+        async ({ returnValue }) => {
+          findSelectedNodesMock.mockReturnValue(returnValue);
+          await executeNewCopyCommand();
 
-      await commandCallback(mockNode);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        expect.stringContaining("No CICS")
+          expect(window.showErrorMessage).toHaveBeenCalled();
+          expect(actionTreeItem).not.toHaveBeenCalled();
+        }
       );
-      expect(actionTreeItem).not.toHaveBeenCalled();
     });
 
-    it("should show error when nodes is null", async () => {
-      (findSelectedNodes as jest.Mock).mockReturnValue(null);
-      getNewCopyCommand(mockTree, mockTreeview);
+    describe("contextValue handling", () => {
+      test.each(CONTEXT_VALUE_TEST_CASES)(
+        "should handle contextValue $desc",
+        async ({ contextValue, expectsParentResource }) => {
+          mockNode.contextValue = contextValue as string | undefined;
+          await executeNewCopyCommand();
 
-      await commandCallback(mockNode);
+          expectActionTreeItemCalledWith([mockNode], expectsParentResource);
+        }
+      );
 
-      expect(window.showErrorMessage).toHaveBeenCalled();
-      expect(actionTreeItem).not.toHaveBeenCalled();
-    });
+      it("should handle multiple programs from library dataset", async () => {
+        const mockNode2 = createMockProgramNode({
+          contextValue: "CICS.Program.PARENT.CICSLibraryDatasetName",
+          getContainedResourceName: jest.fn().mockReturnValue("TESTPROG2"),
+        });
 
-    it("should show error when nodes is undefined", async () => {
-      (findSelectedNodes as jest.Mock).mockReturnValue(undefined);
-      getNewCopyCommand(mockTree, mockTreeview);
+        mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
+        findSelectedNodesMock.mockReturnValue([mockNode, mockNode2]);
+        await executeNewCopyCommand();
 
-      await commandCallback(mockNode);
+        expectActionTreeItemCalledWith([mockNode, mockNode2], true);
+      });
 
-      expect(window.showErrorMessage).toHaveBeenCalled();
-      expect(actionTreeItem).not.toHaveBeenCalled();
-    });
+      it("should handle mixed programs (some from library dataset, some not)", async () => {
+        const mockNode2 = createMockProgramNode({
+          contextValue: "CICS.Program",
+          getContainedResourceName: jest.fn().mockReturnValue("TESTPROG2"),
+        });
 
-    it("should handle program from library dataset with parent resource", async () => {
-      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
-      getNewCopyCommand(mockTree, mockTreeview);
+        mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
+        findSelectedNodesMock.mockReturnValue([mockNode, mockNode2]);
+        await executeNewCopyCommand();
 
-      await commandCallback(mockNode);
-
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode],
-        tree: mockTree,
-        getParentResource: expect.any(Function),
+        // Should use getParentResource based on the clicked node's contextValue
+        expectActionTreeItemCalledWith([mockNode, mockNode2], true);
       });
     });
 
-    it("should verify getParentResource function extracts attributes correctly", async () => {
-      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
-      getNewCopyCommand(mockTree, mockTreeview);
+    describe("getParentResource callback", () => {
+      it("should extract parent resource attributes correctly", async () => {
+        mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
+        await executeNewCopyCommand();
 
-      await commandCallback(mockNode);
+        const callArgs = (actionTreeItem as jest.Mock).mock.calls[0][0];
+        const getParentResource = callArgs.getParentResource;
 
-      const callArgs = (actionTreeItem as jest.Mock).mock.calls[0][0];
-      const getParentResource = callArgs.getParentResource;
-
-      const testNode = {
-        getContainedResource: jest.fn().mockReturnValue({
-          resource: {
-            attributes: {
-              name: "TESTLIB",
-              dsname: "TEST.DATASET",
+        // Create a mock parent node (library dataset) with the expected attributes
+        const parentNode = createMockProgramNode({
+          getContainedResource: jest.fn().mockReturnValue({
+            resource: {
+              attributes: {
+                name: "TESTLIB",
+                dsname: "TEST.DATASET",
+              },
             },
-          },
-        }),
-      } as Partial<CICSResourceContainerNode<IProgram>> as CICSResourceContainerNode<IProgram>;
+          }),
+        });
 
-      const result = getParentResource(testNode);
-      expect(result).toEqual({
-        name: "TESTLIB",
-        dsname: "TEST.DATASET",
-      });
-    });
-
-    it("should handle program with PARENT.CICSLibraryDatasetName in contextValue", async () => {
-      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName.SomeOtherContext";
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode],
-        tree: mockTree,
-        getParentResource: expect.any(Function),
-      });
-    });
-
-    it("should not use getParentResource when contextValue does not include PARENT.CICSLibraryDatasetName", async () => {
-      mockNode.contextValue = "CICS.Program.SomeOtherContext";
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode],
-        tree: mockTree,
-      });
-    });
-
-    it("should handle program with undefined contextValue", async () => {
-      mockNode.contextValue = undefined;
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode],
-        tree: mockTree,
-      });
-    });
-
-    it("should handle program with null contextValue", async () => {
-      mockNode.contextValue = null as unknown as string;
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode],
-        tree: mockTree,
-      });
-    });
-
-    it("should handle multiple programs from library dataset", async () => {
-      const mockNode2 = {
-        ...mockNode,
-        contextValue: "CICS.Program.PARENT.CICSLibraryDatasetName",
-        getContainedResourceName: jest.fn().mockReturnValue("TESTPROG2"),
-      } as Partial<CICSResourceContainerNode<IProgram>> as CICSResourceContainerNode<IProgram>;
-
-      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
-      (findSelectedNodes as jest.Mock).mockReturnValue([mockNode, mockNode2]);
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode, mockNode2],
-        tree: mockTree,
-        getParentResource: expect.any(Function),
-      });
-    });
-
-    it("should handle mixed programs (some from library dataset, some not)", async () => {
-      const mockNode2 = {
-        ...mockNode,
-        contextValue: "CICS.Program",
-        getContainedResourceName: jest.fn().mockReturnValue("TESTPROG2"),
-      } as Partial<CICSResourceContainerNode<IProgram>> as CICSResourceContainerNode<IProgram>;
-
-      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
-      (findSelectedNodes as jest.Mock).mockReturnValue([mockNode, mockNode2]);
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      // Should use getParentResource based on the clicked node's contextValue
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode, mockNode2],
-        tree: mockTree,
-        getParentResource: expect.any(Function),
-      });
-    });
-
-    it("should call findSelectedNodes with correct parameters", async () => {
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      expect(findSelectedNodes).toHaveBeenCalledWith(
-        mockTreeview,
-        ProgramMeta,
-        mockNode
-      );
-    });
-
-    it("should pass tree parameter to actionTreeItem", async () => {
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      const callArgs = (actionTreeItem as jest.Mock).mock.calls[0][0];
-      expect(callArgs.tree).toBe(mockTree);
-    });
-
-    it("should use NEWCOPY action for all scenarios", async () => {
-      // Test regular program
-      getNewCopyCommand(mockTree, mockTreeview);
-      await commandCallback(mockNode);
-      expect((actionTreeItem as jest.Mock).mock.calls[0][0].action).toBe("NEWCOPY");
-
-      // Test program from library dataset
-      jest.clearAllMocks();
-      (findSelectedNodes as jest.Mock).mockReturnValue([mockNode]);
-      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
-      getNewCopyCommand(mockTree, mockTreeview);
-      await commandCallback(mockNode);
-      expect((actionTreeItem as jest.Mock).mock.calls[0][0].action).toBe("NEWCOPY");
-    });
-
-    it("should handle empty contextValue string", async () => {
-      mockNode.contextValue = "";
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode],
-        tree: mockTree,
-      });
-    });
-
-    it("should be case-sensitive when checking contextValue", async () => {
-      mockNode.contextValue = "CICS.Program.PARENT.cicslibrarydatasetname";
-      getNewCopyCommand(mockTree, mockTreeview);
-
-      await commandCallback(mockNode);
-
-      // Should not match due to case difference
-      expect(actionTreeItem).toHaveBeenCalledWith({
-        action: "NEWCOPY",
-        nodes: [mockNode],
-        tree: mockTree,
+        const result = getParentResource(parentNode);
+        expect(result).toEqual({
+          name: "TESTLIB",
+          dsname: "TEST.DATASET",
+        });
       });
     });
   });

--- a/packages/vsce/__tests__/__unit__/commands/newCopyCommand.test.ts
+++ b/packages/vsce/__tests__/__unit__/commands/newCopyCommand.test.ts
@@ -1,0 +1,356 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import { commands, window, TreeView, Disposable } from "vscode";
+import { getNewCopyCommand } from "../../../src/commands/newCopyCommand";
+import { actionTreeItem } from "../../../src/commands/actionResourceCommand";
+import { findSelectedNodes } from "../../../src/utils/commandUtils";
+import { ProgramMeta } from "../../../src/doc";
+import type { CICSResourceContainerNode } from "../../../src/trees";
+import { CICSTree } from "../../../src/trees/CICSTree";
+import type { IProgram } from "@zowe/cics-for-zowe-explorer-api";
+
+jest.mock("vscode");
+jest.mock("../../../src/commands/actionResourceCommand");
+jest.mock("../../../src/utils/commandUtils");
+
+describe("newCopyCommand", () => {
+  let mockTree: CICSTree;
+  let mockTreeview: TreeView<CICSResourceContainerNode<IProgram>>;
+  let mockNode: CICSResourceContainerNode<IProgram>;
+  let commandCallback: (node: CICSResourceContainerNode<IProgram>) => Promise<void>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockTree = new CICSTree();
+    mockTreeview = {} as TreeView<CICSResourceContainerNode<IProgram>>;
+
+    mockNode = {
+      getProfileName: jest.fn().mockReturnValue("testProfile"),
+      regionName: "TESTREGION",
+      cicsplexName: "TESTPLEX",
+      contextValue: "CICS.Program",
+      getContainedResource: jest.fn().mockReturnValue({
+        meta: ProgramMeta,
+        resource: {
+          attributes: {
+            name: "TESTPROG",
+            eyu_cicsname: "TESTREGION",
+          },
+        },
+      }),
+      getContainedResourceName: jest.fn().mockReturnValue("TESTPROG"),
+      getParent: jest.fn().mockReturnValue({
+        getContainedResource: jest.fn().mockReturnValue({
+          resource: {
+            attributes: {
+              name: "PARENTRES",
+            },
+          },
+        }),
+      }),
+    } as Partial<CICSResourceContainerNode<IProgram>> as CICSResourceContainerNode<IProgram>;
+
+    (commands.registerCommand as jest.Mock) = jest.fn((commandId: string, callback: (node: CICSResourceContainerNode<IProgram>) => Promise<void>) => {
+      commandCallback = callback;
+      return { dispose: jest.fn() } as Disposable;
+    });
+
+    (actionTreeItem as jest.Mock) = jest.fn().mockResolvedValue(undefined);
+    (findSelectedNodes as jest.Mock) = jest.fn().mockReturnValue([mockNode]);
+    (window.showErrorMessage as jest.Mock) = jest.fn();
+  });
+
+  describe("getNewCopyCommand", () => {
+    it("should register the newCopyProgram command", () => {
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      expect(commands.registerCommand).toHaveBeenCalledWith(
+        "cics-extension-for-zowe.newCopyProgram",
+        expect.any(Function)
+      );
+    });
+
+    it("should return a disposable", () => {
+      const disposable = getNewCopyCommand(mockTree, mockTreeview);
+
+      expect(disposable).toBeDefined();
+      expect(disposable.dispose).toBeDefined();
+    });
+  });
+
+  describe("newCopyProgram command execution", () => {
+    it("should perform new copy on a program successfully", async () => {
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(findSelectedNodes).toHaveBeenCalledWith(mockTreeview, ProgramMeta, mockNode);
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode],
+        tree: mockTree,
+      });
+      expect(window.showErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it("should handle multiple selected programs", async () => {
+      const mockNode2 = {
+        ...mockNode,
+        getContainedResourceName: jest.fn().mockReturnValue("TESTPROG2"),
+      } as Partial<CICSResourceContainerNode<IProgram>> as CICSResourceContainerNode<IProgram>;
+
+      (findSelectedNodes as jest.Mock).mockReturnValue([mockNode, mockNode2]);
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode, mockNode2],
+        tree: mockTree,
+      });
+    });
+
+    it("should show error when no programs selected", async () => {
+      (findSelectedNodes as jest.Mock).mockReturnValue([]);
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining("No CICS")
+      );
+      expect(actionTreeItem).not.toHaveBeenCalled();
+    });
+
+    it("should show error when nodes is null", async () => {
+      (findSelectedNodes as jest.Mock).mockReturnValue(null);
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(window.showErrorMessage).toHaveBeenCalled();
+      expect(actionTreeItem).not.toHaveBeenCalled();
+    });
+
+    it("should show error when nodes is undefined", async () => {
+      (findSelectedNodes as jest.Mock).mockReturnValue(undefined);
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(window.showErrorMessage).toHaveBeenCalled();
+      expect(actionTreeItem).not.toHaveBeenCalled();
+    });
+
+    it("should handle program from library dataset with parent resource", async () => {
+      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode],
+        tree: mockTree,
+        getParentResource: expect.any(Function),
+      });
+    });
+
+    it("should verify getParentResource function extracts attributes correctly", async () => {
+      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      const callArgs = (actionTreeItem as jest.Mock).mock.calls[0][0];
+      const getParentResource = callArgs.getParentResource;
+
+      const testNode = {
+        getContainedResource: jest.fn().mockReturnValue({
+          resource: {
+            attributes: {
+              name: "TESTLIB",
+              dsname: "TEST.DATASET",
+            },
+          },
+        }),
+      } as Partial<CICSResourceContainerNode<IProgram>> as CICSResourceContainerNode<IProgram>;
+
+      const result = getParentResource(testNode);
+      expect(result).toEqual({
+        name: "TESTLIB",
+        dsname: "TEST.DATASET",
+      });
+    });
+
+    it("should handle program with PARENT.CICSLibraryDatasetName in contextValue", async () => {
+      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName.SomeOtherContext";
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode],
+        tree: mockTree,
+        getParentResource: expect.any(Function),
+      });
+    });
+
+    it("should not use getParentResource when contextValue does not include PARENT.CICSLibraryDatasetName", async () => {
+      mockNode.contextValue = "CICS.Program.SomeOtherContext";
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode],
+        tree: mockTree,
+      });
+    });
+
+    it("should handle program with undefined contextValue", async () => {
+      mockNode.contextValue = undefined;
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode],
+        tree: mockTree,
+      });
+    });
+
+    it("should handle program with null contextValue", async () => {
+      mockNode.contextValue = null as unknown as string;
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode],
+        tree: mockTree,
+      });
+    });
+
+    it("should handle multiple programs from library dataset", async () => {
+      const mockNode2 = {
+        ...mockNode,
+        contextValue: "CICS.Program.PARENT.CICSLibraryDatasetName",
+        getContainedResourceName: jest.fn().mockReturnValue("TESTPROG2"),
+      } as Partial<CICSResourceContainerNode<IProgram>> as CICSResourceContainerNode<IProgram>;
+
+      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
+      (findSelectedNodes as jest.Mock).mockReturnValue([mockNode, mockNode2]);
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode, mockNode2],
+        tree: mockTree,
+        getParentResource: expect.any(Function),
+      });
+    });
+
+    it("should handle mixed programs (some from library dataset, some not)", async () => {
+      const mockNode2 = {
+        ...mockNode,
+        contextValue: "CICS.Program",
+        getContainedResourceName: jest.fn().mockReturnValue("TESTPROG2"),
+      } as Partial<CICSResourceContainerNode<IProgram>> as CICSResourceContainerNode<IProgram>;
+
+      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
+      (findSelectedNodes as jest.Mock).mockReturnValue([mockNode, mockNode2]);
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      // Should use getParentResource based on the clicked node's contextValue
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode, mockNode2],
+        tree: mockTree,
+        getParentResource: expect.any(Function),
+      });
+    });
+
+    it("should call findSelectedNodes with correct parameters", async () => {
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(findSelectedNodes).toHaveBeenCalledWith(
+        mockTreeview,
+        ProgramMeta,
+        mockNode
+      );
+    });
+
+    it("should pass tree parameter to actionTreeItem", async () => {
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      const callArgs = (actionTreeItem as jest.Mock).mock.calls[0][0];
+      expect(callArgs.tree).toBe(mockTree);
+    });
+
+    it("should use NEWCOPY action for all scenarios", async () => {
+      // Test regular program
+      getNewCopyCommand(mockTree, mockTreeview);
+      await commandCallback(mockNode);
+      expect((actionTreeItem as jest.Mock).mock.calls[0][0].action).toBe("NEWCOPY");
+
+      // Test program from library dataset
+      jest.clearAllMocks();
+      (findSelectedNodes as jest.Mock).mockReturnValue([mockNode]);
+      mockNode.contextValue = "CICS.Program.PARENT.CICSLibraryDatasetName";
+      getNewCopyCommand(mockTree, mockTreeview);
+      await commandCallback(mockNode);
+      expect((actionTreeItem as jest.Mock).mock.calls[0][0].action).toBe("NEWCOPY");
+    });
+
+    it("should handle empty contextValue string", async () => {
+      mockNode.contextValue = "";
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode],
+        tree: mockTree,
+      });
+    });
+
+    it("should be case-sensitive when checking contextValue", async () => {
+      mockNode.contextValue = "CICS.Program.PARENT.cicslibrarydatasetname";
+      getNewCopyCommand(mockTree, mockTreeview);
+
+      await commandCallback(mockNode);
+
+      // Should not match due to case difference
+      expect(actionTreeItem).toHaveBeenCalledWith({
+        action: "NEWCOPY",
+        nodes: [mockNode],
+        tree: mockTree,
+      });
+    });
+  });
+});

--- a/packages/vsce/__tests__/__unit__/commands/newCopyCommand.test.ts
+++ b/packages/vsce/__tests__/__unit__/commands/newCopyCommand.test.ts
@@ -143,16 +143,6 @@ describe("newCopyCommand", () => {
     } as CICSResourceContainerNode<IProgram>;
   }
 
-  // Helper function to create mock node with parent resource
-  function createMockNodeWithParent(parentAttributes: Record<string, unknown>): CICSResourceContainerNode<IProgram> {
-    return createMockProgramNode({
-      getParent: jest.fn().mockReturnValue({
-        getContainedResource: jest.fn().mockReturnValue({
-          resource: { attributes: parentAttributes },
-        }),
-      }),
-    });
-  }
 
   // Helper function to execute the new copy command
   async function executeNewCopyCommand(node = mockNode) {

--- a/packages/vsce/src/commands/newCopyCommand.ts
+++ b/packages/vsce/src/commands/newCopyCommand.ts
@@ -30,15 +30,16 @@ export function getNewCopyCommand(tree: CICSTree, treeview: TreeView<any>) {
       return;
     }
 
-    if(clickedNode.contextValue?.includes("PARENT.CICSLibraryDatasetName")){
-      return actionTreeItem({ 
+    // Programs under library datasets require parent resource information for NEWCOPY
+    if (clickedNode.contextValue?.includes("PARENT.CICSLibraryDatasetName")){
+      await actionTreeItem({
         action: "NEWCOPY", 
         nodes, 
         tree, 
-        getParentResource: (node: CICSResourceContainerNode<IProgram>) => node.getContainedResource().resource.attributes  
+        getParentResource: (node: CICSResourceContainerNode<IProgram>) => node.getContainedResource().resource.attributes
       });
     }
 
-    return actionTreeItem({ action: "NEWCOPY", nodes, tree });
+    await actionTreeItem({ action: "NEWCOPY", nodes, tree });
   });
 }

--- a/packages/vsce/src/commands/newCopyCommand.ts
+++ b/packages/vsce/src/commands/newCopyCommand.ts
@@ -30,6 +30,15 @@ export function getNewCopyCommand(tree: CICSTree, treeview: TreeView<any>) {
       return;
     }
 
-    await actionTreeItem({ action: "NEWCOPY", nodes, tree });
+    if(clickedNode.contextValue?.includes("PARENT.CICSLibraryDatasetName")){
+      return actionTreeItem({ 
+        action: "NEWCOPY", 
+        nodes, 
+        tree, 
+        getParentResource: (node: CICSResourceContainerNode<IProgram>) => node.getContainedResource().resource.attributes  
+      });
+    }
+
+    return actionTreeItem({ action: "NEWCOPY", nodes, tree });
   });
 }

--- a/packages/vsce/src/commands/newCopyCommand.ts
+++ b/packages/vsce/src/commands/newCopyCommand.ts
@@ -9,7 +9,7 @@
  *
  */
 
-import type { IProgram } from "@zowe/cics-for-zowe-explorer-api";
+import type { ILibraryDataset, IProgram } from "@zowe/cics-for-zowe-explorer-api";
 import { type TreeView, commands, l10n, window } from "vscode";
 import { ProgramMeta } from "../doc";
 import type { CICSResourceContainerNode } from "../trees";
@@ -36,7 +36,7 @@ export function getNewCopyCommand(tree: CICSTree, treeview: TreeView<any>) {
         action: "NEWCOPY", 
         nodes, 
         tree, 
-        getParentResource: (node: CICSResourceContainerNode<IProgram>) => node.getContainedResource().resource.attributes
+        getParentResource: (parentNode: CICSResourceContainerNode<ILibraryDataset>) => parentNode.getContainedResource().resource.attributes
       });
     }
 


### PR DESCRIPTION
**What It Does**

When newcopying programs nested under a CICS library, as part of a CICS library dataset, an error occurs. This PR addresses this, parsing the correct set of args to the action allowing a newcopy on 1 or more programs under a library.

**How to Test**

NewCopy a program shown under a CICSLibrary. 

**Which Issue It Relates To**
Resolved #642 

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
