### PR TITLE
Update system test configuration following Jest version bump

### DIFF
--- a/common.jest_config.js
+++ b/common.jest_config.js
@@ -22,7 +22,11 @@ function createConfig(testType, title) {
         transformIgnorePatterns: ["^.+\\.cjs$", "^.+\\.js$", "^.+\\.json$"],
         testRegex: "(test|spec)\\.ts$",
         moduleFileExtensions: ["ts", "tsx", "js", "json"],
-        testPathIgnorePatterns: ["<rootDir>/__tests__/__results__", ".*/__".concat(isUnit ? "system" : "unit", "__/.*"), "<rootDir>/__tests__/__e2e__"],
+        testPathIgnorePatterns: [
+            "<rootDir>/__tests__/__results__", 
+            ".*/__".concat(isUnit ? "system" : "unit", "__/.*"), 
+            "<rootDir>/__tests__/__e2e__"
+        ],
         testEnvironment: "node",
         collectCoverage: isUnit,
         coverageReporters: ["json", "lcov", "text", "cobertura"],

--- a/common.jest_config.js
+++ b/common.jest_config.js
@@ -1,0 +1,58 @@
+"use strict";
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.createConfig = void 0;
+function createConfig(testType, title) {
+    var isUnit = testType.toLowerCase() === "unit";
+    return {
+        maxWorkers: isUnit ? "100%" : 1,
+        testTimeout: 600000,
+        displayName: title,
+        modulePathIgnorePatterns: ["__tests__/__snapshots__/"],
+        transform: { ".(ts|tsx)": "ts-jest" },
+        transformIgnorePatterns: ["^.+\\.cjs$", "^.+\\.js$", "^.+\\.json$"],
+        testRegex: "(test|spec)\\.ts$",
+        moduleFileExtensions: ["ts", "tsx", "js", "json"],
+        testPathIgnorePatterns: ["<rootDir>/__tests__/__results__", ".*/__".concat(isUnit ? "system" : "unit", "__/.*"), "<rootDir>/__tests__/__e2e__"],
+        testEnvironment: "node",
+        collectCoverage: isUnit,
+        coverageReporters: ["json", "lcov", "text", "cobertura"],
+        coverageDirectory: "__tests__/__results__/".concat(testType, "/coverage"),
+        coveragePathIgnorePatterns: ["<rootDir>/__tests__/__e2e__"],
+        collectCoverageFrom: [
+            "src/**/*.ts",
+            "!**/__tests__/**",
+            "!**/index.ts",
+            "!**/main.ts"
+        ],
+        reporters: [
+            "default",
+            ["jest-junit", {
+                    outputFile: "__tests__/__results__/".concat(testType, "/junit.xml"),
+                    ancestorSeparator: " > ",
+                    classNameTemplate: "".concat(testType, ".{classname}"),
+                    title: "{title}"
+                }],
+            ["jest-stare", {
+                    resultDir: "__tests__/__results__/".concat(testType, "/jest-stare"),
+                    coverageLink: "../coverage/lcov-report/index.html",
+                    resultHtml: "index.html"
+                }],
+            ["jest-html-reporter", {
+                    pageTitle: title,
+                    outputPath: "__tests__/__results__/".concat(testType, "/results.html"),
+                    includeFailureMsg: true
+                }],
+        ],
+    };
+}
+exports.createConfig = createConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15453,8 +15453,8 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.14",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -14,14 +14,15 @@
     "watch": "turbo watch",
     "package": "turbo package",
     "test": "npm run test --workspaces",
-    "test:system": "npm run test:system --workspaces",
+    "test:system": "npm run validate:system-tests && npm run test:system --workspaces",
     "test:unit": "npm run test:unit --workspaces",
     "test:e2e": "npm run test:e2e --workspaces",
     "lint": "npx eslint --ignore-pattern packages --ignore-pattern scripts && npm run lint --workspaces",
     "lintErrors": "npm run lintErrors --workspaces",
     "prepare": "husky install",
     "license": "node scripts/updateLicenses.js",
-    "pretty": "turbo pretty --no-cache"
+    "pretty": "turbo pretty --no-cache",
+    "validate:system-tests": "node scripts/validate-system-test-config.js"
   },
   "devDependencies": {
     "@eslint/css": "^0.14.1",

--- a/packages/cli/__tests__/__system__/add-to-list/csdGroup/__snapshots__/cli.add-to-list.csdGroup.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/add-to-list/csdGroup/__snapshots__/cli.add-to-list.csdGroup.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS add-to-list csdGroup command should be able to display the help 1`] = `
 "
@@ -131,8 +131,7 @@ exports[`CICS add-to-list csdGroup command should be able to display the help 1`
  EXAMPLES
  --------
 
-   - Add the CSD Group MYGRP to the CSD List MYLIST in the
-   region named MYREG:
+   - Add the CSD Group MYGRP to the CSD List MYLIST in the region named MYREG:
 
       $ zowe cics add-to-list csdGroup MYGRP MYLIST --region-name MYREG
 

--- a/packages/cli/__tests__/__system__/define/program/__snapshots__/cli.define.program.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/define/program/__snapshots__/cli.define.program.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS define program command should be able to display the help 1`] = `
 "
@@ -131,8 +131,8 @@ exports[`CICS define program command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Define a program named PGM123 to the region name MYREGION
-   in the CSD group MYGRP:
+   - Define a program named PGM123 to the region name MYREGION in the CSD group
+   MYGRP:
 
       $ zowe cics define program PGM123 MYGRP --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/define/transaction/__snapshots__/cli.define.transaction.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/define/transaction/__snapshots__/cli.define.transaction.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS define transaction command should be able to display the help 1`] = `
 "
@@ -136,8 +136,8 @@ exports[`CICS define transaction command should be able to display the help 1`] 
  EXAMPLES
  --------
 
-   - Define a transaction named TRN1 for the program named
-   PGM123 to the region named MYREGION in the CSD group MYGRP:
+   - Define a transaction named TRN1 for the program named PGM123 to the region
+   named MYREGION in the CSD group MYGRP:
 
       $ zowe cics define transaction TRN1 PGM123 MYGRP --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/define/urimap-client/__snapshots__/cli.define.urimap.client.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS define urimap-client command should be able to display the help 1`] = `
 "
@@ -170,9 +170,8 @@ exports[`CICS define urimap-client command should be able to display the help 1`
  EXAMPLES
  --------
 
-   - Define a URIMAP named URIMAPA to the region named MYREGION
-   in the CSD group MYGRP where the host is www.example.com and the path is
-   /example/index.html:
+   - Define a URIMAP named URIMAPA to the region named MYREGION in the CSD group
+   MYGRP where the host is www.example.com and the path is /example/index.html:
 
       $ zowe cics define urimap-client URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/define/urimap-pipeline/__snapshots__/cli.define.urimap.pipeline.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS define urimap-pipeline command should be able to display the help 1`] = `
 "
@@ -179,9 +179,9 @@ exports[`CICS define urimap-pipeline command should be able to display the help 
  EXAMPLES
  --------
 
-   - Define a URIMAP named URIMAPA for the pipeline named
-   PIPE123 to the region named MYREGION in the CSD group MYGRP where the host is
-   www.example.com and the path is /example/index.html:
+   - Define a URIMAP named URIMAPA for the pipeline named PIPE123 to the region
+   named MYREGION in the CSD group MYGRP where the host is www.example.com and the
+   path is /example/index.html:
 
       $ zowe cics define urimap-pipeline URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --pipeline-name PIPE123 --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/define/urimap-server/__snapshots__/cli.define.urimap.server.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/define/urimap-server/__snapshots__/cli.define.urimap.server.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS define urimap-server command should be able to display the help 1`] = `
 "
@@ -167,9 +167,9 @@ exports[`CICS define urimap-server command should be able to display the help 1`
  EXAMPLES
  --------
 
-   - Define a URIMAP named URIMAPA for the program named PGM123
-   to the region named MYREGION in the CSD group MYGRP where the host is
-   www.example.com and the path is /example/index.html:
+   - Define a URIMAP named URIMAPA for the program named PGM123 to the region named
+   MYREGION in the CSD group MYGRP where the host is www.example.com and the path
+   is /example/index.html:
 
       $ zowe cics define urimap-server URIMAPA MYGRP --urimap-path /example/index.html --urimap-host www.example.com --program-name PGM123 --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/define/webservice/__snapshots__/cli.define.webservice.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/define/webservice/__snapshots__/cli.define.webservice.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS define web service command should be able to display the help 1`] = `
 "
@@ -158,9 +158,9 @@ exports[`CICS define web service command should be able to display the help 1`] 
  EXAMPLES
  --------
 
-   - Define a webservice named WEBSVCA for the pipeline named
-   PIPE123 to the region named MYREGION in the CSD group MYGRP where the binding
-   file is /u/exampleapp/wsbind/example.log:
+   - Define a webservice named WEBSVCA for the pipeline named PIPE123 to the region
+   named MYREGION in the CSD group MYGRP where the binding file is
+   /u/exampleapp/wsbind/example.log:
 
       $ zowe cics define webservice WEBSVCA MYGRP --pipeline-name PIPELINE --wsbind /u/exampleapp/wsbind/example.log --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/delete/program/__snapshots__/cli.delete.program.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/delete/program/__snapshots__/cli.delete.program.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS delete program command should be able to display the help 1`] = `
 "
@@ -131,8 +131,7 @@ exports[`CICS delete program command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Delete a program named PGM123 from the region named
-   MYREGION:
+   - Delete a program named PGM123 from the region named MYREGION:
 
       $ zowe cics delete program PGM123 --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/delete/transaction/__snapshots__/cli.delete.transaction.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/delete/transaction/__snapshots__/cli.delete.transaction.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS delete transaction command should be able to display the help 1`] = `
 "
@@ -131,8 +131,7 @@ exports[`CICS delete transaction command should be able to display the help 1`] 
  EXAMPLES
  --------
 
-   - Delete a transaction named TRN1 from the region named
-   MYREGION:
+   - Delete a transaction named TRN1 from the region named MYREGION:
 
       $ zowe cics delete transaction TRN1 MYGRP --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/delete/urimap/__snapshots__/cli.delete.urimap.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/delete/urimap/__snapshots__/cli.delete.urimap.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS delete urimap command should be able to display the help 1`] = `
 "
@@ -127,8 +127,8 @@ exports[`CICS delete urimap command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Delete a urimap named URIMAPA from the region named
-   MYREGION belonging to the csdgroup MYGRP:
+   - Delete a urimap named URIMAPA from the region named MYREGION belonging to the
+   csdgroup MYGRP:
 
       $ zowe cics delete urimap URIMAPA MYGRP --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/delete/webservice/__snapshots__/cli.delete.webservice.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/delete/webservice/__snapshots__/cli.delete.webservice.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS delete web service command should be able to display the help 1`] = `
 "
@@ -127,8 +127,8 @@ exports[`CICS delete web service command should be able to display the help 1`] 
  EXAMPLES
  --------
 
-   - Delete a web service named WEBSVCA from the region named
-   MYREGION belonging to the csdgroup MYGRP:
+   - Delete a web service named WEBSVCA from the region named MYREGION belonging to
+   the csdgroup MYGRP:
 
       $ zowe cics delete webservice WEBSVCA MYGRP --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/disable/urimap/__snapshots__/cli.disable.urimap.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/disable/urimap/__snapshots__/cli.disable.urimap.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS disable urimap command should be able to display the help 1`] = `
 "
@@ -122,8 +122,7 @@ exports[`CICS disable urimap command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Disable a urimap named URIMAPA from the region named
-   MYREGION:
+   - Disable a urimap named URIMAPA from the region named MYREGION:
 
       $ zowe cics disable urimap URIMAPA --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/discard/program/__snapshots__/cli.discard.program.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/discard/program/__snapshots__/cli.discard.program.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS discard program command should be able to display the help 1`] = `
 "
@@ -126,8 +126,7 @@ exports[`CICS discard program command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Discard a program named PGM123 from the region named
-   MYREGION:
+   - Discard a program named PGM123 from the region named MYREGION:
 
       $ zowe cics discard program PGM123 --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/discard/transaction/__snapshots__/cli.discard.transaction.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/discard/transaction/__snapshots__/cli.discard.transaction.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS discard transaction command should be able to display the help 1`] = `
 "
@@ -126,8 +126,7 @@ exports[`CICS discard transaction command should be able to display the help 1`]
  EXAMPLES
  --------
 
-   - Discard a transaction named TRN1 from the region named
-   MYREGION:
+   - Discard a transaction named TRN1 from the region named MYREGION:
 
       $ zowe cics discard transaction TRN1 --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/discard/urimap/__snapshots__/cli.discard.urimap.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS discard urimap command should be able to display the help 1`] = `
 "
@@ -122,8 +122,7 @@ exports[`CICS discard urimap command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Discard a urimap named URIMAPA from the region named
-   MYREGION:
+   - Discard a urimap named URIMAPA from the region named MYREGION:
 
       $ zowe cics discard urimap URIMAPA --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/enable/urimap/__snapshots__/cli.enable.urimap.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/enable/urimap/__snapshots__/cli.enable.urimap.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS enable urimap command should be able to display the help 1`] = `
 "
@@ -122,8 +122,7 @@ exports[`CICS enable urimap command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Enable a urimap named URIMAPA from the region named
-   MYREGION:
+   - Enable a urimap named URIMAPA from the region named MYREGION:
 
       $ zowe cics enable urimap URIMAPA --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/get/resource/__snapshots__/cli.get.resource.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/get/resource/__snapshots__/cli.get.resource.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`cics get resource should display the help 1`] = `
 "===============cics PROFILE HELP===============
@@ -174,8 +174,7 @@ exports[`cics get resource should display the help 1`] = `
 
       $ zowe cics get resource CICSProgram --region-name MYREGION
 
-   - Get local transaction resources from the region named
-   MYREGION:
+   - Get local transaction resources from the region named MYREGION:
 
       $ zowe cics get resource CICSLocalTransaction --region-name MYREGION
 
@@ -183,33 +182,32 @@ exports[`cics get resource should display the help 1`] = `
 
       $ zowe cics get resource CICSLocalFile --region-name MYREGION
 
-   - Get program definition resources from the CSD group named
-   GRP1 and the region named MYREGION:
+   - Get program definition resources from the CSD group named GRP1 and the region
+   named MYREGION:
 
       $ zowe cics get resource CICSDefinitionProgram --region-name MYREGION --parameter "CSDGROUP(GRP1)"
 
-   - Get transaction definition resources from the CSD group
-   named GRP1 and the region named MYREGION:
+   - Get transaction definition resources from the CSD group named GRP1 and the
+   region named MYREGION:
 
       $ zowe cics get resource CICSDefinitionTransaction --region-name MYREGION --parameter "CSDGROUP(GRP1)"
 
-   - Get URIMap definition resources from the CSD group named
-   GRP1 and the region named MYREGION:
+   - Get URIMap definition resources from the CSD group named GRP1 and the region
+   named MYREGION:
 
       $ zowe cics get resource CICSDefinitionURIMap --region-name MYREGION --parameter "CSDGROUP(GRP1)"
 
-   - Get program resources that start with the name PRG from the
-   region named MYREGION:
+   - Get program resources that start with the name PRG from the region named
+   MYREGION:
 
       $ zowe cics get resource CICSProgram --region-name MYREGION --criteria "PROGRAM=PRG*"
 
-   - Get a local transaction resource named TRAN from the region
-   named MYREGION:
+   - Get a local transaction resource named TRAN from the region named MYREGION:
 
       $ zowe cics get resource CICSLocalTransaction --region-name MYREGION --criteria "TRANID=TRAN"
 
-   - Get program resources that start with the name MYPRG from
-   the region named MYREGION and display various fields as a table:
+   - Get program resources that start with the name MYPRG from the region named
+   MYREGION and display various fields as a table:
 
       $ zowe cics get resource CICSProgram --region-name MYREGION --criteria "PROGRAM=MYPRG*" --rft table --rfh --rff program length status
 

--- a/packages/cli/__tests__/__system__/install/program/__snapshots__/cli.install.program.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/install/program/__snapshots__/cli.install.program.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS install program command should be able to display the help 1`] = `
 "
@@ -131,8 +131,8 @@ exports[`CICS install program command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Install a program named PGM123 to the region named MYREGION
-   in the CSD group MYGRP:
+   - Install a program named PGM123 to the region named MYREGION in the CSD group
+   MYGRP:
 
       $ zowe cics install program PGM123 MYGRP --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/install/transaction/__snapshots__/cli.install.transaction.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/install/transaction/__snapshots__/cli.install.transaction.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS install transaction command should be able to display the help 1`] = `
 "
@@ -131,8 +131,8 @@ exports[`CICS install transaction command should be able to display the help 1`]
  EXAMPLES
  --------
 
-   - Install a transaction named TRN1 to the region named
-   MYREGION in the CSD group MYGRP:
+   - Install a transaction named TRN1 to the region named MYREGION in the CSD group
+   MYGRP:
 
       $ zowe cics install transaction TRN1 MYGRP --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/install/urimap/__snapshots__/cli.install.urimap.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/install/urimap/__snapshots__/cli.install.urimap.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS install urimap command should be able to display the help 1`] = `
 "
@@ -127,8 +127,8 @@ exports[`CICS install urimap command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Install a urimap named URIMAPA to the region named MYREGION
-   belonging to the csdgroup MYGRP:
+   - Install a urimap named URIMAPA to the region named MYREGION belonging to the
+   csdgroup MYGRP:
 
       $ zowe cics install urimap URIMAPA CSDGROUP --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/refresh/program/__snapshots__/cli.refresh.program.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/refresh/program/__snapshots__/cli.refresh.program.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS refresh program command should be able to display the help 1`] = `
 "
@@ -126,8 +126,7 @@ exports[`CICS refresh program command should be able to display the help 1`] = `
  EXAMPLES
  --------
 
-   - Refresh a program named PGM123 from the region named
-   MYREGION:
+   - Refresh a program named PGM123 from the region named MYREGION:
 
       $ zowe cics refresh program PGM123 --region-name MYREGION
 

--- a/packages/cli/__tests__/__system__/refresh/program/cli.refresh.program.system.test.ts
+++ b/packages/cli/__tests__/__system__/refresh/program/cli.refresh.program.system.test.ts
@@ -15,6 +15,7 @@ import type { ITestPropertiesSchema } from "../../../__src__/ITestPropertiesSche
 
 let TEST_ENVIRONMENT: ITestEnvironment<ITestPropertiesSchema>;
 let regionName: string;
+let session: Session;
 let host: string;
 let port: number;
 let user: string;

--- a/packages/cli/__tests__/__system__/refresh/program/cli.refresh.program.system.test.ts
+++ b/packages/cli/__tests__/__system__/refresh/program/cli.refresh.program.system.test.ts
@@ -11,13 +11,10 @@
 
 import { type ITestEnvironment, TestEnvironment, runCliScript } from "@zowe/cli-test-utils";
 import { Session } from "@zowe/imperative";
-import { type IProgramParms, defineProgram, deleteProgram, discardProgram, installProgram } from "../../../../src";
 import type { ITestPropertiesSchema } from "../../../__src__/ITestPropertiesSchema";
 
 let TEST_ENVIRONMENT: ITestEnvironment<ITestPropertiesSchema>;
 let regionName: string;
-let csdGroup: string;
-let session: Session;
 let host: string;
 let port: number;
 let user: string;
@@ -31,7 +28,6 @@ describe("CICS refresh program command", () => {
       installPlugin: true,
       tempProfileTypes: ["cics"],
     });
-    csdGroup = TEST_ENVIRONMENT.systemTestProperties.cmci.csdGroup;
     regionName = TEST_ENVIRONMENT.systemTestProperties.cmci.regionName;
     host = TEST_ENVIRONMENT.systemTestProperties.cics.host;
     port = TEST_ENVIRONMENT.systemTestProperties.cics.port;

--- a/packages/cli/__tests__/__system__/refresh/program/cli.refresh.program.system.test.ts
+++ b/packages/cli/__tests__/__system__/refresh/program/cli.refresh.program.system.test.ts
@@ -62,27 +62,14 @@ describe("CICS refresh program command", () => {
   });
 
   it("should be able to successfully refresh a program with basic options", async () => {
-    // Expecting to be able to refresh a program called TESTPRG# (where # is a number from 1 to MAX_PROGRAMS)
-    const MAX_PROGRAMS = 4;
-    const programName = "TESTPRG" + (Math.floor(Math.random() * MAX_PROGRAMS) + 1).toString();
-
-    const options: IProgramParms = {
-      name: programName,
-      csdGroup,
-      regionName,
-    };
-
-    await defineProgram(session, options);
-    await installProgram(session, options);
+    // Use DFHBRCV - a standard CICS program that exists in the load library
+    const programName = "DFHBRCV";
 
     const output = runCliScript(__dirname + "/__scripts__/refresh_program.sh", TEST_ENVIRONMENT, [programName, regionName]);
     const stderr = output.stderr.toString();
     expect(stderr).toEqual("");
     expect(output.status).toEqual(0);
     expect(output.stdout.toString()).toContain("success");
-
-    await discardProgram(session, options);
-    await deleteProgram(session, options);
   });
 
   it("should get a syntax error if program name is omitted", () => {
@@ -95,18 +82,8 @@ describe("CICS refresh program command", () => {
   });
 
   it("should be able to successfully refresh a program with profile options", async () => {
-    // Expecting to be able to refresh a program called TESTPRG# (where # is a number from 1 to MAX_PROGRAMS)
-    const MAX_PROGRAMS = 4;
-    const programName = "TESTPRG" + (Math.floor(Math.random() * MAX_PROGRAMS) + 1).toString();
-
-    const options: IProgramParms = {
-      name: programName,
-      csdGroup,
-      regionName,
-    };
-
-    await defineProgram(session, options);
-    await installProgram(session, options);
+    // Use DFHBRCV - a standard CICS program that exists in the load library
+    const programName = "DFHBRCV";
 
     const output = runCliScript(__dirname + "/__scripts__/refresh_program.sh", TEST_ENVIRONMENT, [
       programName,
@@ -120,8 +97,5 @@ describe("CICS refresh program command", () => {
     expect(stderr).toEqual("");
     expect(output.status).toEqual(0);
     expect(output.stdout.toString()).toContain("success");
-
-    await discardProgram(session, options);
-    await deleteProgram(session, options);
   });
 });

--- a/packages/cli/__tests__/__system__/remove-from-list/csdGroup/__snapshots__/cli.remove-from-list.csdGroup.system.test.ts.snap
+++ b/packages/cli/__tests__/__system__/remove-from-list/csdGroup/__snapshots__/cli.remove-from-list.csdGroup.system.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CICS remove-from-list csdGroup command should be able to display the help 1`] = `
 "
@@ -131,8 +131,7 @@ exports[`CICS remove-from-list csdGroup command should be able to display the he
  EXAMPLES
  --------
 
-   - Remove the CSD Group MYGRP from the CSD List MYLIST in the
-   region named MYREG:
+   - Remove the CSD Group MYGRP from the CSD List MYLIST in the region named MYREG:
 
       $ zowe cics remove-from-list csdGroup MYGRP MYLIST --region-name MYREG
 

--- a/packages/cli/system.jest_config.ts
+++ b/packages/cli/system.jest_config.ts
@@ -9,5 +9,30 @@
  *
  */
 
-import { ConfigGlobals, createConfig } from "../../common.jest_config";
-export default createConfig("system", "Zowe CICS CLI System Tests") as ConfigGlobals;
+import { Config } from "jest";
+
+const baseConfig = require("../../jest.config.ts");
+
+const conf: Config = {
+    ...baseConfig,
+    displayName: "Zowe CICS CLI System Tests",
+    maxWorkers: 1,
+    collectCoverage: false,
+    coverageDirectory: "__tests__/__results__/system/coverage",
+    testPathIgnorePatterns: [
+        "<rootDir>/__tests__/__results__",
+        ".*/__unit__/.*",
+        "<rootDir>/__tests__/__e2e__"
+    ],
+    reporters: [
+        "default",
+        ["jest-junit", {
+            outputFile: "__tests__/__results__/system/junit.xml",
+            ancestorSeparator: " > ",
+            classNameTemplate: "system.{classname}",
+            title: "{title}"
+        }],
+    ],
+}
+
+module.exports = conf;

--- a/packages/sdk/__tests__/__system__/refresh/Refresh.program.system.test.ts
+++ b/packages/sdk/__tests__/__system__/refresh/Refresh.program.system.test.ts
@@ -11,7 +11,7 @@
 
 import { type ITestEnvironment, TestEnvironment } from "@zowe/cli-test-utils";
 import { Session } from "@zowe/imperative";
-import { type IProgramParms, defineProgram, deleteProgram, discardProgram, installProgram, programNewcopy } from "../../../src";
+import { type IProgramParms, programNewcopy } from "../../../src";
 import type { ITestPropertiesSchema } from "../../__src__/ITestPropertiesSchema";
 import { generateRandomAlphaNumericString } from "../../__src__/TestUtils";
 

--- a/packages/sdk/__tests__/__system__/refresh/Refresh.program.system.test.ts
+++ b/packages/sdk/__tests__/__system__/refresh/Refresh.program.system.test.ts
@@ -51,17 +51,13 @@ describe("CICS Refresh program", () => {
     let error;
     let response;
 
-    // Expecting to be able to refresh a program called TESTPRG# (where # is a number from 1 to MAX_PROGRAMS)
-    const MAX_PROGRAMS = 4;
-    const programName = "TESTPRG" + (Math.floor(Math.random() * MAX_PROGRAMS) + 1).toString();
+    // Use DFHBRCV - a standard CICS program that exists in the load library
+    const programName = "DFHBRCV";
 
     options.name = programName;
-    options.csdGroup = csdGroup;
     options.regionName = regionName;
 
     try {
-      await defineProgram(session, options);
-      await installProgram(session, options);
       response = await programNewcopy(session, options);
     } catch (err) {
       error = err;
@@ -70,8 +66,6 @@ describe("CICS Refresh program", () => {
     expect(error).toBeFalsy();
     expect(response).toBeTruthy();
     expect(response.response.resultsummary.api_response1).toBe("1024");
-    await discardProgram(session, options);
-    await deleteProgram(session, options);
   });
 
   it("should fail to refresh a program from CICS with invalid CICS region", async () => {

--- a/packages/sdk/system.jest_config.ts
+++ b/packages/sdk/system.jest_config.ts
@@ -9,5 +9,30 @@
  *
  */
 
-import { ConfigGlobals, createConfig } from "../../common.jest_config.js";
-export default createConfig("system", "Zowe CICS SDK System Tests") as ConfigGlobals;
+import { Config } from "jest";
+
+const baseConfig = require("../../jest.config.ts");
+
+const conf: Config = {
+    ...baseConfig,
+    displayName: "Zowe CICS SDK System Tests",
+    maxWorkers: 1,
+    collectCoverage: false,
+    coverageDirectory: "__tests__/__results__/system/coverage",
+    testPathIgnorePatterns: [
+        "<rootDir>/__tests__/__results__",
+        ".*/__unit__/.*",
+        "<rootDir>/__tests__/__e2e__"
+    ],
+    reporters: [
+        "default",
+        ["jest-junit", {
+            outputFile: "__tests__/__results__/system/junit.xml",
+            ancestorSeparator: " > ",
+            classNameTemplate: "system.{classname}",
+            title: "{title}"
+        }],
+    ],
+}
+
+module.exports = conf;

--- a/scripts/validate-system-test-config.js
+++ b/scripts/validate-system-test-config.js
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ * System Test Configuration Validator
+ * 
+ * This script validates that all required configuration is in place
+ * before running system tests for the SDK and CLI packages.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+// ANSI color codes for terminal output
+const colors = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+};
+
+function log(message, color = 'reset') {
+  console.log(`${colors[color]}${message}${colors.reset}`);
+}
+
+function logSection(title) {
+  console.log('\n' + '='.repeat(70));
+  log(title, 'cyan');
+  console.log('='.repeat(70));
+}
+
+function logSuccess(message) {
+  log(`✓ ${message}`, 'green');
+}
+
+function logError(message) {
+  log(`✗ ${message}`, 'red');
+}
+
+function logWarning(message) {
+  log(`⚠ ${message}`, 'yellow');
+}
+
+function logInfo(message) {
+  log(`ℹ ${message}`, 'blue');
+}
+
+// Validation results
+const results = {
+  errors: [],
+  warnings: [],
+  info: [],
+};
+
+/**
+ * Check if a file exists
+ */
+function fileExists(filePath) {
+  try {
+    return fs.existsSync(filePath);
+  } catch (err) {
+    return false;
+  }
+}
+
+/**
+ * Validate SDK configuration
+ */
+function validateSDKConfig() {
+  logSection('Validating SDK System Test Configuration');
+  
+  const sdkPropertiesPath = path.join(__dirname, '..', 'packages', 'sdk', '__tests__', '__resources__', 'properties', 'custom_properties.yaml');
+  const sdkExamplePath = path.join(__dirname, '..', 'packages', 'sdk', '__tests__', '__resources__', 'properties', 'example_properties.yaml');
+  
+  // Check if custom_properties.yaml exists
+  if (!fileExists(sdkPropertiesPath)) {
+    logError('SDK custom_properties.yaml not found');
+    results.errors.push('SDK: custom_properties.yaml missing');
+    logInfo(`Expected location: ${sdkPropertiesPath}`);
+    logInfo(`Copy from: ${sdkExamplePath}`);
+    return false;
+  }
+  
+  logSuccess('SDK custom_properties.yaml found');
+  
+  // Load and validate the YAML content
+  try {
+    const content = fs.readFileSync(sdkPropertiesPath, 'utf8');
+    const config = yaml.load(content);
+    
+    // Validate required fields
+    const requiredFields = {
+      'cics.user': config?.cics?.user,
+      'cics.password': config?.cics?.password,
+      'cics.host': config?.cics?.host,
+      'cics.port': config?.cics?.port,
+      'cmci.regionName': config?.cmci?.regionName,
+      'cmci.csdGroup': config?.cmci?.csdGroup,
+    };
+    
+    let allFieldsValid = true;
+    
+    for (const [field, value] of Object.entries(requiredFields)) {
+      if (!value || value === 'zosmf-user' || value === 'zosmf-password' || 
+          value === 'zosmf-host' || value === 'region-name' || value === 'CSDGROUP') {
+        logError(`SDK: ${field} is not configured (still has placeholder value)`);
+        results.errors.push(`SDK: ${field} needs to be configured`);
+        allFieldsValid = false;
+      } else {
+        logSuccess(`SDK: ${field} is configured`);
+      }
+    }
+    
+    // Check optional fields
+    if (config?.cics?.protocol) {
+      logInfo(`SDK: Protocol set to '${config.cics.protocol}'`);
+    }
+    
+    if (config?.cics?.rejectUnauthorized !== undefined) {
+      logInfo(`SDK: rejectUnauthorized set to '${config.cics.rejectUnauthorized}'`);
+    }
+    
+    return allFieldsValid;
+    
+  } catch (err) {
+    logError(`SDK: Failed to parse custom_properties.yaml: ${err.message}`);
+    results.errors.push(`SDK: Invalid YAML format - ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Validate CLI configuration
+ */
+function validateCLIConfig() {
+  logSection('Validating CLI System Test Configuration');
+  
+  const cliPropertiesPath = path.join(__dirname, '..', 'packages', 'cli', '__tests__', '__resources__', 'properties', 'custom_properties.yaml');
+  const cliExamplePath = path.join(__dirname, '..', 'packages', 'cli', '__tests__', '__resources__', 'properties', 'example_properties.yaml');
+  
+  // Check if custom_properties.yaml exists
+  if (!fileExists(cliPropertiesPath)) {
+    logError('CLI custom_properties.yaml not found');
+    results.errors.push('CLI: custom_properties.yaml missing');
+    logInfo(`Expected location: ${cliPropertiesPath}`);
+    logInfo(`Copy from: ${cliExamplePath}`);
+    return false;
+  }
+  
+  logSuccess('CLI custom_properties.yaml found');
+  
+  // Load and validate the YAML content
+  try {
+    const content = fs.readFileSync(cliPropertiesPath, 'utf8');
+    const config = yaml.load(content);
+    
+    // Validate required fields
+    const requiredFields = {
+      'cics.user': config?.cics?.user,
+      'cics.password': config?.cics?.password,
+      'cics.host': config?.cics?.host,
+      'cics.port': config?.cics?.port,
+      'cmci.regionName': config?.cmci?.regionName,
+      'cmci.csdGroup': config?.cmci?.csdGroup,
+    };
+    
+    let allFieldsValid = true;
+    
+    for (const [field, value] of Object.entries(requiredFields)) {
+      if (!value || value === 'my-user-name' || value === 'my-password' || 
+          value === 'my-cics-host' || value === 'my-region-name' || value === 'my-csd-group') {
+        logError(`CLI: ${field} is not configured (still has placeholder value)`);
+        results.errors.push(`CLI: ${field} needs to be configured`);
+        allFieldsValid = false;
+      } else {
+        logSuccess(`CLI: ${field} is configured`);
+      }
+    }
+    
+    // Check optional fields
+    if (config?.cics?.protocol) {
+      logInfo(`CLI: Protocol set to '${config.cics.protocol}'`);
+    }
+    
+    if (config?.cics?.rejectUnauthorized !== undefined) {
+      logInfo(`CLI: rejectUnauthorized set to '${config.cics.rejectUnauthorized}'`);
+    }
+    
+    return allFieldsValid;
+    
+  } catch (err) {
+    logError(`CLI: Failed to parse custom_properties.yaml: ${err.message}`);
+    results.errors.push(`CLI: Invalid YAML format - ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Check for Zowe CLI installation (required for CLI tests)
+ */
+function checkZoweCLI() {
+  logSection('Checking Zowe CLI Installation');
+  
+  const { execSync } = require('child_process');
+  
+  try {
+    const version = execSync('zowe --version', { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] });
+    logSuccess(`Zowe CLI is installed: ${version.trim()}`);
+    return true;
+  } catch (err) {
+    logWarning('Zowe CLI is not installed or not in PATH');
+    results.warnings.push('Zowe CLI not found - required for CLI system tests');
+    logInfo('Install with: npm install -g @zowe/cli');
+    return false;
+  }
+}
+
+/**
+ * Check Node.js version
+ */
+function checkNodeVersion() {
+  logSection('Checking Node.js Version');
+  
+  const currentVersion = process.version;
+  const requiredVersion = 'v18.12.0';
+  
+  logInfo(`Current Node.js version: ${currentVersion}`);
+  logInfo(`Required Node.js version: >= ${requiredVersion}`);
+  
+  const current = currentVersion.slice(1).split('.').map(Number);
+  const required = requiredVersion.slice(1).split('.').map(Number);
+  
+  if (current[0] > required[0] || 
+      (current[0] === required[0] && current[1] >= required[1])) {
+    logSuccess('Node.js version meets requirements');
+    return true;
+  } else {
+    logError('Node.js version is too old');
+    results.errors.push(`Node.js version ${currentVersion} is below required ${requiredVersion}`);
+    return false;
+  }
+}
+
+/**
+ * Main validation function
+ */
+function main() {
+  console.log('\n');
+  log('╔════════════════════════════════════════════════════════════════════╗', 'cyan');
+  log('║     CICS for Zowe - System Test Configuration Validator           ║', 'cyan');
+  log('╚════════════════════════════════════════════════════════════════════╝', 'cyan');
+  
+  // Run all validations
+  const nodeValid = checkNodeVersion();
+  const sdkValid = validateSDKConfig();
+  const cliValid = validateCLIConfig();
+  const zoweInstalled = checkZoweCLI();
+  
+  // Summary
+  logSection('Validation Summary');
+  
+  if (results.errors.length === 0 && results.warnings.length === 0) {
+    logSuccess('All validations passed! ✓');
+    logInfo('\nYou can now run system tests:');
+    logInfo('  • SDK tests: npm run test:system --workspace=packages/sdk');
+    logInfo('  • CLI tests: npm run test:system --workspace=packages/cli');
+    logInfo('  • All tests: npm run test:system');
+    process.exit(0);
+  } else {
+    if (results.errors.length > 0) {
+      log('\nErrors found:', 'red');
+      results.errors.forEach(err => logError(err));
+    }
+    
+    if (results.warnings.length > 0) {
+      log('\nWarnings:', 'yellow');
+      results.warnings.forEach(warn => logWarning(warn));
+    }
+    
+    log('\nPlease fix the errors above before running system tests.', 'yellow');
+    process.exit(1);
+  }
+}
+
+// Run the validator
+main();


### PR DESCRIPTION
**What It Does**
Updates the config for SDK and CLI system tests so they can run with the most recent Jest version. 

This also includes snapshot updates that use a slightly different format in this version. Content is the same, formatting changes in a few places.

**How to Test**
Create config and run `npm run test:system`

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
