### PR TITLE
chore(v2): pin actions to SHA sums

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,12 +16,12 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: lts/*
 

--- a/.github/workflows/auto-comment.yml
+++ b/.github/workflows/auto-comment.yml
@@ -11,10 +11,10 @@ jobs:
     name: Process Label Action
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Process Label Action
-        uses: dessant/label-actions@v4
+        uses: dessant/label-actions@102faf474a544be75fbaf4df54e73d3c515a0e65 # v4.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           config-path: '.github/label-actions.yml'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,13 +15,13 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Check Changelog Updated
       id: checkchangelogupdated
-      uses: awharn/check_changelog_action@v1
+      uses: awharn/check_changelog_action@c55576539feda35872002e76b03da4e61cc4fed7 # v1.1.5
       with:
         header: '## Recent Changes'
         file: 'CHANGELOG.md'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,15 +32,15 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2
       with:
         languages: ${{ matrix.language }}
         config-file: ./.github/resources/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3.36.2

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: lts/*
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,10 +38,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: ${{ matrix.node-version }}
 
@@ -55,7 +55,7 @@ jobs:
 
     - name: Update Dependencies
       id: npm-update
-      uses: zowe-actions/octorelease/script@v1
+      uses: zowe-actions/octorelease/script@e0672bf28f74f36219713afe75915ea2dc7bf85b # v1.5.5
       with:
         config-dir: .github
         script: npmUpdate
@@ -70,13 +70,13 @@ jobs:
 
     - name: Archive Results
       if: ${{ always() && steps.build.outcome == 'success' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ matrix.os }}-${{ matrix.node-version }}-results
         path: packages/*/__tests__/__results__/
 
     - name: Upload Results to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4.6.0
       with:
         env_vars: OS,NODE
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -103,14 +103,14 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 0
         persist-credentials: false
         ref: ${{ github.ref }}
 
     - name: Use Node.js LTS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: lts/*
 
@@ -118,7 +118,7 @@ jobs:
       run: npm ci
 
     - name: Update Dependencies
-      uses: zowe-actions/octorelease/script@v1
+      uses: zowe-actions/octorelease/script@e0672bf28f74f36219713afe75915ea2dc7bf85b # v1.5.5
       env:
         GIT_COMMITTER_NAME: zowe_robot
         GIT_COMMITTER_EMAIL: zowe.robot@gmail.com
@@ -130,7 +130,7 @@ jobs:
     - name: Build Source
       run: npm run build
 
-    - uses: zowe-actions/octorelease@v1
+    - uses: zowe-actions/octorelease@e0672bf28f74f36219713afe75915ea2dc7bf85b # v1.5.5
       env:
         GIT_COMMITTER_NAME: ${{ secrets.ZOWE_ROBOT_USER }}
         GIT_COMMITTER_EMAIL: ${{ secrets.ZOWE_ROBOT_EMAIL }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           # General rules applied to both, issues and pull requests (PRs)
           days-before-close: 14

--- a/.github/workflows/update-project.yml
+++ b/.github/workflows/update-project.yml
@@ -20,14 +20,14 @@ jobs:
     name: Move project item
     runs-on: ubuntu-latest
     steps:
-    - uses: zowe-actions/shared-actions/project-move-item@main
+    - uses: zowe-actions/shared-actions/project-move-item@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
       if: ${{ github.event.issue && fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}
       with:
         item-status: ${{ fromJSON(env.ISSUE_STATUSES)[github.event.label.name] }}
         project-number: ${{ env.PROJECT_NUMBER }}
         project-token: ${{ secrets.ZOWE_ROBOT_TOKEN }}
 
-    - uses: zowe-actions/shared-actions/project-move-item@main
+    - uses: zowe-actions/shared-actions/project-move-item@77d7d9b50e60fedc8132b5e5eb6d611c4e483416 # main
       if: ${{ github.event.pull_request }}
       with:
         assign-author: true


### PR DESCRIPTION
**What It Does**

V2-specific changes for same purposes as #665: 

- Pins action versions to SHA checksums to avoid pulling changes introduced with tag updates
- Automatically update SHA checksums for actions using `dependabot.yml` config

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)