### PR TITLE
refactor(v2): Remove assignments to `globalAgent` and its options

### DIFF
--- a/packages/vsce/CHANGELOG.md
+++ b/packages/vsce/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the "cics-extension-for-zowe" extension will be documente
 
 ## Recent Changes
 
+- BugFix: Fixed an issue where assignments to the Node.js global HTTP agent (`http.globalAgent`) could impact concurrent requests for different Zowe profiles. [#689](https://github.com/zowe/cics-for-zowe-client/pull/689)
 - Removed the dependency on `axios`. [#276](https://github.com/zowe/cics-for-zowe-client/pull/276)
 
 ## `2.3.10`

--- a/packages/vsce/__tests__/__unit__/security/globalAgentMutation.unit.test.ts
+++ b/packages/vsce/__tests__/__unit__/security/globalAgentMutation.unit.test.ts
@@ -1,0 +1,48 @@
+/**
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Regression guard: none of the extension's source files should mutate the process-wide
+ * https.globalAgent (e.g. `https.globalAgent.options.rejectUnauthorized = ...`). TLS
+ * verification is already carried per-session via imperative.Session.ISession.rejectUnauthorized
+ * (see ProfileManagement.getSessionFromProfile) and honoured per-request by @zowe/imperative's
+ * RestClient. Mutating globalAgent's options changes shared, process-wide state for the
+ * lifetime of an await, which can flip TLS verification off for unrelated concurrent HTTPS
+ * requests made by other profiles or extensions in the same VS Code extension host.
+ */
+describe("https.globalAgent mutation", () => {
+  const srcDir = path.join(__dirname, "..", "..", "..", "src");
+
+  function collectTsFiles(dir: string): string[] {
+    return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return collectTsFiles(entryPath);
+      }
+      return entry.name.endsWith(".ts") ? [entryPath] : [];
+    });
+  }
+
+  // Matches an assignment into globalAgent's options (e.g. `https.globalAgent.options.rejectUnauthorized = ...`)
+  // or a reassignment of globalAgent itself, while allowing safe reads (e.g. `globalAgent.maxSockets`).
+  const mutationPattern = /\bglobalAgent(\.options)?(\.\w+)?\s*=(?!=)/;
+
+  it("should not mutate https.globalAgent or its options", () => {
+    const offendingFiles = collectTsFiles(srcDir)
+      .filter((filePath) => mutationPattern.test(fs.readFileSync(filePath, "utf8")))
+      .map((filePath) => path.relative(srcDir, filePath));
+
+    expect(offendingFiles).toEqual([]);
+  });
+});

--- a/packages/vsce/src/commands/closeLocalFileCommand.ts
+++ b/packages/vsce/src/commands/closeLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -52,8 +51,6 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
-            https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
             try {
               await closeLocalFile(
                 currentNode.parentRegion.parentSession.session,
@@ -64,12 +61,10 @@ export function getCloseLocalFileCommand(tree: CICSTree, treeview: TreeView<any>
                 },
                 busyDecision
               );
-              https.globalAgent.options.rejectUnauthorized = undefined;
               if (!parentRegions.includes(currentNode.parentRegion)) {
                 parentRegions.push(currentNode.parentRegion);
               }
             } catch (error) {
-              https.globalAgent.options.rejectUnauthorized = undefined;
               // @ts-ignore
               if (error.mMessage) {
                 // @ts-ignore

--- a/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSLocalFileTreeItem } from "../../trees/treeItems/CICSLocalFileTreeItem";
@@ -52,8 +51,6 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<an
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
-            https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
             try {
               await disableLocalFile(
                 currentNode.parentRegion.parentSession.session,
@@ -64,12 +61,10 @@ export function getDisableLocalFileCommand(tree: CICSTree, treeview: TreeView<an
                 },
                 busyDecision
               );
-              https.globalAgent.options.rejectUnauthorized = undefined;
               if (!parentRegions.includes(currentNode.parentRegion)) {
                 parentRegions.push(currentNode.parentRegion);
               }
             } catch (error) {
-              https.globalAgent.options.rejectUnauthorized = undefined;
               window.showErrorMessage(
                 `Something went wrong when performing a DISABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                   /(\\n\t|\\n|\\t)/gm,

--- a/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableProgramCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSProgramTreeItem } from "../../trees/treeItems/CICSProgramTreeItem";
@@ -50,20 +49,16 @@ export function getDisableProgramCommand(tree: CICSTree, treeview: TreeView<any>
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await disableProgram(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             window.showErrorMessage(
               `Something went wrong when performing a disable - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(

--- a/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
+++ b/packages/vsce/src/commands/disableCommands/disableTransactionCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes, splitCmciErrorMessage } from "../../utils/commandUtils";
 import { CICSTransactionTreeItem } from "../../trees/treeItems/CICSTransactionTreeItem";
@@ -45,20 +44,16 @@ export function getDisableTransactionCommand(tree: CICSTree, treeview: TreeView<
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await disableTransaction(currentNode.parentRegion.parentSession.session, {
               name: currentNode.transaction.tranid,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore

--- a/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes } from "../../utils/commandUtils";
@@ -45,20 +44,16 @@ export function getEnableLocalFileCommand(tree: CICSTree, treeview: TreeView<any
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await enableLocalFile(currentNode.parentRegion.parentSession.session, {
               name: currentNode.localFile.file,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             window.showErrorMessage(
               `Something went wrong when performing an ENABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                 /(\\n\t|\\n|\\t)/gm,

--- a/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableProgramCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes } from "../../utils/commandUtils";
@@ -50,20 +49,16 @@ export function getEnableProgramCommand(tree: CICSTree, treeview: TreeView<any>)
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await enableProgram(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             window.showErrorMessage(
               `Something went wrong when performing an ENABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                 /(\\n\t|\\n|\\t)/gm,

--- a/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
+++ b/packages/vsce/src/commands/enableCommands/enableTransactionCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../../trees/CICSRegionTree";
 import { CICSTree } from "../../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../../trees/CICSRegionsContainer";
 import { findSelectedNodes } from "../../utils/commandUtils";
 import { CICSTransactionTreeItem } from "../../trees/treeItems/CICSTransactionTreeItem";
@@ -46,20 +45,16 @@ export function getEnableTransactionCommand(tree: CICSTree, treeview: TreeView<a
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await enableTransaction(currentNode.parentRegion.parentSession.session, {
               name: currentNode.transaction.tranid,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             window.showErrorMessage(
               `Something went wrong when performing an ENABLE - ${JSON.stringify(error, Object.getOwnPropertyNames(error)).replace(
                 /(\\n\t|\\n|\\t)/gm,

--- a/packages/vsce/src/commands/newCopyCommand.ts
+++ b/packages/vsce/src/commands/newCopyCommand.ts
@@ -13,7 +13,6 @@ import { programNewcopy } from "@zowe/cics-for-zowe-sdk";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -49,21 +48,17 @@ export function getNewCopyCommand(tree: CICSTree, treeview: TreeView<any>) {
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await programNewcopy(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
             // CMCI new copy error
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore

--- a/packages/vsce/src/commands/openLocalFileCommand.ts
+++ b/packages/vsce/src/commands/openLocalFileCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSLocalFileTreeItem } from "../trees/treeItems/CICSLocalFileTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -45,20 +44,16 @@ export function getOpenLocalFileCommand(tree: CICSTree, treeview: TreeView<any>)
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await openLocalFile(currentNode.parentRegion.parentSession.session, {
               name: currentNode.localFile.file,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore

--- a/packages/vsce/src/commands/phaseInCommand.ts
+++ b/packages/vsce/src/commands/phaseInCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
 import { CICSProgramTreeItem } from "../trees/treeItems/CICSProgramTreeItem";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
@@ -50,21 +49,16 @@ export function getPhaseInCommand(tree: CICSTree, treeview: TreeView<any>) {
           });
           const currentNode = allSelectedNodes[parseInt(index)];
 
-          https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
           try {
             await performPhaseIn(currentNode.parentRegion.parentSession.session, {
               name: currentNode.program.program,
               regionName: currentNode.parentRegion.label,
               cicsPlex: currentNode.parentRegion.parentPlex ? currentNode.parentRegion.parentPlex.getPlexName() : undefined,
             });
-            https.globalAgent.options.rejectUnauthorized = undefined;
-
             if (!parentRegions.includes(currentNode.parentRegion)) {
               parentRegions.push(currentNode.parentRegion);
             }
           } catch (error) {
-            https.globalAgent.options.rejectUnauthorized = undefined;
             // @ts-ignore
             if (error.mMessage) {
               // @ts-ignore

--- a/packages/vsce/src/commands/purgeTaskCommand.ts
+++ b/packages/vsce/src/commands/purgeTaskCommand.ts
@@ -14,7 +14,6 @@ import { imperative } from "@zowe/zowe-explorer-api";
 import { commands, ProgressLocation, TreeView, window } from "vscode";
 import { CICSRegionTree } from "../trees/CICSRegionTree";
 import { CICSTree } from "../trees/CICSTree";
-import * as https from "https";
 import { findSelectedNodes, splitCmciErrorMessage } from "../utils/commandUtils";
 import { CICSTaskTreeItem } from "../trees/treeItems/CICSTaskTreeItem";
 import { CICSRegionsContainer } from "../trees/CICSRegionsContainer";
@@ -55,8 +54,6 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
             });
             const currentNode = allSelectedNodes[parseInt(index)];
 
-            https.globalAgent.options.rejectUnauthorized = currentNode.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
             try {
               await purgeTask(
                 currentNode.parentRegion.parentSession.session,
@@ -67,12 +64,10 @@ export function getPurgeTaskCommand(tree: CICSTree, treeview: TreeView<any>) {
                 },
                 purgeType
               );
-              https.globalAgent.options.rejectUnauthorized = undefined;
               if (!parentRegions.includes(currentNode.parentRegion)) {
                 parentRegions.push(currentNode.parentRegion);
               }
             } catch (error) {
-              https.globalAgent.options.rejectUnauthorized = undefined;
               // @ts-ignore
               if (error.mMessage) {
                 // @ts-ignore

--- a/packages/vsce/src/trees/CICSLibraryTree.ts
+++ b/packages/vsce/src/trees/CICSLibraryTree.ts
@@ -12,7 +12,6 @@
 import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { getIconPathInResources } from "../utils/profileUtils";
 import { CICSLibraryTreeItem } from "./treeItems/CICSLibraryTreeItem";
 import { toEscapedCriteriaString } from "../utils/filterUtils";
@@ -42,15 +41,12 @@ export class CICSLibraryTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const libraryResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSLibrary",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
       const librariesArray = Array.isArray(libraryResponse.response.records.cicslibrary)
         ? libraryResponse.response.records.cicslibrary
         : [libraryResponse.response.records.cicslibrary];
@@ -61,7 +57,6 @@ export class CICSLibraryTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a library filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/CICSLocalFileTree.ts
+++ b/packages/vsce/src/trees/CICSLocalFileTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window, workspace } from "vscode";
 import { CICSLocalFileTreeItem } from "./treeItems/CICSLocalFileTreeItem";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
 import { CICSRegionTree } from "./CICSRegionTree";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../utils/filterUtils";
 import { getIconPathInResources } from "../utils/profileUtils";
 
@@ -46,15 +45,12 @@ export class CICSLocalFileTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const localFileResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSLocalFile",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
       const localFileArray = Array.isArray(localFileResponse.response.records.cicslocalfile)
         ? localFileResponse.response.records.cicslocalfile
         : [localFileResponse.response.records.cicslocalfile];
@@ -65,7 +61,6 @@ export class CICSLocalFileTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       // @ts-ignore
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a local file filter to narrow search`);

--- a/packages/vsce/src/trees/CICSPlexTree.ts
+++ b/packages/vsce/src/trees/CICSPlexTree.ts
@@ -14,7 +14,6 @@ import { CICSRegionTree } from "./CICSRegionTree";
 import { imperative } from "@zowe/zowe-explorer-api";
 import { CICSSessionTree } from "./CICSSessionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { CICSCombinedProgramTree } from "./CICSCombinedTrees/CICSCombinedProgramTree";
 import { CICSCombinedTransactionsTree } from "./CICSCombinedTrees/CICSCombinedTransactionTree";
 import { CICSCombinedLocalFileTree } from "./CICSCombinedTrees/CICSCombinedLocalFileTree";
@@ -71,14 +70,12 @@ export class CICSPlexTree extends TreeItem {
    */
   public async loadOnlyRegion() {
     const plexProfile = this.getProfile();
-    https.globalAgent.options.rejectUnauthorized = plexProfile.profile.rejectUnauthorized;
     const session = this.getParent().getSession();
     const regionsObtained = await getResource(session, {
       name: "CICSRegion",
       cicsPlex: plexProfile.profile.cicsPlex,
       regionName: plexProfile.profile.regionName,
     });
-    https.globalAgent.options.rejectUnauthorized = undefined;
     const newRegionTree = new CICSRegionTree(
       plexProfile.profile.regionName,
       regionsObtained.response.records.cicsregion,

--- a/packages/vsce/src/trees/CICSProgramTree.ts
+++ b/packages/vsce/src/trees/CICSProgramTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSProgramTreeItem } from "./treeItems/CICSProgramTreeItem";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { getDefaultProgramFilter, toEscapedCriteriaString } from "../utils/filterUtils";
 import { getIconPathInResources } from "../utils/profileUtils";
 export class CICSProgramTree extends TreeItem {
@@ -41,15 +40,12 @@ export class CICSProgramTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const programResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSProgram",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
       const programsArray = Array.isArray(programResponse.response.records.cicsprogram)
         ? programResponse.response.records.cicsprogram
         : [programResponse.response.records.cicsprogram];
@@ -60,7 +56,6 @@ export class CICSProgramTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a program filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/CICSRegionsContainer.ts
+++ b/packages/vsce/src/trees/CICSRegionsContainer.ts
@@ -16,7 +16,6 @@ import { CICSTree } from "./CICSTree";
 import { ProfileManagement } from "../utils/profileManagement";
 import { getIconPathInResources } from "../utils/profileUtils";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 
 export class CICSRegionsContainer extends TreeItem {
   children: CICSRegionTree[];
@@ -61,14 +60,12 @@ export class CICSRegionsContainer extends TreeItem {
   public async loadRegionsInCICSGroup(tree: CICSTree) {
     const parentPlex = this.getParent();
     const plexProfile = parentPlex.getProfile();
-    https.globalAgent.options.rejectUnauthorized = plexProfile.profile.rejectUnauthorized;
     const session = parentPlex.getParent().getSession();
     const regionsObtained = await getResource(session, {
       name: "CICSManagedRegion",
       cicsPlex: plexProfile.profile.cicsPlex,
       regionName: plexProfile.profile.regionName,
     });
-    https.globalAgent.options.rejectUnauthorized = undefined;
     this.clearChildren();
     const regionsArray = Array.isArray(regionsObtained.response.records.cicsmanagedregion)
       ? regionsObtained.response.records.cicsmanagedregion

--- a/packages/vsce/src/trees/CICSTaskTree.ts
+++ b/packages/vsce/src/trees/CICSTaskTree.ts
@@ -12,7 +12,6 @@
 import { TreeItemCollapsibleState, TreeItem, window, workspace } from "vscode";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../utils/filterUtils";
 import { getIconPathInResources } from "../utils/profileUtils";
 import { CICSTaskTreeItem } from "./treeItems/CICSTaskTreeItem";
@@ -46,16 +45,12 @@ export class CICSTaskTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const taskResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSTASK",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-
       const tasksArray = Array.isArray(taskResponse.response.records.cicstask)
         ? taskResponse.response.records.cicstask
         : [taskResponse.response.records.cicstask];
@@ -72,7 +67,6 @@ export class CICSTaskTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a task filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/CICSTransactionTree.ts
+++ b/packages/vsce/src/trees/CICSTransactionTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSTransactionTreeItem } from "./treeItems/CICSTransactionTreeItem";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { getDefaultTransactionFilter, toEscapedCriteriaString } from "../utils/filterUtils";
 import { getIconPathInResources } from "../utils/profileUtils";
 
@@ -42,15 +41,12 @@ export class CICSTransactionTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const transactionResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSLocalTransaction",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
       const transactionArray = Array.isArray(transactionResponse.response.records.cicslocaltransaction)
         ? transactionResponse.response.records.cicslocaltransaction
         : [transactionResponse.response.records.cicslocaltransaction];
@@ -61,7 +57,6 @@ export class CICSTransactionTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       // @ts-ignore
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a transaction filter to narrow search`);

--- a/packages/vsce/src/trees/CICSTree.ts
+++ b/packages/vsce/src/trees/CICSTree.ts
@@ -28,7 +28,6 @@ import { addProfileHtml } from "../utils/webviewHTML";
 import { CICSPlexTree } from "./CICSPlexTree";
 import { CICSRegionTree } from "./CICSRegionTree";
 import { CICSSessionTree } from "./CICSSessionTree";
-import * as https from "https";
 import { getIconPathInResources, missingSessionParameters, promptCredentials } from "../utils/profileUtils";
 import { Gui, imperative } from "@zowe/zowe-explorer-api";
 
@@ -229,15 +228,12 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
                 protocol: profile.profile.protocol,
               });
               try {
-                https.globalAgent.options.rejectUnauthorized = profile.profile.rejectUnauthorized;
-
                 const regionsObtained = await getResource(session, {
                   name: "CICSRegion",
                   regionName: item.regions[0].applid,
                 });
                 // 200 OK received
                 newSessionTree.setAuthorized();
-                https.globalAgent.options.rejectUnauthorized = undefined;
                 const newRegionTree = new CICSRegionTree(
                   item.regions[0].applid,
                   regionsObtained.response.records.cicsregion,
@@ -247,7 +243,6 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
                 );
                 newSessionTree.addRegion(newRegionTree);
               } catch (error) {
-                https.globalAgent.options.rejectUnauthorized = undefined;
                 console.log(error);
               }
             } else {
@@ -274,7 +269,6 @@ export class CICSTree implements TreeDataProvider<CICSSessionTree> {
           }
           this._onDidChangeTreeData.fire(undefined);
         } catch (error) {
-          https.globalAgent.options.rejectUnauthorized = undefined;
           // Change session tree icon to disconnected upon error
           newSessionTree = new CICSSessionTree(profile, getIconPathInResources("profile-disconnected-dark.svg", "profile-disconnected-light.svg"));
           // If method was called when expanding profile

--- a/packages/vsce/src/trees/treeItems/CICSLibraryDatasets.ts
+++ b/packages/vsce/src/trees/treeItems/CICSLibraryDatasets.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { getIconPathInResources } from "../../utils/profileUtils";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { CICSProgramTreeItem } from "./CICSProgramTreeItem";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
 
@@ -58,15 +57,12 @@ export class CICSLibraryDatasets extends TreeItem {
 
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
       const datasetResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSProgram",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
-
       const programsArray = Array.isArray(datasetResponse.response.records.cicsprogram)
         ? datasetResponse.response.records.cicsprogram
         : [datasetResponse.response.records.cicsprogram];
@@ -76,7 +72,6 @@ export class CICSLibraryDatasets extends TreeItem {
         this.addProgram(newProgramItem);
       }
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a program filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
+++ b/packages/vsce/src/trees/treeItems/CICSLibraryTreeItem.ts
@@ -12,7 +12,6 @@
 import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSRegionTree } from "../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { getIconPathInResources } from "../../utils/profileUtils";
 import { CICSLibraryDatasets } from "./CICSLibraryDatasets";
 import { toEscapedCriteriaString } from "../../utils/filterUtils";
@@ -58,15 +57,12 @@ export class CICSLibraryTreeItem extends TreeItem {
 
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const libraryResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "cicslibrarydatasetname",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
       const datasetArray = Array.isArray(libraryResponse.response.records.cicslibrarydatasetname)
         ? libraryResponse.response.records.cicslibrarydatasetname
         : [libraryResponse.response.records.cicslibrarydatasetname];
@@ -79,7 +75,6 @@ export class CICSLibraryTreeItem extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a datasets filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSPipelineTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSPipelineTreeItem } from "./treeItems/CICSPipelineTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconPathInResources } from "../../../utils/profileUtils";
 export class CICSPipelineTree extends TreeItem {
@@ -41,15 +40,12 @@ export class CICSPipelineTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const pipelineResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSPipeline",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
       const pipelinesArray = Array.isArray(pipelineResponse.response.records.cicspipeline)
         ? pipelineResponse.response.records.cicspipeline
         : [pipelineResponse.response.records.cicspipeline];
@@ -61,7 +57,6 @@ export class CICSPipelineTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a Pipeline filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSTCPIPServiceTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSTCPIPServiceTreeItem } from "./treeItems/CICSTCPIPServiceTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconPathInResources } from "../../../utils/profileUtils";
 export class CICSTCPIPServiceTree extends TreeItem {
@@ -41,15 +40,12 @@ export class CICSTCPIPServiceTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const tcpipsResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSTCPIPService",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
       const tcpipservicesArray = Array.isArray(tcpipsResponse.response.records.cicstcpipservice)
         ? tcpipsResponse.response.records.cicstcpipservice
         : [tcpipsResponse.response.records.cicstcpipservice];
@@ -63,7 +59,6 @@ export class CICSTCPIPServiceTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a TCPIPService filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSURIMapTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSURIMapTreeItem } from "./treeItems/CICSURIMapTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconPathInResources } from "../../../utils/profileUtils";
 export class CICSURIMapTree extends TreeItem {
@@ -41,15 +40,12 @@ export class CICSURIMapTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const urimapResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSURIMap",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
       const urimapArray = Array.isArray(urimapResponse.response.records.cicsurimap)
         ? urimapResponse.response.records.cicsurimap
         : [urimapResponse.response.records.cicsurimap];
@@ -63,7 +59,6 @@ export class CICSURIMapTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a URIMap filter to narrow search`);
       } else if (this.children.length === 0) {

--- a/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
+++ b/packages/vsce/src/trees/treeItems/web/CICSWebServiceTree.ts
@@ -13,7 +13,6 @@ import { TreeItemCollapsibleState, TreeItem, window } from "vscode";
 import { CICSWebServiceTreeItem } from "./treeItems/CICSWebServiceTreeItem";
 import { CICSRegionTree } from "../../CICSRegionTree";
 import { getResource } from "@zowe/cics-for-zowe-sdk";
-import * as https from "https";
 import { toEscapedCriteriaString } from "../../../utils/filterUtils";
 import { getIconPathInResources } from "../../../utils/profileUtils";
 export class CICSWebServiceTree extends TreeItem {
@@ -41,15 +40,12 @@ export class CICSWebServiceTree extends TreeItem {
     }
     this.children = [];
     try {
-      https.globalAgent.options.rejectUnauthorized = this.parentRegion.parentSession.session.ISession.rejectUnauthorized;
-
       const webserviceResponse = await getResource(this.parentRegion.parentSession.session, {
         name: "CICSWebService",
         regionName: this.parentRegion.getRegionName(),
         cicsPlex: this.parentRegion.parentPlex ? this.parentRegion.parentPlex.getPlexName() : undefined,
         criteria: criteria,
       });
-      https.globalAgent.options.rejectUnauthorized = undefined;
       const webservicesArray = Array.isArray(webserviceResponse.response.records.cicswebservice)
         ? webserviceResponse.response.records.cicswebservice
         : [webserviceResponse.response.records.cicswebservice];
@@ -61,7 +57,6 @@ export class CICSWebServiceTree extends TreeItem {
       }
       this.iconPath = getIconPathInResources("folder-open-dark.svg", "folder-open-light.svg");
     } catch (error) {
-      https.globalAgent.options.rejectUnauthorized = undefined;
       if (error.mMessage!.includes("exceeded a resource limit")) {
         window.showErrorMessage(`Resource Limit Exceeded - Set a Web Services filter to narrow search`);
       } else if (this.children.length === 0) {


### PR DESCRIPTION
**What It Does**

Fixes an issue where mutating the `globalAgent` or its options could affect concurrent requests for other profiles or extensions within the extension host.

**Review Checklist**
I certify that I have:
- [x] tested my changes
- [x] added/updated automated tests
- [x] considered whether the docs need updating
- [x] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)