### PR TITLE
Change Node version to `lts/-1` in release workflow 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
     - name: Use Node.js LTS
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: lts/*
+        node-version: lts/-1
 
     - name: Install Dependencies
       run: npm ci


### PR DESCRIPTION
**What It Does**
<!-- A list of relevant issues, enhancements, fixed bugs, etc -->
Downgrades the Node.js version used in the release workflow by one major version. This should fix the `npm list` command failing and matches the version used by Zowe CLI packaging workflow:
> Stay back one major release to avoid bugs in unstable npm versions

<sup>https://github.com/zowe/zowe-cli-standalone-package/blob/master/.github/workflows/zowe-cli-deploy-component.yaml#L58</sup>

**How to Test**
<!-- If a bug has been fixed, how can reviewers verify that the change(s) fixed it? -->
See that the `release` job in main workflow was [failing](https://github.com/zowe/cics-for-zowe-client/actions/runs/28644037087/job/85265060966) but now [succeeds](https://github.com/zowe/cics-for-zowe-client/actions/runs/28806728229/job/85427020771)

**Which Issue It Relates To**
<!-- Either "Resolves #XXX" or "Working towards #XXX" - these must be github.com/zowe links. These allow you to navigate from a github issue to the PRs that delivered code to resolve it -->

**Review Checklist**
I certify that I have:
- [ ] tested my changes
- [ ] added/updated automated tests
- [ ] considered whether the docs need updating
- [ ] followed the [contribution guidelines](https://github.com/zowe/zowe-cli/blob/master/CONTRIBUTING.md)

**Additional Comments**
<!-- Anything else noteworthy about this pull request. This section is optional. -->
