### PR TITLE
Lock codeserver version for e2e tests

### DIFF
--- a/packages/vsce/__tests__/__e2e__/docker-compose.yaml
+++ b/packages/vsce/__tests__/__e2e__/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
     entrypoint: ["/docker-entrypoint.sh", "--verbose"]
 
   code-server:
-    image: lscr.io/linuxserver/code-server:latest
+    image: lscr.io/linuxserver/code-server:4.124.2
     ports:
       - 1234:8443
     container_name: code-server


### PR DESCRIPTION
**What It Does**
Temporarily lock codeserver version while a fix for new accessibility features breaking our tests is added.

**How to Test**
Run e2e tests.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)
